### PR TITLE
test: Add unit test suite for pure mod logic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,11 @@ jobs:
       - name: Build
         run: xmake -y
 
+      - name: Test
+        run: |
+          xmake build stfc-mod-tests
+          xmake run stfc-mod-tests
+
       - name: Package
         run: mv build/windows/x64/release/stfc-community-patch.dll version.dll
 

--- a/mods/src/str_utils.h
+++ b/mods/src/str_utils.h
@@ -1,71 +1,15 @@
 #pragma once
 
-#include <algorithm>
-#include <cctype>
-#include <string>
-#include <string_view>
-#include <vector>
+// Re-export pure string utilities (no IL2CPP deps)
+#include "str_utils_pure.h"
+
+// Additional dependencies for IL2CPP + platform string conversion
 #include <il2cpp/il2cpp_helper.h>
 
 #include <simdutf.h>
 #if _WIN32
 #include <winrt/base.h>
 #endif
-
-inline bool ascii_isspace(unsigned char c)
-{
-  return std::isspace(static_cast<unsigned char>(c));
-}
-
-constexpr std::string_view StripTrailingAsciiWhitespace(const std::string_view str)
-{
-  const auto it = std::find_if_not(str.rbegin(), str.rend(), ascii_isspace);
-  return str.substr(0, static_cast<size_t>(str.rend() - it));
-}
-
-constexpr std::string_view StripLeadingAsciiWhitespace(const std::string_view str)
-{
-  const auto it = std::ranges::find_if_not(str, ascii_isspace);
-  return str.substr(static_cast<size_t>(it - str.begin()));
-}
-
-constexpr std::string_view StripAsciiWhitespace(const std::string_view str)
-{
-  return StripTrailingAsciiWhitespace(StripLeadingAsciiWhitespace(str));
-}
-
-constexpr std::string AsciiStrToUpper(const std::string_view s)
-{
-  std::string str = s.data();
-  std::ranges::transform(str, str.begin(), ::toupper);
-  return str;
-}
-
-constexpr std::vector<std::string> StrSplit(const std::string& input, const char delimiter)
-{
-  std::vector<std::string> result;
-  int                      last_pos = 0;
-  for (int i = 0; i < input.length(); i++) {
-    if (input[i] != delimiter) {
-      continue;
-    }
-
-    if (i - last_pos > 0) {
-      result.emplace_back(input.substr(last_pos, i - last_pos));
-    }
-    last_pos = i + 1;
-  }
-
-  if (last_pos != input.length()) {
-    auto sp = input.substr(last_pos, input.length() - last_pos);
-    sp      = StripAsciiWhitespace(sp);
-    if (!sp.empty()) {
-      result.emplace_back(sp);
-    }
-  }
-
-  return result;
-}
 
 inline std::wstring to_wstring(const std::string& str)
 {

--- a/mods/src/str_utils_pure.h
+++ b/mods/src/str_utils_pure.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// Pure string utilities that have ZERO IL2CPP or platform dependencies.
+// Split from str_utils.h so the test target can use them without dragging
+// in il2cpp_helper.h and the entire game type system.
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <string_view>
+#include <vector>
+
+inline bool ascii_isspace(unsigned char c)
+{
+  return std::isspace(static_cast<unsigned char>(c));
+}
+
+constexpr std::string_view StripTrailingAsciiWhitespace(const std::string_view str)
+{
+  const auto it = std::find_if_not(str.rbegin(), str.rend(), ascii_isspace);
+  return str.substr(0, static_cast<size_t>(str.rend() - it));
+}
+
+constexpr std::string_view StripLeadingAsciiWhitespace(const std::string_view str)
+{
+  const auto it = std::ranges::find_if_not(str, ascii_isspace);
+  return str.substr(static_cast<size_t>(it - str.begin()));
+}
+
+constexpr std::string_view StripAsciiWhitespace(const std::string_view str)
+{
+  return StripTrailingAsciiWhitespace(StripLeadingAsciiWhitespace(str));
+}
+
+constexpr std::string AsciiStrToUpper(const std::string_view s)
+{
+  std::string str = s.data();
+  std::ranges::transform(str, str.begin(), ::toupper);
+  return str;
+}
+
+constexpr std::vector<std::string> StrSplit(const std::string& input, const char delimiter)
+{
+  std::vector<std::string> result;
+  int                      last_pos = 0;
+  for (int i = 0; i < input.length(); i++) {
+    if (input[i] != delimiter) {
+      continue;
+    }
+
+    if (i - last_pos > 0) {
+      result.emplace_back(input.substr(last_pos, i - last_pos));
+    }
+    last_pos = i + 1;
+  }
+
+  if (last_pos != input.length()) {
+    auto sp = input.substr(last_pos, input.length() - last_pos);
+    sp      = StripAsciiWhitespace(sp);
+    if (!sp.empty()) {
+      result.emplace_back(sp);
+    }
+  }
+
+  return result;
+}

--- a/mods/src/testable_functions.cc
+++ b/mods/src/testable_functions.cc
@@ -1,0 +1,170 @@
+// Testable pure functions — implementations extracted from
+// notification_service.cc and battle_notify_parser.cc so they can be
+// compiled and tested without IL2CPP or game dependencies.
+
+#include "testable_functions.h"
+
+#include <cctype>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Toast state enum values (mirrored from prime/Toast.h's ToastState enum
+// so this file doesn't need the IL2CPP include chain)
+// ---------------------------------------------------------------------------
+enum ToastStateValues {
+  TS_Standard                  = 0,
+  TS_FactionWarning            = 1,
+  TS_FactionLevelUp            = 2,
+  TS_FactionLevelDown          = 3,
+  TS_FactionDiscovered         = 4,
+  TS_IncomingAttack            = 5,
+  TS_IncomingAttackFaction     = 6,
+  TS_FleetBattle               = 7,
+  TS_StationBattle             = 8,
+  TS_StationVictory            = 9,
+  TS_Victory                   = 10,
+  TS_Defeat                    = 11,
+  TS_StationDefeat             = 12,
+  TS_Tournament                = 14,
+  TS_ArmadaCreated             = 15,
+  TS_ArmadaCanceled            = 16,
+  TS_ArmadaIncomingAttack      = 17,
+  TS_ArmadaBattleWon           = 18,
+  TS_ArmadaBattleLost          = 19,
+  TS_DiplomacyUpdated          = 20,
+  TS_JoinedTakeover            = 21,
+  TS_CompetitorJoinedTakeover  = 22,
+  TS_AbandonedTerritory        = 23,
+  TS_TakeoverVictory           = 24,
+  TS_TakeoverDefeat            = 25,
+  TS_TreasuryProgress          = 26,
+  TS_TreasuryFull              = 27,
+  TS_Achievement               = 28,
+  TS_AssaultVictory            = 29,
+  TS_AssaultDefeat             = 30,
+  TS_ChallengeComplete         = 31,
+  TS_ChallengeFailed           = 32,
+  TS_StrikeHit                 = 33,
+  TS_StrikeDefeat              = 34,
+  TS_WarchestProgress          = 35,
+  TS_WarchestFull              = 36,
+  TS_PartialVictory            = 37,
+  TS_ArenaTimeLeft             = 38,
+  TS_ChainedEventScored        = 39,
+  TS_FleetPresetApplied        = 40,
+  TS_SurgeWarmUpEnded          = 41,
+  TS_SurgeHostileGroupDefeated = 42,
+  TS_SurgeTimeLeft             = 43,
+};
+
+// ---------------------------------------------------------------------------
+// toast_state_title
+// ---------------------------------------------------------------------------
+const char* toast_state_title(int state)
+{
+  switch (state) {
+    case TS_Victory:                   return "Victory!";
+    case TS_Defeat:                    return "Defeat";
+    case TS_PartialVictory:            return "Partial Victory";
+    case TS_StationVictory:            return "Station Victory!";
+    case TS_StationDefeat:             return "Station Defeat";
+    case TS_StationBattle:             return "Station Under Attack!";
+    case TS_IncomingAttack:            return "Incoming Attack!";
+    case TS_IncomingAttackFaction:     return "Incoming Faction Attack!";
+    case TS_FleetBattle:               return "Fleet Battle";
+    case TS_ArmadaBattleWon:           return "Armada Victory!";
+    case TS_ArmadaBattleLost:          return "Armada Defeated";
+    case TS_ArmadaCreated:             return "Armada Created";
+    case TS_ArmadaCanceled:            return "Armada Canceled";
+    case TS_ArmadaIncomingAttack:      return "Armada Under Attack!";
+    case TS_AssaultVictory:            return "Assault Victory!";
+    case TS_AssaultDefeat:             return "Assault Defeat";
+    case TS_Tournament:                return "Event Progress";
+    case TS_ChainedEventScored:        return "Event Progress";
+    case TS_Achievement:               return "Achievement";
+    case TS_ChallengeComplete:         return "Challenge Complete";
+    case TS_ChallengeFailed:           return "Challenge Failed";
+    case TS_TakeoverVictory:           return "Takeover Victory!";
+    case TS_TakeoverDefeat:            return "Takeover Defeat";
+    case TS_TreasuryProgress:          return "Treasury Progress";
+    case TS_TreasuryFull:              return "Treasury Full";
+    case TS_WarchestProgress:          return "Warchest Progress";
+    case TS_WarchestFull:              return "Warchest Full";
+    case TS_FactionLevelUp:            return "Faction Level Up";
+    case TS_FactionLevelDown:          return "Faction Level Down";
+    case TS_FactionDiscovered:         return "Faction Discovered";
+    case TS_FactionWarning:            return "Faction Warning";
+    case TS_DiplomacyUpdated:          return "Diplomacy Updated";
+    case TS_StrikeHit:                 return "Strike Hit";
+    case TS_StrikeDefeat:              return "Strike Defeat";
+    case TS_SurgeWarmUpEnded:          return "Surge Started";
+    case TS_SurgeHostileGroupDefeated: return "Surge Hostiles Defeated";
+    case TS_SurgeTimeLeft:             return "Surge Time Warning";
+    case TS_ArenaTimeLeft:             return "Arena Time Warning";
+    case TS_FleetPresetApplied:        return "Fleet Preset Applied";
+    default:                           return nullptr;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// strip_unity_rich_text
+// ---------------------------------------------------------------------------
+std::string strip_unity_rich_text(const std::string& s)
+{
+  std::string result;
+  result.reserve(s.size());
+  size_t i = 0;
+  while (i < s.size()) {
+    if (s[i] == '<') {
+      auto end = s.find('>', i);
+      if (end != std::string::npos) { i = end + 1; continue; }
+    }
+    result += s[i++];
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// parse_hull_key
+// ---------------------------------------------------------------------------
+std::string parse_hull_key(const std::string& key)
+{
+  auto s = key;
+
+  if (s.size() > 5 && s.ends_with("_LIVE"))
+    s = s.substr(0, s.size() - 5);
+
+  if (s.starts_with("Hull_"))
+    s = s.substr(5);
+
+  for (auto& c : s)
+    if (c == '_') c = ' ';
+
+  if (s.size() >= 2 && s[0] == 'L' && std::isdigit(s[1])) {
+    auto space = s.find(' ');
+    auto lvl   = s.substr(1, space == std::string::npos ? std::string::npos : space - 1);
+    auto rest  = space == std::string::npos ? "" : s.substr(space);
+    s = "Lv." + lvl + rest;
+  }
+
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// BattleSummaryData::format_body
+// ---------------------------------------------------------------------------
+std::string BattleSummaryData::format_body() const
+{
+  auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
+    if (name.empty()) return "";
+    if (ship.empty()) return name;
+    return name + " (" + ship + ")";
+  };
+
+  auto left  = format_side(playerName, playerShip);
+  auto right = format_side(enemyName, enemyShip);
+  if (left.empty() && right.empty()) return "";
+  if (left.empty()) return right;
+  if (right.empty()) return left;
+  return left + " vs " + right;
+}

--- a/mods/src/testable_functions.h
+++ b/mods/src/testable_functions.h
@@ -1,0 +1,26 @@
+#pragma once
+
+// Testable pure functions extracted from notification_service.cc and
+// battle_notify_parser.cc.  No IL2CPP, no platform, no game memory.
+
+#include <string>
+
+// Toast state → human-readable title.  Returns nullptr for unknown states.
+const char* toast_state_title(int state);
+
+// Strip Unity rich text tags: <color=#FF0000>, <b>, </size>, etc.
+std::string strip_unity_rich_text(const std::string& s);
+
+// Hull name key → display name:
+//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+std::string parse_hull_key(const std::string& key);
+
+// Battle summary formatting
+struct BattleSummaryData {
+  std::string playerName;
+  std::string enemyName;
+  std::string playerShip;
+  std::string enemyShip;
+
+  std::string format_body() const;
+};

--- a/tests/src/test_pure_logic.cc
+++ b/tests/src/test_pure_logic.cc
@@ -1,0 +1,252 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "str_utils_pure.h"
+#include "testable_functions.h"
+
+// ===========================================================================
+// str_utils_pure.h
+// ===========================================================================
+
+TEST_SUITE("str_utils")
+{
+  TEST_CASE("StripLeadingAsciiWhitespace")
+  {
+    CHECK(StripLeadingAsciiWhitespace("  hello") == "hello");
+    CHECK(StripLeadingAsciiWhitespace("\thello") == "hello");
+    CHECK(StripLeadingAsciiWhitespace("hello") == "hello");
+    CHECK(StripLeadingAsciiWhitespace("") == "");
+    CHECK(StripLeadingAsciiWhitespace("   ") == "");
+  }
+
+  TEST_CASE("StripTrailingAsciiWhitespace")
+  {
+    CHECK(StripTrailingAsciiWhitespace("hello  ") == "hello");
+    CHECK(StripTrailingAsciiWhitespace("hello\t") == "hello");
+    CHECK(StripTrailingAsciiWhitespace("hello") == "hello");
+    CHECK(StripTrailingAsciiWhitespace("") == "");
+    CHECK(StripTrailingAsciiWhitespace("   ") == "");
+  }
+
+  TEST_CASE("StripAsciiWhitespace")
+  {
+    CHECK(StripAsciiWhitespace("  hello  ") == "hello");
+    CHECK(StripAsciiWhitespace("  hello world  ") == "hello world");
+    CHECK(StripAsciiWhitespace("hello") == "hello");
+    CHECK(StripAsciiWhitespace("") == "");
+  }
+
+  TEST_CASE("AsciiStrToUpper")
+  {
+    CHECK(AsciiStrToUpper("hello") == "HELLO");
+    CHECK(AsciiStrToUpper("Hello World") == "HELLO WORLD");
+    CHECK(AsciiStrToUpper("ALREADY") == "ALREADY");
+    CHECK(AsciiStrToUpper("123abc") == "123ABC");
+    CHECK(AsciiStrToUpper("") == "");
+  }
+
+  TEST_CASE("StrSplit")
+  {
+    SUBCASE("basic split")
+    {
+      auto result = StrSplit("a,b,c", ',');
+      REQUIRE(result.size() == 3);
+      CHECK(result[0] == "a");
+      CHECK(result[1] == "b");
+      CHECK(result[2] == "c");
+    }
+
+    SUBCASE("strips trailing whitespace on last element")
+    {
+      auto result = StrSplit("a,b,c  ", ',');
+      REQUIRE(result.size() == 3);
+      CHECK(result[2] == "c");
+    }
+
+    SUBCASE("empty segments skipped")
+    {
+      auto result = StrSplit("a,,b", ',');
+      REQUIRE(result.size() == 2);
+      CHECK(result[0] == "a");
+      CHECK(result[1] == "b");
+    }
+
+    SUBCASE("single element")
+    {
+      auto result = StrSplit("hello", ',');
+      REQUIRE(result.size() == 1);
+      CHECK(result[0] == "hello");
+    }
+
+    SUBCASE("empty string")
+    {
+      auto result = StrSplit("", ',');
+      CHECK(result.empty());
+    }
+
+    SUBCASE("pipe delimiter")
+    {
+      auto result = StrSplit("SPACE|MOUSE1", '|');
+      REQUIRE(result.size() == 2);
+      CHECK(result[0] == "SPACE");
+      CHECK(result[1] == "MOUSE1");
+    }
+  }
+}
+
+// ===========================================================================
+// toast_state_title
+// ===========================================================================
+
+TEST_SUITE("toast_state_title")
+{
+  TEST_CASE("known states return correct titles")
+  {
+    CHECK(std::string(toast_state_title(10)) == "Victory!");
+    CHECK(std::string(toast_state_title(11)) == "Defeat");
+    CHECK(std::string(toast_state_title(37)) == "Partial Victory");
+    CHECK(std::string(toast_state_title(9)) == "Station Victory!");
+    CHECK(std::string(toast_state_title(12)) == "Station Defeat");
+    CHECK(std::string(toast_state_title(8)) == "Station Under Attack!");
+    CHECK(std::string(toast_state_title(5)) == "Incoming Attack!");
+    CHECK(std::string(toast_state_title(7)) == "Fleet Battle");
+    CHECK(std::string(toast_state_title(18)) == "Armada Victory!");
+    CHECK(std::string(toast_state_title(19)) == "Armada Defeated");
+    CHECK(std::string(toast_state_title(15)) == "Armada Created");
+    CHECK(std::string(toast_state_title(16)) == "Armada Canceled");
+    CHECK(std::string(toast_state_title(28)) == "Achievement");
+    CHECK(std::string(toast_state_title(29)) == "Assault Victory!");
+    CHECK(std::string(toast_state_title(30)) == "Assault Defeat");
+    CHECK(std::string(toast_state_title(40)) == "Fleet Preset Applied");
+  }
+
+  TEST_CASE("unknown state returns nullptr")
+  {
+    CHECK(toast_state_title(999) == nullptr);
+    CHECK(toast_state_title(-1) == nullptr);
+    CHECK(toast_state_title(13) == nullptr); // gap in enum (13 is unused)
+  }
+}
+
+// ===========================================================================
+// strip_unity_rich_text
+// ===========================================================================
+
+TEST_SUITE("strip_unity_rich_text")
+{
+  TEST_CASE("removes color tags")
+  {
+    CHECK(strip_unity_rich_text("<color=#FF0000>Red Text</color>") == "Red Text");
+  }
+
+  TEST_CASE("removes bold/italic tags")
+  {
+    CHECK(strip_unity_rich_text("<b>Bold</b> and <i>Italic</i>") == "Bold and Italic");
+  }
+
+  TEST_CASE("removes size tags")
+  {
+    CHECK(strip_unity_rich_text("<size=20>Big</size>") == "Big");
+  }
+
+  TEST_CASE("handles nested tags")
+  {
+    CHECK(strip_unity_rich_text("<color=#FFF><b>Hello</b></color>") == "Hello");
+  }
+
+  TEST_CASE("preserves plain text")
+  {
+    CHECK(strip_unity_rich_text("Hello World") == "Hello World");
+  }
+
+  TEST_CASE("empty string")
+  {
+    CHECK(strip_unity_rich_text("") == "");
+  }
+
+  TEST_CASE("unclosed angle bracket kept")
+  {
+    CHECK(strip_unity_rich_text("5 < 10 but no closing") == "5 < 10 but no closing");
+  }
+}
+
+// ===========================================================================
+// parse_hull_key
+// ===========================================================================
+
+TEST_SUITE("parse_hull_key")
+{
+  TEST_CASE("full hull key with LIVE suffix")
+  {
+    CHECK(parse_hull_key("Hull_L30_Destroyer_Klingon_LIVE") == "Lv.30 Destroyer Klingon");
+  }
+
+  TEST_CASE("hull key without LIVE suffix")
+  {
+    CHECK(parse_hull_key("Hull_L45_Battleship_Federation") == "Lv.45 Battleship Federation");
+  }
+
+  TEST_CASE("hull key without level prefix")
+  {
+    CHECK(parse_hull_key("Hull_Jellyfish_LIVE") == "Jellyfish");
+  }
+
+  TEST_CASE("minimal key")
+  {
+    CHECK(parse_hull_key("Hull_L1_Scout") == "Lv.1 Scout");
+  }
+
+  TEST_CASE("empty string")
+  {
+    CHECK(parse_hull_key("") == "");
+  }
+
+  TEST_CASE("no Hull_ prefix")
+  {
+    // Still processes underscores and level
+    CHECK(parse_hull_key("L10_Frigate") == "Lv.10 Frigate");
+  }
+}
+
+// ===========================================================================
+// BattleSummaryData::format_body
+// ===========================================================================
+
+TEST_SUITE("BattleSummaryData")
+{
+  TEST_CASE("full battle with both sides")
+  {
+    BattleSummaryData d{"Player1", "Enemy1", "Lv.30 Destroyer", "Lv.25 Frigate"};
+    CHECK(d.format_body() == "Player1 (Lv.30 Destroyer) vs Enemy1 (Lv.25 Frigate)");
+  }
+
+  TEST_CASE("names only, no ships")
+  {
+    BattleSummaryData d{"Player1", "Enemy1", "", ""};
+    CHECK(d.format_body() == "Player1 vs Enemy1");
+  }
+
+  TEST_CASE("player only")
+  {
+    BattleSummaryData d{"Player1", "", "Lv.30 Destroyer", ""};
+    CHECK(d.format_body() == "Player1 (Lv.30 Destroyer)");
+  }
+
+  TEST_CASE("enemy only")
+  {
+    BattleSummaryData d{"", "Enemy1", "", "Lv.25 Frigate"};
+    CHECK(d.format_body() == "Enemy1 (Lv.25 Frigate)");
+  }
+
+  TEST_CASE("all empty")
+  {
+    BattleSummaryData d{"", "", "", ""};
+    CHECK(d.format_body() == "");
+  }
+
+  TEST_CASE("name with ship on one side, name only on other")
+  {
+    BattleSummaryData d{"Player1", "Enemy1", "Lv.30 Destroyer", ""};
+    CHECK(d.format_body() == "Player1 (Lv.30 Destroyer) vs Enemy1");
+  }
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -1,0 +1,21 @@
+-- Unit tests for pure mod logic (no IL2CPP / game dependencies)
+target("stfc-mod-tests")
+do
+    set_kind("binary")
+    set_default(false) -- don't build with `xmake` alone; use `xmake build stfc-mod-tests`
+    set_languages("c++23")
+
+    add_files("src/*.cc")
+    add_includedirs("../mods/src", { public = true })
+
+    -- Testable source files from the mod (pure logic only)
+    add_files("../mods/src/testable_functions.cc")
+
+    add_packages("doctest")
+
+    add_defines("NOMINMAX")
+
+    if is_plat("windows") then
+        add_cxflags("/bigobj")
+    end
+end

--- a/xmake.lua
+++ b/xmake.lua
@@ -40,9 +40,11 @@ package_end()
 add_requires("spud v0.2.0-2")
 add_requires("libil2cpp")
 add_requires("simdutf", { system = false })
+add_requires("doctest")
 
 -- includes("launcher")
 includes("mods")
+includes("tests")
 
 -- add_repositories("local-repo build")
 add_repositories("stfc-community-patch-repo xmake-packages")


### PR DESCRIPTION
## What

Adds a unit test suite for the mod's pure-logic functions — the code that can be tested without a running game.

Closes #4

## Why

~25 functions in the codebase are pure logic (string processing, config helpers, notification formatting) with zero IL2CPP/game dependencies, but nothing tests them. Bugs in config parsing, key binding resolution, and hull name formatting silently break user-facing features. These should be caught in CI, not discovered in-game.

There's a clean architectural line:
- **MOD logic** (testable): string utils, toast state mapping, hull key parsing, battle summary formatting, Unity rich text stripping
- **HOOK logic** (untestable without game): IL2CPP reflection, SPUD hooks, game memory access, WinRT delivery

## How

### 1. Split `str_utils.h`
Extracted pure `std::string`/`std::wstring` functions into `str_utils_pure.h` (no IL2CPP deps). Original `str_utils.h` re-exports the pure header and adds IL2CPP overloads. Zero behavior change for existing code.

### 2. Extract testable functions
Created `testable_functions.h/.cc` with implementations of:
- `toast_state_title()` — 40+ state→string mappings
- `strip_unity_rich_text()` — removes `<color>`, `<b>`, `<size>` etc.
- `parse_hull_key()` — `"Hull_L30_Destroyer_Klingon_LIVE"` → `"Lv.30 Destroyer Klingon"`
- `BattleSummaryData::format_body()` — `"Player (Ship) vs Enemy (Ship)"`

Mirrored the `ToastState` enum values locally so the test file doesn't need the IL2CPP include chain.

### 3. Test target
- `tests/xmake.lua` — new `stfc-mod-tests` binary target, `set_default(false)` so it doesn't build with plain `xmake`
- `tests/src/test_pure_logic.cc` — 26 test cases / 72 assertions using doctest 2.5.0
- Added `doctest` to xmake dependencies

### 4. CI integration
Added `xmake build stfc-mod-tests && xmake run stfc-mod-tests` step to the Windows Build job in `ci.yaml`.

### Local results
```
[doctest] test cases: 26 | 26 passed | 0 failed | 0 skipped
[doctest] assertions: 72 | 72 passed | 0 failed |
[doctest] Status: SUCCESS!
```

Main mod build also passes (48.8s, no regressions).