### PR TITLE
docs: Comprehensive code documentation sweep (86 files, +2607 lines)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,12 @@
+# @file ci.yaml
+# @brief CI build workflow — compiles the community patch on Windows and macOS.
+#
+# Triggers on every push and on PRs targeting main/dev.  Builds release
+# artifacts for both platforms using xmake, creates a universal macOS app
+# bundle (arm64 + x86_64 via lipo), ad-hoc signs it, and packages a .dmg
+# installer.  Uploads version.dll (Windows) and the .dmg (macOS) as
+# build artifacts.
+
 name: Build
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,11 @@
+# @file release.yaml
+# @brief Release workflow — creates a GitHub release from a version tag.
+#
+# Triggered when a tag matching "v*" is pushed.  Verifies that the CI Build
+# workflow succeeded for the same commit, downloads its artifacts, packages
+# them into a .zip, detects alpha/beta pre-releases, and publishes a GitHub
+# release with the Windows .zip and macOS .dmg attached.
+
 name: Create Release
 
 on:

--- a/macos-dylib/src/main.cc
+++ b/macos-dylib/src/main.cc
@@ -1,3 +1,13 @@
+/**
+ * @file main.cc
+ * @brief macOS dylib entry point for the STFC community patch.
+ *
+ * This shared library is injected into the game process via
+ * DYLD_INSERT_LIBRARIES (set by the macOS loader/launcher). The
+ * __attribute__((constructor)) function runs before the game's main(),
+ * giving us the chance to apply mod hooks.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <syslog.h>
@@ -5,12 +15,21 @@
 
 #include "patches/patches.h"
 
+/**
+ * @brief Constructor — runs automatically when the dylib is loaded into the game process.
+ *
+ * Logs injection to syslog and applies all mod patches.
+ */
 __attribute__((constructor))
 void myconstructor(int argc, const char **argv)
 {
   syslog(LOG_ERR, "[+] dylib injected in %s\n", argv[0]);
   ApplyPatches();
 }
+
+// ─── EASTL operator new[] Overloads ──────────────────────────────────────────
+// EASTL requires custom operator new[] with extended signatures for its
+// allocator. These forward to malloc, satisfying the linker.
 
 void* operator new[](size_t size, const char* /*name*/, int /*flags*/, unsigned /*debugFlags*/, const char* /*file*/,
                      int /*line*/)

--- a/macos-dylib/xmake.lua
+++ b/macos-dylib/xmake.lua
@@ -1,3 +1,9 @@
+-- @file xmake.lua
+-- @brief Build target for the macOS community patch shared library.
+--
+-- Produces libstfc-community-patch.dylib, which is injected into the game
+-- process via DYLD_INSERT_LIBRARIES by the macOS loader/launcher.
+
 target("stfc-community-patch")
 do
     set_kind("shared")

--- a/macos-loader/src/folder_manager.h
+++ b/macos-loader/src/folder_manager.h
@@ -1,3 +1,13 @@
+/**
+ * @file folder_manager.h
+ * @brief C++ wrapper around macOS NSFileManager directory lookup APIs.
+ *
+ * Mirrors Apple's NSSearchPathDirectory / NSSearchPathDomainMask enums and
+ * provides a static helper to resolve well-known system directories (e.g.
+ * Application Support, Library) without pulling in Objective-C headers.
+ * Used by the macOS loader to locate the game install path.
+ */
+
 #pragma once
 
 namespace fm

--- a/macos-loader/src/main.cc
+++ b/macos-loader/src/main.cc
@@ -1,3 +1,14 @@
+/**
+ * @file main.cc
+ * @brief macOS CLI loader — launches STFC with the community patch dylib injected.
+ *
+ * Reads the game install path from ~/Library/Preferences/Star Trek Fleet
+ * Command/launcher_settings.ini, then sets DYLD_INSERT_LIBRARIES to point at
+ * the community patch dylib and DYLD_LIBRARY_PATH to the loader's own
+ * directory.  Finally, it exec's the game binary so the dylib constructor
+ * fires before the game's main().
+ */
+
 #include "folder_manager.h"
 
 #include <inicpp.h>

--- a/macos-loader/xmake.lua
+++ b/macos-loader/xmake.lua
@@ -1,3 +1,10 @@
+-- @file xmake.lua
+-- @brief Build target for the macOS CLI loader binary.
+--
+-- Produces the stfc-community-patch-loader executable, which reads the game
+-- install path from launcher_settings.ini, sets up DYLD environment variables,
+-- and exec's the game with the community patch dylib injected.
+
 target("stfc-community-patch-loader")
 do
     set_kind("binary")

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1,3 +1,11 @@
+/**
+ * @file config.cc
+ * @brief Configuration loading, saving, and migration for the Community Mod.
+ *
+ * Parses community_patch_settings.toml via toml++, applies DefaultConfig
+ * fallbacks for every key, writes a merged "runtime vars" snapshot, handles
+ * macOS config-path migration, and converts legacy sync options.
+ */
 #include "config.h"
 #include "file.h"
 #include "patches/mapkey.h"
@@ -30,11 +38,15 @@ namespace DCSH = DefaultConfig::Shortcuts;
 // See: fix/lto-and-sync-crashes for context on why Config struct changes crash.
 static bool g_allow_key_fallthrough = false;
 
+/** @brief Accessor for the file-scope allow_key_fallthrough flag. */
 bool AllowKeyFallthrough()
 {
   return g_allow_key_fallthrough;
 }
 
+/// Human-readable names → ToastState enum values.
+/// Used to map comma-separated strings from the TOML config into the
+/// disabled_banner_types / notify_banner_types integer vectors.
 static const eastl::tuple<const char*, int> bannerTypes[] = {
     {"Standard", ToastState::Standard},
     {"FactionWarning", ToastState::FactionWarning},
@@ -238,6 +250,10 @@ void Config::AdjustUiViewerScale(bool scaleUp)
   }
 }
 
+/**
+ * @brief Mask the middle portion of a bearer token for safe logging.
+ * @return The token with interior characters replaced by '*' (preserving dashes).
+ */
 inline std::string mask_token(const std::string& token)
 {
   if (token.size() > 21) {
@@ -253,6 +269,7 @@ inline std::string mask_token(const std::string& token)
   }
 }
 
+/** @brief Convert a toml::node_type to a human-readable string for diagnostics. */
 std::string get_config_type_as_string(const toml::node_type type)
 {
   switch (type) {
@@ -281,6 +298,21 @@ std::string get_config_type_as_string(const toml::node_type type)
   return "The node type is unknown";
 }
 
+/**
+ * @brief Read a single config value from the parsed TOML, falling back to default.
+ *
+ * Also writes the resolved value into @p new_config so the merged "runtime vars"
+ * snapshot reflects what the mod is actually using.
+ *
+ * @tparam T        Expected value type (bool, int, float, std::string, etc.).
+ * @param config     The user-parsed toml::table.
+ * @param new_config The output table that accumulates resolved values.
+ * @param section    TOML section name (e.g. "graphics").
+ * @param item       Key within the section (e.g. "ui_scale").
+ * @param default_value  Fallback if the key is missing or invalid.
+ * @param write_log  Whether to log the resolved value at debug level.
+ * @return The resolved value.
+ */
 template <typename T>
 T get_config_or_default(toml::table& config, toml::table& new_config, std::string_view section, std::string_view item,
                         T default_value, bool write_log)
@@ -308,6 +340,12 @@ T get_config_or_default(toml::table& config, toml::table& new_config, std::strin
   return (T)final_value;
 }
 
+/**
+ * @brief Parse all [sync.targets.<name>] tables and populate the targets map.
+ *
+ * Each target inherits the top-level [sync] defaults for any per-category
+ * toggle not explicitly overridden.
+ */
 void read_sync_targets(toml::table& config, toml::table& new_config,
                        std::map<std::string, SyncTargetConfig>& sync_targets, const SyncConfig& defaults)
 {
@@ -369,6 +407,12 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
   }
 }
 
+/**
+ * @brief Parse a single shortcut config entry and register it with MapKey.
+ *
+ * Supports pipe-delimited multi-bind strings (e.g. "SPACE|MOUSE1").
+ * "NONE" explicitly unbinds the shortcut.
+ */
 void parse_config_shortcut(toml::table& config, toml::table& new_config, std::string_view item,
                            GameFunction gameFunction, std::string_view default_value)
 {
@@ -414,6 +458,12 @@ void parse_config_shortcut(toml::table& config, toml::table& new_config, std::st
   spdlog::debug("shortcut value {}.{} value: {}", section, item, shortcut);
 }
 
+/**
+ * @brief Migrate macOS config from the old bundle-id directory to the new one.
+ *
+ * Moves ~/Library/Preferences/com.tashcan.startrekpatch/ to
+ * com.stfcmod.startrekpatch/ and leaves a symlink + info file at the old location.
+ */
 void migrate_mac_config_if_needed(const char* filename)
 {
 #if !_WIN32
@@ -462,6 +512,7 @@ void migrate_mac_config_if_needed(const char* filename)
 #endif
 }
 
+/** @brief Remove the old misspelled vars file (community_path_runtime.vars). */
 void delete_old_vars()
 {
   namespace fs = std::filesystem;

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -1,3 +1,11 @@
+/**
+ * @file config.h
+ * @brief TOML-based configuration system for the STFC Community Mod.
+ *
+ * Defines the Config singleton (runtime settings loaded from
+ * community_patch_settings.toml) and the SyncConfig / SyncTargetConfig
+ * structures that drive per-target data synchronisation.
+ */
 #pragma once
 
 #include <array>
@@ -11,9 +19,16 @@
 #include <Windows.h>
 #endif
 
+/**
+ * @brief Per-target synchronisation toggles and proxy settings.
+ *
+ * Each boolean flag controls whether a specific data category is sent
+ * to the sync backend.  SyncTargetConfig extends this with URL/token.
+ */
 class SyncConfig
 {
 public:
+  /// Categories of game data that can be synced to an external service.
   enum class Type {
     Battles,
     Buffs,
@@ -31,11 +46,17 @@ public:
     Traits
   };
 
+  /**
+   * @brief Maps a sync type to its JSON key, TOML key, and member pointer.
+   *
+   * Used by SyncOptions[] to drive config loading and JSON serialisation
+   * from a single table, avoiding per-type boilerplate.
+   */
   struct Option {
     Type             type;
-    std::string_view type_str;   // used in JSON body
-    std::string_view option_str; // used in TOML file
-    bool SyncConfig::* option;
+    std::string_view type_str;   ///< Key used in the outbound JSON body.
+    std::string_view option_str; ///< Key used in the TOML config file.
+    bool SyncConfig::* option;   ///< Pointer-to-member for the bool toggle.
   };
 
   std::string proxy;
@@ -55,9 +76,11 @@ public:
   bool tech       = false;
   bool traits     = false;
 
+  /** @brief Check whether a given sync type is enabled on this config. */
   [[nodiscard]] bool enabled(Type type) const;
 };
 
+/// Master table mapping every SyncConfig::Type to its JSON/TOML keys and member pointer.
 constexpr std::array SyncOptions{
     SyncConfig::Option{SyncConfig::Type::Battles, "battlelog", "battlelogs", &SyncConfig::battlelogs},
     SyncConfig::Option{SyncConfig::Type::Buffs, "buff", "buffs", &SyncConfig::buffs},
@@ -96,29 +119,59 @@ constexpr std::string operator+(const SyncConfig::Type type, const std::string& 
   return to_string(type) + suffix;
 }
 
+/**
+ * @brief A single sync target: base SyncConfig toggles plus endpoint credentials.
+ *
+ * Multiple targets can be defined under [sync.targets.<name>] in the TOML file,
+ * each with its own URL, bearer token, and per-category overrides.
+ */
 class SyncTargetConfig : public SyncConfig
 {
 public:
-  std::string url;
-  std::string token;
+  std::string url;   ///< Endpoint URL for this sync target.
+  std::string token; ///< Bearer token / API key.
 };
 
+/**
+ * @brief Singleton holding all runtime configuration for the Community Mod.
+ *
+ * Constructed once via Config::Get().  The constructor calls Load(), which
+ * parses the user's TOML file (falling back to DefaultConfig values),
+ * writes a merged "runtime vars" snapshot, and populates every member.
+ */
 class Config final
 {
 public:
   Config();
 
+  /** @brief Access the process-wide singleton. */
   [[nodiscard]] static Config& Get();
+
+  /** @brief Current monitor DPI scale factor (cached per monitor change). */
   [[nodiscard]] static float   GetDPI();
+
+  /** @brief Force a DPI re-read (e.g. after a display change). */
   static float                 RefreshDPI();
 
 #ifdef _WIN32
   [[nodiscard]] static HWND WindowHandle();
 #endif
 
+  /**
+   * @brief Serialise a toml::table to disk.
+   * @param config    The table to write.
+   * @param filename  Target filename (resolved via File::MakePath).
+   * @param apply_warning  If true, prepend a "this is not the config file" header.
+   */
   static void Save(const toml::table& config, std::string_view filename, bool apply_warning = true);
+
+  /** @brief Parse the user TOML and populate all members. Called by the constructor. */
   void        Load();
+
+  /** @brief Bump UI scale up or down by ui_scale_adjust, clamped to [0.1, 2.0]. */
   void        AdjustUiScale(bool scaleUp);
+
+  /** @brief Bump object-viewer UI scale (finer step: ui_scale_adjust * 0.25). */
   void        AdjustUiViewerScale(bool scaleUp);
 
   // Disallow copying/moving to enforce singleton
@@ -189,6 +242,7 @@ public:
 
   std::map<std::string, SyncTargetConfig> sync_targets;
 
+  // ─── Patch Toggles (debug builds only — release forces all true) ──────────
   bool installUiScaleHooks;
   bool installZoomHooks;
   bool installBuffFixHooks;
@@ -209,5 +263,11 @@ public:
   std::string config_assets_url_override;
 };
 
-// Standalone config flag — kept outside Config struct to avoid layout sensitivity crashes.
+/**
+ * @brief Whether unhandled key events pass through to the game's default input.
+ *
+ * Stored as a file-scope static in config.cc rather than a Config member to
+ * avoid changing the struct layout, which can trigger LTO-related crashes.
+ * @see fix/lto-and-sync-crashes
+ */
 bool AllowKeyFallthrough();

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -1,70 +1,108 @@
+/**
+ * @file defaultconfig.h
+ * @brief Compile-time default values for every TOML configuration key.
+ *
+ * Organised into namespaces that mirror the [section] structure of
+ * community_patch_settings.toml.  Config::Load() uses these as fallbacks
+ * when the user file is missing or a key is absent.
+ */
 #pragma once
 
 namespace DefaultConfig
 {
 namespace Buffs
 {
+  /// Apply out-of-dock power buffs even when the ship is undocked.
+  /// Default: true.
   constexpr bool use_out_of_dock_power = true;
 } // namespace Buffs
 
 namespace SystemConfig
 {
+  /// Override URL for downloading remote asset bundles (empty = use game default).
   constexpr const char* assets_url_override = "";
+  /// URL for fetching remote settings updates (empty = disabled).
   constexpr const char* settings_url        = "";
 } // namespace SystemConfig
 
 namespace Control
 {
+  /// Enable experimental/unstable features (e.g. pan-momentum, WASD move keys). Default: false.
   constexpr bool enable_experimental = false;
+  /// Master toggle for keyboard hotkeys. Default: true.
   constexpr bool hotkeys_enabled     = true;
+  /// Enable the extended hotkey set (bookmarks, cargo toggles, etc.). Default: true.
   constexpr bool hotkeys_extended    = true;
+  /// When true, use Scopely's built-in hotkey layer instead of the mod's. Default: false.
   constexpr bool use_scopely_hotkeys = false;
+  /// Enable the action queue system. Default: true.
   constexpr bool queue_enabled       = true;
+  /// Delay in ms before a tap is registered as a select action. Default: 500.
   constexpr auto select_timer        = 500;
 } // namespace Control
 
 namespace Graphics
 {
+  /// Start in borderless-fullscreen mode. Default: true.
   constexpr bool borderless_fullscreen       = true;
+  /// Show the OS cursor instead of hiding it. Default: true.
   constexpr bool allow_cursor                = true;
+  /// Default system-view zoom level (game units). Default: 1750.
   constexpr auto default_system_zoom         = 1750;
+  /// Allow free window resizing (not locked to 16:9). Default: true.
   constexpr bool free_resize                 = true;
+  /// Speed of keyboard-driven zoom (game units/s). Default: 350.
   constexpr auto keyboard_zoom_speed         = 350;
+  /// Expose all display resolutions, not just 16:9. Default: false.
   constexpr bool show_all_resolutions        = false;
+  /// Momentum decay rate for system-view panning (0–1, higher = slower decay). Default: 0.8.
   constexpr auto system_pan_momentum_falloff = 0.8;
+  /// Initial pan-momentum strength (0–1). Default: 0.4. Requires enable_experimental.
   constexpr auto system_pan_momentum         = 0.4;
+  /// Zoom preset levels 1–5 (game units, low = close, high = far). Defaults: 50–5000.
   constexpr auto system_zoom_preset_1        = 50;
   constexpr auto system_zoom_preset_2        = 500;
   constexpr auto system_zoom_preset_3        = 1250;
   constexpr auto system_zoom_preset_4        = 2750;
   constexpr auto system_zoom_preset_5        = 5000;
+  /// Camera transition duration in seconds. Default: 0.01 (near-instant).
   constexpr auto transition_time             = 0.01;
+  /// Base UI scale multiplier. Default: 0.6.
   constexpr auto ui_scale                    = 0.6;
+  /// Step size for PgUp/PgDown UI scale adjustment. Default: 0.05.
   constexpr auto ui_scale_adjust             = 0.05;
+  /// Scale multiplier for the object-viewer panel. Default: 1.2.
   constexpr auto ui_scale_viewer             = 1.2;
+  /// Use zoom presets as the initial zoom on system entry. Default: true.
   constexpr bool use_presets_as_default      = true;
+  /// Maximum camera zoom distance (game units). Default: 5000.
   constexpr auto zoom                        = 5000;
 } // namespace Graphics
 
 namespace Patches
 {
-  constexpr bool bufffixhooks               = true;
-  constexpr bool chatpatches                = true;
-  constexpr bool freeresizehooks            = true;
-  constexpr bool hotkeyhooks                = true;
-  constexpr bool improveresponsivenesshooks = true;
-  constexpr bool miscpatches                = true;
-  constexpr bool objecttracker              = true;
-  constexpr bool panhooks                   = true;
-  constexpr bool resolutionlistfix          = true;
-  constexpr bool syncpatches                = true;
-  constexpr bool tempcrashfixes             = true;
-  constexpr bool testpatches                = true;
-  constexpr bool toastbannerhooks           = true;
-  constexpr bool uiscalehooks               = true;
-  constexpr bool zoomhooks                  = true;
+  // Debug-build toggles for individual hook categories.
+  // In release builds these are ignored and all patches are force-enabled.
+  constexpr bool bufffixhooks               = true;  ///< Out-of-dock power / buff calculation fixes.
+  constexpr bool chatpatches                = true;  ///< Chat-related UI patches.
+  constexpr bool freeresizehooks            = true;  ///< Free window resize hooks.
+  constexpr bool hotkeyhooks                = true;  ///< Keyboard hotkey injection.
+  constexpr bool improveresponsivenesshooks = true;  ///< Input-responsiveness improvements.
+  constexpr bool miscpatches                = true;  ///< Misc one-off fixes.
+  constexpr bool objecttracker              = true;  ///< In-system object tracking overlay.
+  constexpr bool panhooks                   = true;  ///< Pan-momentum hooks.
+  constexpr bool resolutionlistfix          = true;  ///< Resolution-list population fix.
+  constexpr bool syncpatches                = true;  ///< Data-sync network hooks.
+  constexpr bool tempcrashfixes             = true;  ///< Temporary crash mitigations.
+  constexpr bool testpatches                = true;  ///< Test / experimental patches.
+  constexpr bool toastbannerhooks           = true;  ///< Toast-banner filtering hooks.
+  constexpr bool uiscalehooks               = true;  ///< UI scale override hooks.
+  constexpr bool zoomhooks                  = true;  ///< Camera zoom override hooks.
 } // namespace Patches
 
+/// Default key-binding strings for the [shortcuts] TOML section.
+/// Format: \"MODIFIER-KEY\" or \"KEY1|KEY2\" for multi-bind.
+/// \"NONE\" unbinds the action entirely.  See KEYMAPPING.md for full syntax.
 namespace Shortcuts
 {
   constexpr const char* toggle_queue          = "CTRL-Q";
@@ -161,51 +199,73 @@ namespace Shortcuts
 
 namespace Sync
 {
-  constexpr bool        battlelogs         = true;
-  constexpr bool        buffs              = true;
-  constexpr bool        buildings          = true;
-  constexpr bool        inventory          = true;
-  constexpr bool        jobs               = true;
-  constexpr bool        missions           = true;
-  constexpr bool        officer            = true;
-  constexpr const char* proxy              = "";
-  constexpr bool        research           = true;
-  constexpr bool        resources          = true;
-  constexpr bool        ships              = true;
-  constexpr bool        slots              = true;
-  constexpr bool        tech               = true;
-  constexpr bool        traits             = true;
-  constexpr const char* token              = "";
-  constexpr const char* url                = "";
-  constexpr bool        debug              = false;
-  constexpr bool        logging            = false;
-  constexpr bool        verify_ssl         = true;
+  // Per-category defaults — each maps to a [sync] TOML key.
+  // Individual [sync.targets.<name>] sections can override these.
+  constexpr bool        battlelogs         = true;   ///< Sync battle-log reports.
+  constexpr bool        buffs              = true;   ///< Sync buff / Emerald Chain data.
+  constexpr bool        buildings          = true;   ///< Sync station module data.
+  constexpr bool        inventory          = true;   ///< Sync inventory contents.
+  constexpr bool        jobs               = true;   ///< Sync active job/build queues.
+  constexpr bool        missions           = true;   ///< Sync mission progress.
+  constexpr bool        officer            = true;   ///< Sync officer roster.
+  constexpr const char* proxy              = "";     ///< HTTP proxy for sync requests (empty = none).
+  constexpr bool        research           = true;   ///< Sync research tree state.
+  constexpr bool        resources          = true;   ///< Sync resource amounts.
+  constexpr bool        ships              = true;   ///< Sync fleet / ship data.
+  constexpr bool        slots              = true;   ///< Sync crew-slot assignments.
+  constexpr bool        tech               = true;   ///< Sync forbidden tech data.
+  constexpr bool        traits             = true;   ///< Sync officer traits.
+  constexpr const char* token              = "";     ///< Bearer token (legacy, prefer targets).
+  constexpr const char* url                = "";     ///< Endpoint URL (legacy, prefer targets).
+  constexpr bool        debug              = false;  ///< Extra debug logging for sync subsystem.
+  constexpr bool        logging            = false;  ///< Log raw sync payloads.
+  constexpr bool        verify_ssl         = true;   ///< Verify TLS certificates on sync requests.
+  /// DNS resolver cache TTL in seconds. Default: 300 (5 min).
   constexpr auto        resolver_cache_ttl = 300;
 } // namespace Sync
 
 namespace UI
 {
+  /// Auto-skip the ship/officer reveal animation. Default: true.
   constexpr bool        always_skip_reveal_sequence = true;
+  /// Auto-confirm new system discoveries. Default: true.
   constexpr bool        auto_confirm_discovery      = true;
+  /// Block the Escape key from closing the game. Default: true.
   constexpr bool        disable_escape_exit         = true;
-  // Max ms between two Escape presses to count as a double-tap.
-  // 0 = disabled (Escape fully blocked). 500 = half-second window.
+  /// Max ms between two Escape presses to count as a double-tap.
+  /// 0 = disabled (Escape fully blocked). 500 = half-second window.
   constexpr auto        escape_exit_timer           = 0;
+  /// Suppress the first-run welcome popup. Default: false.
   constexpr bool        disable_first_popup         = false;
+  /// Hide galaxy chat entirely. Default: false.
   constexpr bool        disable_galaxy_chat         = false;
+  /// Disable WASD movement keys. Default: false.
   constexpr bool        disable_move_keys           = false;
+  /// Disable the "locate" preview on fleet-select. Default: false.
   constexpr bool        disable_preview_locate      = false;
+  /// Disable the "recall" preview on fleet-select. Default: false.
   constexpr bool        disable_preview_recall      = false;
+  /// Suppress all toast banners. Default: false.
   constexpr bool        disable_toast_banners       = false;
+  /// Hide Veil-sector chat. Default: false.
   constexpr bool        disable_veil_chat           = false;
+  /// Comma-separated list of toast banner type names to suppress (empty = none).
   constexpr const char* disabled_banner_types       = "";
+  /// Comma-separated list of banner types that trigger a desktop notification (empty = none).
   constexpr const char* notify_banner_types         = "";
+  /// Maximum alliance-donation slider value (percentage). Default: 80.
   constexpr auto        extend_donation_max         = 80;
+  /// Enable the extended donation slider range. Default: true. (Windows only.)
   constexpr bool        extend_donation_slider      = true;
+  /// Show cargo overlay on armada targets by default. Default: true.
   constexpr bool        show_armada_cargo           = true;
+  /// Show cargo overlay on all entities by default. Default: true.
   constexpr bool        show_cargo_default          = true;
+  /// Show cargo overlay on hostile ships. Default: true.
   constexpr bool        show_hostile_cargo          = true;
+  /// Show cargo overlay on player ships. Default: true.
   constexpr bool        show_player_cargo           = true;
+  /// Show cargo overlay on stations. Default: true.
   constexpr bool        show_station_cargo          = true;
 } // namespace UI
 

--- a/mods/src/errormsg.h
+++ b/mods/src/errormsg.h
@@ -1,3 +1,10 @@
+/**
+ * @file errormsg.h
+ * @brief Centralised error-logging helpers for common failure patterns.
+ *
+ * Provides short, consistent spdlog::error() wrappers for missing IL2CPP
+ * methods/helpers, sync transport errors, and WinRT HRESULT failures.
+ */
 #pragma once
 
 #include "str_utils.h"
@@ -8,18 +15,27 @@
 #include <winrt/Windows.Foundation.h>
 #endif
 
+/**
+ * @brief Structured error-logging helpers for recurring failure patterns.
+ *
+ * Each function logs via spdlog::error() with a consistent format so grep/log
+ * analysis can easily filter by category (method lookup, sync transport, etc.).
+ */
 namespace ErrorMsg
 {
+/** @brief Log a missing instance method (classname->methodname). */
 static auto MissingMethod(const char* classname, const char* methodname)
 {
   spdlog::error("Unable to find method '{}->{}'", classname, methodname);
 }
 
+/** @brief Log a missing static method (classname::methodname). */
 static void MissingStaticMethod(const char* classname, const char* methodname)
 {
   spdlog::error("Unable to find method '{}::{}'", classname, methodname);
 }
 
+/** @brief Log a missing IL2CPP helper class (namespace.classname). */
 static void MissingHelper(const char* namespacename, const char* classname)
 {
   spdlog::error("Unable to find helper '{}.{}'", namespacename, classname);

--- a/mods/src/file.cc
+++ b/mods/src/file.cc
@@ -1,7 +1,16 @@
+/**
+ * @file file.cc
+ * @brief Implementation of File path resolution, Init(), and static caches.
+ *
+ * On Windows, parses -ccm <profile> from the command line to derive per-profile
+ * filenames for config, log, vars, and battle-log files.  On macOS, paths are
+ * routed through ~/Library/Preferences/ via MakePath().
+ */
 #include "file.h"
 #include "windowtitle.h"
 
 #if _WIN32
+/** @brief Convert a wide string to UTF-8 via WideCharToMultiByte. */
 std::string ConvertWStringToString(const std::wstring& wstr)
 {
   if (wstr.empty())
@@ -236,6 +245,8 @@ bool File::hasTrace()
 {
   return File::trace;
 }
+
+// ─── Static Member Definitions ─────────────────────────────────────────────────
 
 #ifdef _MODDBG
 bool File::debug = true;

--- a/mods/src/file.h
+++ b/mods/src/file.h
@@ -1,3 +1,11 @@
+/**
+ * @file file.h
+ * @brief File-path resolution and naming for mod config, log, and data files.
+ *
+ * The File class manages path derivation from a base config filename,
+ * supports a -ccm command-line override for multiple config profiles on
+ * Windows, and handles macOS library-directory layout via MakePath().
+ */
 #include "config.h"
 #include "patches/mapkey.h"
 #include "prime/KeyCode.h"
@@ -36,20 +44,53 @@
 #define FILE_EXT_LOG ".log"
 #define FILE_EXT_JSON ".json"
 
+/**
+ * @brief Central file-path manager for the mod's config, log, and data files.
+ *
+ * All paths are lazily initialised on first access (via Init()).
+ * On Windows, the -ccm <profile> argument allows multiple config profiles
+ * by deriving all filenames from a single base path.
+ */
 class File
 {
 public:
+  /** @brief Parse command-line args and populate all cached paths. */
   static void         Init();
+
+  /** @brief Window title (prefixed with profile name if -ccm is active). */
   static std::wstring Title();
+
+  /** @brief Default config filename (always community_patch_settings.toml). */
   static const char*  Default();
+
+  /** @brief Active config filename (may differ from Default if -ccm is used). */
   static const char*  Config();
+
+  /** @brief Runtime-vars snapshot filename. */
   static const char*  Vars();
+
+  /** @brief Log filename. */
   static const char*  Log();
+
+  /** @brief Battle-log JSON filename. */
   static const char*  Battles();
+
+  /** @brief True if running with a -ccm profile override. */
   static bool         hasCustomNames();
+
+  /** @brief True if -debug was passed on the command line. */
   static bool         hasDebug();
+
+  /** @brief True if -trace was passed on the command line. */
   static bool         hasTrace();
 
+  /**
+   * @brief Build a full path for a mod file.
+   * @param filename    The leaf filename.
+   * @param create_dir  Create parent directories if they don't exist (macOS only).
+   * @param old_path    Use the legacy bundle-id directory (macOS migration).
+   * @return Platform-appropriate path string.
+   */
 #if _WIN32
   static std::string_view MakePath(std::string_view filename, bool create_dir = false, bool old_path = false);
 #else

--- a/mods/src/folder_manager.h
+++ b/mods/src/folder_manager.h
@@ -1,7 +1,18 @@
+/**
+ * @file folder_manager.h
+ * @brief macOS NSSearchPathForDirectoriesInDomains bridge for C++.
+ *
+ * Wraps the Objective-C Foundation API so C++ code can resolve standard
+ * macOS directories (Library, Caches, Application Support, etc.) without
+ * importing Foundation headers directly.
+ */
 #pragma once
 
 namespace fm
 {
+/// NSSearchPathDirectory constants mirroring Apple's Foundation enum.
+/// Only the subset actually used by the mod is meaningful; the rest
+/// are included for completeness if future code needs them.
 enum {
   NSApplicationDirectory = 1,
   NSDemoApplicationDirectory,
@@ -33,6 +44,7 @@ enum {
 };
 typedef unsigned long SearchPathDirectory;
 
+/// NSSearchPathDomainMask constants.
 enum {
   NSUserDomainMask = 1, // user's home directory --- place to install user's personal items (~)
   NSLocalDomainMask =
@@ -44,9 +56,21 @@ enum {
 };
 typedef unsigned long SearchPathDomainMask;
 
+/**
+ * @brief C++ bridge to NSSearchPathForDirectoriesInDomains.
+ *
+ * Implementation is in Objective-C++ (folder_manager.mm).  Returns
+ * C strings owned by a static cache — valid for the process lifetime.
+ */
 class FolderManager
 {
 public:
+  /**
+   * @brief Resolve a standard macOS directory.
+   * @param directory  NSSearchPathDirectory constant (e.g. NSLibraryDirectory).
+   * @param domainMask Domain mask (typically NSUserDomainMask).
+   * @return Null-terminated path string, valid for the process lifetime.
+   */
   static const char *pathForDirectory(SearchPathDirectory directory, SearchPathDomainMask domainMask);
   static const char *pathForDirectoryAppropriateForItemAtPath(SearchPathDirectory  directory,
                                                               SearchPathDomainMask domainMask, const char *itemPath,

--- a/mods/src/il2cpp/il2cpp-functions.cc
+++ b/mods/src/il2cpp/il2cpp-functions.cc
@@ -1,3 +1,13 @@
+/**
+ * @file il2cpp-functions.cc
+ * @brief Runtime resolution of IL2CPP API function pointers.
+ *
+ * On macOS, defines the storage for every IL2CPP function pointer (via the
+ * same X-macro pattern used in il2cpp-functions.h) and resolves them at
+ * runtime by dlopen()ing GameAssembly.dylib. On Windows the entire file
+ * compiles to a no-op because GameAssembly.lib provides the symbols at link
+ * time.
+ */
 #include "il2cpp-functions.h"
 
 #include <cstdio>
@@ -11,6 +21,7 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif // __cplusplus
+// Define the actual function-pointer variables (one per IL2CPP API function).
 #define DO_API(r, n, p) n##_t n;
 #define DO_API_NO_RETURN(r, n, p) DO_API(r, n, p)
 #include "il2cpp-api-functions.h"

--- a/mods/src/il2cpp/il2cpp-functions.h
+++ b/mods/src/il2cpp/il2cpp-functions.h
@@ -1,3 +1,13 @@
+/**
+ * @file il2cpp-functions.h
+ * @brief Foreign-function declarations for the IL2CPP runtime API.
+ *
+ * Uses an X-macro pattern with il2cpp-api-functions.h to declare every IL2CPP
+ * C API function. On Windows the symbols are imported directly from
+ * GameAssembly.lib at link time. On macOS, function-pointer typedefs and
+ * extern declarations are emitted instead, to be resolved at runtime by
+ * init_il2cpp_pointers().
+ */
 #pragma once
 
 #ifdef _WIN32
@@ -12,6 +22,9 @@
 #if defined(__cplusplus)
 extern "C" {
 #endif // __cplusplus
+// On Windows: DO_API expands to __declspec(dllimport) declarations (via IL2CPP_IMPORT).
+// On macOS:   DO_API expands to a function-pointer typedef + extern variable,
+//             populated later by init_il2cpp_pointers().
 #if _WIN32
 #define DO_API(r, n, p) IL2CPP_IMPORT r n p;
 #define DO_API_NO_RETURN(r, n, p) IL2CPP_IMPORT NORETURN r n p;
@@ -28,4 +41,11 @@ extern "C" {
 }
 #endif // __cplusplus
 
+/**
+ * @brief Resolve IL2CPP API function pointers at runtime (macOS only).
+ *
+ * On Windows this is a no-op because symbols are resolved at link time via
+ * GameAssembly.lib. On macOS it dlopen()s GameAssembly.dylib and fills every
+ * function pointer declared above via dlsym().
+ */
 void init_il2cpp_pointers();

--- a/mods/src/il2cpp/il2cpp_helper.cc
+++ b/mods/src/il2cpp/il2cpp_helper.cc
@@ -1,5 +1,14 @@
+/**
+ * @file il2cpp_helper.cc
+ * @brief Implementation helpers for IL2CPP managed-object access.
+ */
 #include "il2cpp_helper.h"
 
+/**
+ * @brief Resolve a GC handle to its managed object pointer.
+ * @param handle IL2CPP garbage-collector handle.
+ * @return Pointer to the managed Il2CppObject, or nullptr if the handle is invalid.
+ */
 Il2CppObject* get_target(Il2CppGCHandle handle)
 {
   return il2cpp_gchandle_get_target(handle);

--- a/mods/src/il2cpp/il2cpp_helper.h
+++ b/mods/src/il2cpp/il2cpp_helper.h
@@ -1,3 +1,20 @@
+/**
+ * @file il2cpp_helper.h
+ * @brief High-level C++ wrappers around the IL2CPP reflection API.
+ *
+ * Provides helper classes that simplify common IL2CPP operations such as
+ * looking up classes, calling methods, and reading/writing fields and
+ * properties on managed objects. These wrappers are the primary interface
+ * used by the prime/ game-object headers to interact with the C# runtime.
+ *
+ * Key types:
+ *  - IL2CppPropertyHelper  -- read/write managed properties via reflection.
+ *  - IL2CppFieldHelper      -- resolve field offsets for direct memory access.
+ *  - IL2CppStaticFieldHelper-- read static fields.
+ *  - IL2CppClassHelper      -- the main workhorse: method lookup, object
+ *                              allocation, nested types, parent traversal.
+ *  - ObjectFinder<T>        -- locate tracked managed objects by class.
+ */
 #pragma once
 
 #include "il2cpp-functions.h"
@@ -17,6 +34,15 @@
 #include <unistd.h>
 #endif
 
+/**
+ * @brief Wrapper for reading and writing a managed C# property via IL2CPP reflection.
+ *
+ * Holds a class pointer and PropertyInfo obtained from il2cpp_class_get_property_from_name().
+ * Property access goes through virtual dispatch so overridden getters/setters are honoured.
+ *
+ * @note GetRaw() returns the raw Il2CppObject* (boxed for value types).
+ *       Get() additionally unboxes the result, suitable for value types like int/float.
+ */
 class IL2CppPropertyHelper
 {
 public:
@@ -35,6 +61,12 @@ public:
 #endif
   }
 
+  /**
+   * @brief Set the property value via its managed setter (virtual dispatch).
+   * @tparam T The value type to pass.
+   * @param _this Pointer to the managed object instance.
+   * @param v Value to set.
+   */
   template <typename T> void SetRaw(void* _this, T& v)
   {
     if (!this->propInfo) {
@@ -50,6 +82,12 @@ public:
     il2cpp_runtime_invoke(set_method_virtual, _this, params, &exception);
   }
 
+  /**
+   * @brief Invoke the property getter via virtual dispatch.
+   * @tparam T Cast the returned pointer to this type.
+   * @param _this Pointer to the managed object instance.
+   * @return Pointer to the result (still boxed for value types), or nullptr on failure.
+   */
   template <typename T = void> T* GetRaw(void* _this)
   {
     if (!this->propInfo) {
@@ -69,12 +107,24 @@ public:
     return (T*)(result);
   }
 
+  /**
+   * @brief Get and unbox a property value (for value types like int, float, enum).
+   * @tparam T The unboxed value type.
+   * @param _this Pointer to the managed object instance.
+   * @return Pointer to the unboxed value, or nullptr on failure.
+   */
   template <typename T> T* Get(void* _this)
   {
     auto r = GetRaw<Il2CppObject>(_this);
     return !r ? nullptr : (T*)(il2cpp_object_unbox(r));
   }
 
+  /**
+   * @brief Get a property from an already-boxed object, unboxing both self and result.
+   * @tparam T The unboxed value type.
+   * @param _this Pointer to the boxed managed object.
+   * @return Pointer to the unboxed value, or nullptr on failure.
+   */
   template <typename T> T* GetUnboxedSelf(void* _this)
   {
     auto r = GetRaw<Il2CppObject>(il2cpp_object_unbox((Il2CppObject*)_this));
@@ -86,6 +136,12 @@ private:
   const PropertyInfo* propInfo;
 };
 
+/**
+ * @brief Wrapper for accessing a managed instance field by its byte offset.
+ *
+ * Used by the prime/ headers to read/write fields directly in managed object
+ * memory via offset arithmetic (e.g. `*(T*)((ptrdiff_t)this + field.offset())`).
+ */
 class IL2CppFieldHelper
 {
 public:
@@ -114,6 +170,12 @@ private:
   FieldInfo*   fieldInfo;
 };
 
+/**
+ * @brief Wrapper for reading managed static fields.
+ *
+ * Static fields live in class-level storage rather than on an instance, so
+ * they are accessed via il2cpp_field_static_get_value() instead of offsets.
+ */
 class IL2CppStaticFieldHelper
 {
 public:
@@ -135,6 +197,20 @@ private:
   FieldInfo*   fieldInfo;
 };
 
+/**
+ * @brief Central helper for IL2CPP class reflection operations.
+ *
+ * Wraps an Il2CppClass* and provides methods for:
+ *  - Allocating managed objects (New).
+ *  - Looking up methods by name and argument count, returning native function pointers.
+ *  - Virtual method resolution.
+ *  - Custom method searches with parameter-type filters (GetMethodSpecial).
+ *  - Property, field, and static field access (returns the corresponding helper).
+ *  - Parent class and nested type traversal.
+ *
+ * Most prime/ struct headers obtain one of these via il2cpp_get_class_helper()
+ * and cache it in a static local.
+ */
 class IL2CppClassHelper
 {
 public:
@@ -143,11 +219,20 @@ public:
     this->cls = cls;
   }
 
+  /**
+   * @brief Allocate a new managed object of this class.
+   * @tparam T Native type to cast the result to.
+   * @return Pointer to the newly allocated (uninitialized) managed object.
+   */
   template <typename T> T* New()
   {
     return (T*)il2cpp_object_new(this->cls);
   }
 
+  /**
+   * @brief Get the System.Type object for this class.
+   * @return Pointer to the managed System.Type (Il2CppReflectionType*).
+   */
   void* GetType()
   {
     auto obj = il2cpp_type_get_object(&this->cls->byval_arg);
@@ -163,6 +248,13 @@ public:
 #endif
   }
 
+  /**
+   * @brief Look up a method by name and optional argument count.
+   * @tparam T Cast the native function pointer to this type.
+   * @param name Method name in the C# class.
+   * @param arg_count Expected parameter count, or -1 to match any.
+   * @return Native function pointer, or nullptr if not found.
+   */
   template <typename T = void> T* GetMethod(const char* name, int arg_count = -1)
   {
     if (!this->cls) {
@@ -177,6 +269,15 @@ public:
     return nullptr;
   }
 
+  /**
+   * @brief Look up a method and resolve it through virtual dispatch.
+   * @tparam T Cast the native function pointer to this type.
+   * @param name Method name.
+   * @param arg_count Expected parameter count, or -1 to match any.
+   * @return Native function pointer to the virtual implementation.
+   * @note Uses `this` as the Il2CppObject for vtable lookup, which means
+   *       the IL2CppClassHelper instance itself must point at a valid object.
+   */
   template <typename T = void> T* GetVirtualMethod(const char* name, int arg_count = -1)
   {
     if (!this->cls) {
@@ -190,6 +291,15 @@ public:
     return (T*)get_method_virtual->methodPointer;
   }
 
+  /**
+   * @brief Helper for calling methods through il2cpp_runtime_invoke().
+   *
+   * Unlike the direct function-pointer approach, this goes through the
+   * managed invocation path, which handles boxing/unboxing and exceptions.
+   *
+   * @tparam R Return type (value type; will be unboxed).
+   * @tparam Args Parameter types.
+   */
   template <typename R, typename... Args> class InvokerMethod
   {
 
@@ -223,6 +333,16 @@ public:
     return InvokerMethod<R, Args...>(fn);
   }
 
+  /**
+   * @brief Find a method using a custom parameter-type filter, returning its MethodInfo.
+   *
+   * Iterates all methods on the class and applies @p arg_filter to let the
+   * caller disambiguate overloads by inspecting parameter Il2CppTypes.
+   *
+   * @param name Method name.
+   * @param arg_filter Predicate receiving (param_count, params[]). Return true to accept.
+   * @return The first matching MethodInfo*, or nullptr.
+   */
   const MethodInfo*
   GetMethodInfoSpecial(const char*                                                    name,
                        std::function<bool(int param_count, const Il2CppType** param)> arg_filter = nullptr)
@@ -243,6 +363,13 @@ public:
     return nullptr;
   }
 
+  /**
+   * @brief Like GetMethodInfoSpecial but returns a cast native function pointer.
+   * @tparam T Function pointer type to cast to.
+   * @param name Method name.
+   * @param arg_filter Optional predicate for parameter disambiguation.
+   * @return Native function pointer, or nullptr.
+   */
   template <typename T = void>
   T* GetMethodSpecial(const char*                                                    name,
                       std::function<bool(int param_count, const Il2CppType** param)> arg_filter = nullptr)
@@ -296,6 +423,11 @@ public:
     return IL2CppStaticFieldHelper{this->cls, il2cpp_class_get_field_from_name(this->cls, name)};
   }
 
+  /**
+   * @brief Walk the class hierarchy upward to find a parent class by name.
+   * @param name Simple class name to search for.
+   * @return Helper wrapping the parent class, or a null-class helper if not found.
+   */
   inline IL2CppClassHelper GetParent(const char* name)
   {
     Il2CppClass* pcls = this->cls;
@@ -311,6 +443,11 @@ public:
     return IL2CppClassHelper{nullptr};
   }
 
+  /**
+   * @brief Find a nested type (inner class) by name.
+   * @param name Simple name of the nested type.
+   * @return Helper wrapping the nested type, or a null-class helper if not found.
+   */
   inline IL2CppClassHelper GetNestedType(const char* name)
   {
     for (int i = 0; i < this->cls->nested_type_count; ++i) {
@@ -332,8 +469,22 @@ private:
   Il2CppClass* cls;
 };
 
+/**
+ * @brief Convenience macro that resolves to il2cpp_get_class_helper_impl().
+ */
 #define il2cpp_get_class_helper(assembly, namespacez, name) il2cpp_get_class_helper_impl(assembly, namespacez, name)
 
+/**
+ * @brief Resolve a managed class by assembly, namespace, and name.
+ *
+ * Opens the assembly image via the IL2CPP domain and looks up the class.
+ * The result is typically cached in a static local by each prime/ header.
+ *
+ * @param assembly  Assembly name (e.g. "Assembly-CSharp").
+ * @param namespacez C# namespace (e.g. "Digit.Client.Core").
+ * @param name      Simple class name (e.g. "Hub").
+ * @return IL2CppClassHelper wrapping the resolved Il2CppClass*.
+ */
 inline IL2CppClassHelper il2cpp_get_class_helper_impl(const char* assembly, const char* namespacez, const char* name)
 {
   auto domain    = il2cpp_domain_get();
@@ -345,14 +496,31 @@ inline IL2CppClassHelper il2cpp_get_class_helper_impl(const char* assembly, cons
   return IL2CppClassHelper{cls};
 }
 
+/**
+ * @brief Access an element of an Il2CppArray by index with a typed cast.
+ * @tparam T Element type.
+ * @param array Pointer to the managed array.
+ * @param index Zero-based element index.
+ * @return Pointer to the element cast to T*.
+ */
 template <typename T> inline T* il2cpp_get_array_element(Il2CppArray* array, size_t index)
 {
   Il2CppArraySize* n = (Il2CppArraySize*)(array);
   return (T*)n->vector[index];
 }
 
+/** @brief Global map of tracked managed object pointers, keyed by Il2CppClass*. */
 extern eastl::unordered_map<Il2CppClass*, eastl::vector<uintptr_t>> tracked_objects;
 
+/**
+ * @brief Look up live managed objects of a given type from the global tracked_objects map.
+ *
+ * The game's object-tracking hooks populate tracked_objects whenever a managed
+ * object of interest is constructed or destroyed. ObjectFinder provides typed
+ * access into that map.
+ *
+ * @tparam T A prime/ struct type that exposes a static get_class_helper() method.
+ */
 template <typename T> class ObjectFinder
 {
 public:
@@ -373,6 +541,12 @@ public:
   }
 };
 
+/**
+ * @brief Typed wrapper around il2cpp_resolve_icall() for internal calls.
+ * @tparam T Function pointer type.
+ * @param name Fully qualified internal call name (e.g. "UnityEngine.Screen::get_width").
+ * @return Native function pointer cast to T*, or nullptr if unresolved.
+ */
 template <typename T> T* il2cpp_resolve_icall_typed(const char* name)
 {
   return (T*)il2cpp_resolve_icall(name);

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -1,3 +1,12 @@
+/**
+ * @file battle_notify_parser.cc
+ * @brief Extracts battle participant names and ship hulls from combat toast data.
+ *
+ * Parses BattleResultHeader objects attached to combat-related Toast events.
+ * Uses SEH on Windows to guard against invalid IL2CPP pointers that can occur
+ * when game objects are collected mid-access. Resolves hull IDs to readable
+ * names via SpecService.
+ */
 #include "patches/battle_notify_parser.h"
 
 #include "str_utils.h"
@@ -18,9 +27,16 @@
 #include <windows.h>
 #endif
 
-// ---------------------------------------------------------------------------
-// SEH wrapper — catches access violations from bad IL2CPP pointers
-// ---------------------------------------------------------------------------
+// ─── SEH Safety Wrapper ───────────────────────────────────────────────────────────────
+
+/**
+ * @brief Execute a callable inside a Windows SEH __try/__except block.
+ *
+ * IL2CPP pointers may become invalid between frames due to GC. This wrapper
+ * catches access violations so a single bad pointer doesn't crash the mod.
+ *
+ * @return true if fn() completed without an SEH exception.
+ */
 template <typename Fn>
 static bool seh_call(Fn fn)
 {
@@ -37,10 +53,18 @@ static bool seh_call(Fn fn)
 #endif
 }
 
-// ---------------------------------------------------------------------------
-// Hull name key → human-readable name
-//   "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
-// ---------------------------------------------------------------------------
+// ─── Hull Name Parsing ───────────────────────────────────────────────────────────────
+
+/**
+ * @brief Convert an internal hull key string to a human-readable name.
+ *
+ * Strips the "Hull_" prefix and "_LIVE" suffix, replaces underscores with
+ * spaces, and converts level prefixes ("L30") to "Lv.30" format.
+ * Example: "Hull_L30_Destroyer_Klingon_LIVE" → "Lv.30 Destroyer Klingon"
+ *
+ * @param key Raw hull name key from HullSpec.
+ * @return Formatted display name.
+ */
 static std::string parse_hull_key(const std::string& key)
 {
   auto s = key;
@@ -64,9 +88,14 @@ static std::string parse_hull_key(const std::string& key)
   return s;
 }
 
-// ---------------------------------------------------------------------------
-// Resolve hull ID → display name via SpecService
-// ---------------------------------------------------------------------------
+// ─── Hull ID Resolution ──────────────────────────────────────────────────────────────
+
+/**
+ * @brief Resolve a hull ID to a display name via the game's SpecService.
+ * @param brh BattleResultHeader providing access to SpecService.
+ * @param hullId The numeric hull ID to look up.
+ * @return Parsed display name, or "Hull#<id>" if lookup fails.
+ */
 static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
 {
   if (hullId == 0) return "";
@@ -84,15 +113,16 @@ static std::string resolve_hull_name(BattleResultHeader* brh, long hullId)
   return fmt::format("Hull#{}", hullId);
 }
 
-// ---------------------------------------------------------------------------
-// Format "Name (Ship) vs Name (Ship)"
-// ---------------------------------------------------------------------------
+// ─── Battle Summary Formatting ───────────────────────────────────────────────────────
+
+/** Intermediate structure holding extracted battle participant data. */
 struct BattleSummaryData {
   std::string playerName;
   std::string enemyName;
   std::string playerShip;
   std::string enemyShip;
 
+  /** @brief Format the summary as "Player (Ship) vs Enemy (Ship)". */
   std::string format_body() const
   {
     auto format_side = [](const std::string& name, const std::string& ship) -> std::string {
@@ -110,9 +140,17 @@ struct BattleSummaryData {
   }
 };
 
-// ---------------------------------------------------------------------------
-// Extract player/enemy names + ship hulls from BattleResultHeader
-// ---------------------------------------------------------------------------
+// ─── BattleResultHeader Extraction ───────────────────────────────────────────────────
+
+/**
+ * @brief Extract player and enemy names + ship hull names from a BattleResultHeader.
+ *
+ * Each field extraction is wrapped in seh_call() to survive invalid pointers.
+ * Falls back to NPC LocaId formatting when player names are empty.
+ *
+ * @param data Raw Il2CppObject* from Toast::get_Data(), cast to BattleResultHeader.
+ * @return Populated BattleSummaryData (fields may be empty on failure).
+ */
 static BattleSummaryData build_battle_data(Il2CppObject* data)
 {
   BattleSummaryData result;
@@ -165,9 +203,7 @@ static BattleSummaryData build_battle_data(Il2CppObject* data)
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+// ─── Public API ──────────────────────────────────────────────────────────────────────
 std::string battle_notify_parse(Toast* toast)
 {
   auto state = toast->get_State();

--- a/mods/src/patches/battle_notify_parser.h
+++ b/mods/src/patches/battle_notify_parser.h
@@ -1,9 +1,24 @@
+/**
+ * @file battle_notify_parser.h
+ * @brief Extracts player/enemy names and ship hulls from battle toast data.
+ *
+ * Parses the BattleResultHeader attached to combat-related Toast objects to
+ * produce a "Player (Ship) vs Enemy (Ship)" summary string used in OS
+ * notifications. Uses SEH guards on Windows to survive bad IL2CPP pointers.
+ */
 #pragma once
 
 #include <string>
 
 struct Toast;
 
-// Attempt to build a detailed notification body from a battle toast's Data.
-// Returns empty string if the toast has no battle data or parsing fails.
+/**
+ * @brief Build a human-readable battle summary from a toast's attached data.
+ *
+ * Only processes combat-related toast states (Victory, Defeat, etc.).
+ * Returns an empty string for non-combat toasts or when parsing fails.
+ *
+ * @param toast The game Toast object to extract battle data from.
+ * @return Formatted "Name (Ship) vs Name (Ship)" string, or empty.
+ */
 std::string battle_notify_parse(Toast* toast);

--- a/mods/src/patches/cargo_display.cc
+++ b/mods/src/patches/cargo_display.cc
@@ -1,3 +1,11 @@
+/**
+ * @file cargo_display.cc
+ * @brief Automatic cargo/rewards panel display based on target type and config.
+ *
+ * Evaluates the selected target's fleet type (player, hostile, armada, station)
+ * against per-type config toggles to decide whether to auto-show the cargo
+ * rewards panel. Called from hook delegates in the hotkey router.
+ */
 #include "errormsg.h"
 #include "config.h"
 

--- a/mods/src/patches/cargo_display.h
+++ b/mods/src/patches/cargo_display.h
@@ -1,8 +1,31 @@
+/**
+ * @file cargo_display.h
+ * @brief Automatic cargo/rewards panel display based on target type and config.
+ *
+ * Decides whether to auto-show the cargo rewards panel when a target is
+ * selected, based on the fleet type (player, hostile, armada, station) and
+ * the user's per-type toggle settings.
+ */
 #pragma once
 
 class RewardsButtonWidget;
 struct PreScanTargetWidget;
 
+/**
+ * @brief Evaluate whether the cargo panel should auto-show for this widget's target.
+ * @param widget The RewardsButtonWidget whose context to check.
+ * @return true if config allows auto-display for this target type.
+ */
 bool CheckShowCargo(RewardsButtonWidget* widget);
+
+/**
+ * @brief Hook handler for RewardsButtonWidget::BindContext — auto-shows cargo if enabled.
+ * @param _this The hooked RewardsButtonWidget instance.
+ */
 void HandleCargoBindContext(RewardsButtonWidget* _this);
+
+/**
+ * @brief Hook handler for PreScanTargetWidget::ShowFleet — auto-shows cargo if enabled.
+ * @param _this The hooked PreScanTargetWidget instance.
+ */
 void HandleCargoShowFleet(PreScanTargetWidget* _this);

--- a/mods/src/patches/fleet_actions.cc
+++ b/mods/src/patches/fleet_actions.cc
@@ -1,3 +1,12 @@
+/**
+ * @file fleet_actions.cc
+ * @brief Ship selection, space actions, and fleet command execution.
+ *
+ * Implements the core fleet interaction logic: number-key ship selection with
+ * double-tap-to-locate, Shift+number tow-to-Discovery, and the contextual
+ * space action system that inspects visible object viewers to determine the
+ * correct action (engage, scan, mine, warp, join armada, queue, recall, repair).
+ */
 #include "errormsg.h"
 #include "config.h"
 
@@ -26,10 +35,12 @@
 #include <chrono>
 #include <span>
 
-// Shared state — written by ExecuteSpaceAction, read by router
+// ─── Ship Selection ───────────────────────────────────────────────────────────────────
+
+/** When true, the next frame will re-attempt the primary space action. */
 bool force_space_action_next_frame = false;
 
-// Ship selection double-tap timer
+/** Double-tap detection timer for ship selection. */
 static std::chrono::time_point<std::chrono::steady_clock> select_clock = std::chrono::steady_clock::now();
 
 // Returns true if the hook should return early (skip original)
@@ -88,12 +99,21 @@ bool HandleShipSelection(int ship_select_request)
   return false;
 }
 
-// ---------------------------------------------------------------------------
-// Fleet action helpers
-// ---------------------------------------------------------------------------
+// ─── Fleet Action Helpers ─────────────────────────────────────────────────────────────
 
 #define FleetAction_Format "Fleet {} ({}) #{} - State: {}, previous {} - canAction {}, canState {} - didAction: {}"
 
+/**
+ * @brief Generic fleet action executor — checks fleet state and requests an action.
+ *
+ * @tparam T Unused (originally intended for requirement checking; kept for signature compat).
+ * @param actionText Human-readable action name for trace logging.
+ * @param actionType The ActionType enum value to request.
+ * @param fleet_bar The active FleetBarViewController.
+ * @param wantedStates States in which the action is valid.
+ * @param helpState If set and fleet enters this state, re-request with AskHelp behavior.
+ * @return true if the action was successfully requested.
+ */
 template <typename T>
 inline bool DidExecuteFleetAction(std::string_view actionText, ActionType actionType, FleetBarViewController* fleet_bar,
                                   const std::span<const FleetState> wantedStates,
@@ -151,6 +171,8 @@ bool DidExecuteRepair(FleetBarViewController* fleet_bar)
   return DidExecuteFleetAction<CanRepairRequirement>("Repair", ActionType::Repair, fleet_bar, states,
                                                      FleetState::Repairing);
 }
+
+// ─── Space Action Execution ───────────────────────────────────────────────────────────
 
 void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
 {
@@ -320,6 +342,8 @@ void ExecuteSpaceAction(FleetBarViewController* fleet_bar)
     }
   }
 }
+
+// ─── Hull Type Resolution ─────────────────────────────────────────────────────────────
 
 HullType GetHullTypeFromBattleTarget(BattleTargetData* context)
 {

--- a/mods/src/patches/fleet_actions.h
+++ b/mods/src/patches/fleet_actions.h
@@ -1,3 +1,11 @@
+/**
+ * @file fleet_actions.h
+ * @brief Ship selection, space actions (engage/scan/recall/repair), and fleet management.
+ *
+ * Handles all hotkey-driven fleet interactions: selecting ships via number keys
+ * (with double-tap-to-locate), executing contextual space actions (engage,
+ * scan, mine, recall, repair, warp, queue), and Shift+number tow requests.
+ */
 #pragma once
 
 #include "prime/FleetBarViewController.h"
@@ -5,10 +13,48 @@
 
 struct BattleTargetData;
 
+/** When true, the next frame will re-attempt the primary space action (deferred engage). */
 extern bool force_space_action_next_frame;
 
+/**
+ * @brief Process a ship selection request from number keys 1-8.
+ *
+ * Handles Shift+number for tow-to-Discovery, plain number for select (with
+ * double-tap-to-locate within the configured timer window).
+ *
+ * @param ship_select_request 0-based ship index, or -1 if no selection key was pressed.
+ * @return true if the selection was handled (caller should skip original).
+ */
 bool     HandleShipSelection(int ship_select_request);
+
+/**
+ * @brief Execute the contextual space action for the currently selected fleet.
+ *
+ * Inspects visible object viewers and pre-scan widgets to determine the
+ * correct action: engage, scan, mine, warp, join armada, add-to-queue, recall,
+ * or repair. Supports deferred actions via force_space_action_next_frame.
+ *
+ * @param fleet_bar The active FleetBarViewController.
+ */
 void     ExecuteSpaceAction(FleetBarViewController* fleet_bar);
+
+/**
+ * @brief Attempt to recall the currently selected fleet.
+ * @param fleet_bar The active FleetBarViewController.
+ * @return true if recall was successfully requested.
+ */
 bool     DidExecuteRecall(FleetBarViewController* fleet_bar);
+
+/**
+ * @brief Attempt to repair the currently selected fleet.
+ * @param fleet_bar The active FleetBarViewController.
+ * @return true if repair was successfully requested.
+ */
 bool     DidExecuteRepair(FleetBarViewController* fleet_bar);
+
+/**
+ * @brief Extract the HullType from a BattleTargetData context.
+ * @param context The battle target data (may be null).
+ * @return The target's hull type, or HullType::Any if context is null/incomplete.
+ */
 HullType GetHullTypeFromBattleTarget(BattleTargetData* context);

--- a/mods/src/patches/gamefunctions.h
+++ b/mods/src/patches/gamefunctions.h
@@ -1,13 +1,26 @@
+/**
+ * @file gamefunctions.h
+ * @brief Enum of all bindable game functions for the keyboard mapping system.
+ *
+ * Each value corresponds to a configurable action that can be bound to one or
+ * more key combinations in the TOML settings file. MapKey maintains an array
+ * of bindings indexed by these values.
+ */
 #pragma once
 
 enum GameFunction {
+  // ─── Navigation ──────────────────────────────────────────────────────────
   MoveLeft,
   MoveRight,
   MoveUp,
   MoveDown,
+
+  // ─── Chat Channel Selection ──────────────────────────────────────────────
   SelectChatAlliance,
   SelectChatGlobal,
   SelectChatPrivate,
+
+  // ─── Ship Selection ──────────────────────────────────────────────────────
   SelectShip1,
   SelectShip2,
   SelectShip3,
@@ -16,7 +29,9 @@ enum GameFunction {
   SelectShip6,
   SelectShip7,
   SelectShip8,
-  SelectCurrent,
+  SelectCurrent,              ///< Re-select the currently active ship.
+
+  // ─── UI Panel Toggles ───────────────────────────────────────────────────
   ShowAlliance,
   ShowAllianceArmada,
   ShowAllianceHelp,
@@ -24,13 +39,13 @@ enum GameFunction {
   ShowOfficers,
   ShowCommander,
   ShowRefinery,
-  ShowQTrials,
+  ShowQTrials,                ///< Q's Trials event panel.
   ShowBookmarks,
-  ShowLookup,
+  ShowLookup,                 ///< System / player search panel.
   ShowExoComp,
   ShowFactions,
   ShowGifts,
-  ShowDaily,
+  ShowDaily,                  ///< Daily goals / login rewards.
   ShowAwayTeam,
   ShowMissions,
   ShowResearch,
@@ -38,14 +53,18 @@ enum GameFunction {
   ShowShips,
   ShowInventory,
   ShowStationInterior,
-  ShoWStationExterior,
-  ShowGalaxy,
-  ShowSystem,
+  ShoWStationExterior,        ///< Note: typo preserved from original enum.
+  ShowGalaxy,                 ///< Switch to galaxy map view.
+  ShowSystem,                 ///< Switch to system view.
+
+  // ─── Chat & Side Panels ─────────────────────────────────────────────────
   ShowChat,
-  ShowChatSide1,
-  ShowChatSide2,
+  ShowChatSide1,              ///< First side-panel chat slot.
+  ShowChatSide2,              ///< Second side-panel chat slot.
   ShowEvents,
   ShowSettings,
+
+  // ─── Zoom ────────────────────────────────────────────────────────────────
   ZoomPreset1,
   ZoomPreset2,
   ZoomPreset3,
@@ -53,43 +72,59 @@ enum GameFunction {
   ZoomPreset5,
   ZoomIn,
   ZoomOut,
-  ZoomMin,
-  ZoomMax,
+  ZoomMin,                    ///< Zoom all the way out.
+  ZoomMax,                    ///< Zoom all the way in.
   ZoomReset,
+
+  // ─── UI Scaling ──────────────────────────────────────────────────────────
   UiScaleUp,
   UiScaleDown,
-  UiViewerScaleUp,
+  UiViewerScaleUp,            ///< Object viewer panel scale.
   UiViewerScaleDown,
-  ActionPrimary,
-  ActionSecondary,
-  ActionQueue,
-  ActionQueueClear,
-  ActionView,
+
+  // ─── Ship Actions ────────────────────────────────────────────────────────
+  ActionPrimary,              ///< Context-dependent primary action (e.g. warp, mine).
+  ActionSecondary,            ///< Context-dependent secondary action.
+  ActionQueue,                ///< Queue the next action.
+  ActionQueueClear,           ///< Clear the entire action queue.
+  ActionView,                 ///< Open the object viewer for the selected target.
   ActionRecall,
   ActionRecallCancel,
   ActionRepair,
+
+  // ─── Zoom Preset Assignment ──────────────────────────────────────────────
   SetZoomPreset1,
   SetZoomPreset2,
   SetZoomPreset3,
   SetZoomPreset4,
   SetZoomPreset5,
   SetZoomDefault,
-  DisableHotKeys,
-  EnableHotKeys,
-  ToggleQueue,
-  TogglePreviewLocate,
-  TogglePreviewRecall,
+
+  // ─── Hotkey System Control ───────────────────────────────────────────────
+  DisableHotKeys,             ///< Temporarily disable all keyboard shortcuts.
+  EnableHotKeys,              ///< Re-enable keyboard shortcuts.
+
+  // ─── Toggles ─────────────────────────────────────────────────────────────
+  ToggleQueue,                ///< Toggle action queue display.
+  TogglePreviewLocate,        ///< Toggle locate preview on map.
+  TogglePreviewRecall,        ///< Toggle recall preview on map.
+
+  // ─── Cargo Filter Toggles ───────────────────────────────────────────────
   ToggleCargoDefault,
   ToggleCargoPlayer,
   ToggleCargoStation,
   ToggleCargoHostile,
   ToggleCargoArmada,
+
+  // ─── Log Level ───────────────────────────────────────────────────────────
   LogLevelDebug,
   LogLevelInfo,
   LogLevelTrace,
   LogLevelError,
   LogLevelWarn,
   LogLevelOff,
+
+  // ─── Application ─────────────────────────────────────────────────────────
   Quit,
 
   // Automatic max value

--- a/mods/src/patches/hotkey_dispatch.cc
+++ b/mods/src/patches/hotkey_dispatch.cc
@@ -1,3 +1,12 @@
+/**
+ * @file hotkey_dispatch.cc
+ * @brief Static dispatch table and handler implementations for all table-driven hotkeys.
+ *
+ * Each handler is a small static function that performs one action (navigate to
+ * a section, toggle a config flag, change log level, etc.) and returns a
+ * DispatchDecision telling the router whether to suppress the original method.
+ * The table at the bottom maps GameFunction values to these handlers.
+ */
 #include "patches/hotkey_dispatch.h"
 #include "patches/navigation.h"
 
@@ -9,9 +18,9 @@
 
 #include <spdlog/spdlog.h>
 
-// ---------------------------------------------------------------------------
-// Section navigation handlers
-// ---------------------------------------------------------------------------
+// ─── Section Navigation Handlers ────────────────────────────────────────────────────────────
+// Each handler navigates to a specific game section and suppresses the original
+// method call (HandledStop), since the section change is the complete action.
 
 static DispatchDecision HandleShowQTrials()
 {
@@ -168,9 +177,9 @@ static DispatchDecision HandleShowSettings()
   return DispatchDecision::HandledStop;
 }
 
-// ---------------------------------------------------------------------------
-// UI scale handlers (use IsPressed for repeat-while-held)
-// ---------------------------------------------------------------------------
+// ─── UI Scale Handlers ────────────────────────────────────────────────────────────────
+// Use InputMode::Pressed for repeat-while-held behavior. Return
+// HandledAllowOriginal so the game's own update cycle still runs.
 
 static DispatchDecision HandleUiScaleUp()
 {
@@ -196,9 +205,9 @@ static DispatchDecision HandleUiViewerScaleDown()
   return DispatchDecision::HandledAllowOriginal;
 }
 
-// ---------------------------------------------------------------------------
-// Config toggle handlers
-// ---------------------------------------------------------------------------
+// ─── Config Toggle Handlers ────────────────────────────────────────────────────────────
+// Toggle boolean config flags in-place. All return HandledAllowOriginal
+// so the game still processes the frame normally.
 
 static DispatchDecision HandleTogglePreviewLocate()
 {
@@ -242,9 +251,8 @@ static DispatchDecision HandleToggleCargoArmada()
   return DispatchDecision::HandledAllowOriginal;
 }
 
-// ---------------------------------------------------------------------------
-// Log level handlers
-// ---------------------------------------------------------------------------
+// ─── Log Level Handlers ───────────────────────────────────────────────────────────────
+// Change spdlog level and flush-on threshold at runtime for live debugging.
 
 static DispatchDecision HandleLogLevelOff()
 {
@@ -288,9 +296,8 @@ static DispatchDecision HandleLogLevelTrace()
   return DispatchDecision::HandledAllowOriginal;
 }
 
-// ---------------------------------------------------------------------------
-// Ship management handler
-// ---------------------------------------------------------------------------
+// ─── Ship Management Handler ──────────────────────────────────────────────────────────
+// Opens the ship management screen for the currently selected fleet.
 
 static DispatchDecision HandleShowShips()
 {
@@ -305,9 +312,9 @@ static DispatchDecision HandleShowShips()
   return DispatchDecision::HandledAllowOriginal;
 }
 
-// ---------------------------------------------------------------------------
-// Dispatch table
-// ---------------------------------------------------------------------------
+// ─── Dispatch Table ──────────────────────────────────────────────────────────────────
+// The router iterates this table each frame and invokes the first matching
+// handler. Entries default to InputMode::Down unless overridden.
 
 static constexpr HotkeyEntry g_dispatch_table[] = {
     // Section navigation

--- a/mods/src/patches/hotkey_dispatch.h
+++ b/mods/src/patches/hotkey_dispatch.h
@@ -1,24 +1,37 @@
+/**
+ * @file hotkey_dispatch.h
+ * @brief Data-driven hotkey dispatch table mapping GameFunctions to handlers.
+ *
+ * Defines the dispatch table consumed by the hotkey router. Each entry binds a
+ * GameFunction enum value to a handler callback and an input mode (single-press
+ * vs. repeat-while-held). The router iterates the table on every frame and
+ * invokes the first matching handler.
+ */
 #pragma once
 
 #include <patches/gamefunctions.h>
 
 #include <span>
 
+/** Outcome returned by a dispatch handler to control post-handler flow. */
 enum class DispatchDecision {
-  NoMatch,              // handler didn't match / didn't act
-  HandledStop,          // handler acted, do NOT call original
-  HandledAllowOriginal  // handler acted, still call original
+  NoMatch,              ///< Handler didn't match or didn't act.
+  HandledStop,          ///< Handler acted; suppress the original method call.
+  HandledAllowOriginal  ///< Handler acted; still call the original method.
 };
 
+/** How the router samples key state for a dispatch entry. */
 enum class InputMode {
-  Down,     // MapKey::IsDown — single trigger on key press
-  Pressed   // MapKey::IsPressed — repeats while held
+  Down,     ///< MapKey::IsDown — fires once on initial key press.
+  Pressed   ///< MapKey::IsPressed — fires every frame while held.
 };
 
+/** A single row in the hotkey dispatch table. */
 struct HotkeyEntry {
-  GameFunction    game_function;
-  DispatchDecision (*handler)();
-  InputMode       input_mode = InputMode::Down;
+  GameFunction    game_function;          ///< The bound game function / key binding.
+  DispatchDecision (*handler)();          ///< Callback invoked when the key is active.
+  InputMode       input_mode = InputMode::Down; ///< Sampling mode (single-press vs. held).
 };
 
+/** @brief Returns the global dispatch table (static constexpr array). */
 std::span<const HotkeyEntry> GetHotkeyDispatchTable();

--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -1,3 +1,12 @@
+/**
+ * @file hotkey_router.cc
+ * @brief Central hotkey routing logic — called every frame from ScreenManager::Update hook.
+ *
+ * This is the main keyboard input processing loop for the community patch.
+ * It handles enable/disable toggling, ship selection, escape behavior, chat
+ * channel shortcuts, space actions (engage/scan/mine/recall/repair), the
+ * table-driven dispatch system, and the configurable double-tap escape exit.
+ */
 #include "errormsg.h"
 #include "config.h"
 
@@ -27,6 +36,8 @@
 
 #include <spdlog/spdlog.h>
 #include <chrono>
+
+// ─── Main Per-Frame Hotkey Router ─────────────────────────────────────────────────────
 
 // Returns true when the original ScreenManager::Update should be called.
 bool hotkey_router_screen_update(ScreenManager* _this)
@@ -60,7 +71,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   }
 #endif
 
-  // --- Ship selection (1-8 keys) ---
+  // ─── Ship selection (1-8 keys) ───────────────────────────────────────────────────────
   int32_t ship_select_request = -1;
   if (MapKey::IsDown(GameFunction::SelectShip1)) {
     ship_select_request = 0;
@@ -84,7 +95,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
     return false;
   }
 
-  // --- Escape in chat / input focus ---
+  // ─── Escape in chat / input focus ───────────────────────────────────────────────────
   if (Key::Pressed(KeyCode::Escape) && (Key::IsInputFocused() || Hub::IsInChat())) {
     Key::ClearInputFocus();
     return false;
@@ -161,7 +172,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
       }
     }
   } else {
-    // In-chat channel selection
+    // ─── In-chat channel selection ─────────────────────────────────────────────────────
     if (auto chat_manager = ChatManager::Instance(); chat_manager) {
       if (MapKey::IsDown(GameFunction::SelectChatGlobal)) {
         chat_manager->OpenChannel(ChatChannelCategory::Global);
@@ -215,6 +226,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
     TickInfoPending();
   }
 
+  // ─── Configurable double-tap Escape exit ───────────────────────────────────────────
   // Suppress escape exit if configured
   if (config->disable_escape_exit && Key::Pressed(KeyCode::Escape)) {
     static std::chrono::time_point<std::chrono::steady_clock> escape_clock = {};
@@ -229,6 +241,8 @@ bool hotkey_router_screen_update(ScreenManager* _this)
 
   return true;
 }
+
+// ─── Hook Delegate Functions ─────────────────────────────────────────────────────────
 
 bool hotkey_router_init_actions()
 {

--- a/mods/src/patches/hotkey_router.h
+++ b/mods/src/patches/hotkey_router.h
@@ -1,13 +1,39 @@
+/**
+ * @file hotkey_router.h
+ * @brief Layer-2 hotkey router — bridges IL2CPP hook entry points to concern handlers.
+ *
+ * The router sits between the raw spud hooks (which intercept IL2CPP methods)
+ * and the individual feature modules (navigation, fleet actions, cargo, viewers).
+ * Each function here is called from exactly one hook and fans out to the
+ * appropriate subsystem based on key state, UI context, and config flags.
+ */
 #pragma once
 
 struct ScreenManager;
 class RewardsButtonWidget;
 struct PreScanTargetWidget;
 
-// Layer 2 — routes hook entry points to concern handlers.
-// Returns true when the hook should call original(), false to suppress.
-
+/**
+ * @brief Main per-frame hotkey processing, called from the ScreenManager::Update hook.
+ * @param _this The hooked ScreenManager instance.
+ * @return true if the original ScreenManager::Update should still execute.
+ */
 bool  hotkey_router_screen_update(ScreenManager* _this);
+
+/**
+ * @brief Called from the InitializeActions hook.
+ * @return true to let the original InitializeActions run (Scopely hotkeys or fallthrough).
+ */
 bool  hotkey_router_init_actions();
+
+/**
+ * @brief Called from RewardsButtonWidget::BindContext hook to auto-show cargo panels.
+ * @param _this The hooked RewardsButtonWidget instance.
+ */
 void  hotkey_router_bind_context(RewardsButtonWidget* _this);
+
+/**
+ * @brief Called from PreScanTargetWidget::ShowFleet hook to auto-show cargo panels.
+ * @param _this The hooked PreScanTargetWidget instance.
+ */
 void  hotkey_router_show_fleet(PreScanTargetWidget* _this);

--- a/mods/src/patches/key.cc
+++ b/mods/src/patches/key.cc
@@ -1,3 +1,11 @@
+/**
+ * @file key.cc
+ * @brief Implementation of per-frame key state caching and key name parsing.
+ *
+ * All engine queries (GetKeyInt / GetKeyDownInt) are resolved once via
+ * il2cpp_resolve_icall and cached per-frame in tri-state arrays so repeat
+ * queries within the same frame are effectively free.
+ */
 #include "key.h"
 #include "prime/EventSystem.h"
 #include "str_utils.h"
@@ -12,6 +20,10 @@ int Key::cacheInputModified = 0;
 
 std::array<int, (int)KeyCode::Max> Key::cacheKeyPressed = {};
 std::array<int, (int)KeyCode::Max> Key::cacheKeyDown    = {};
+
+// ─── Name → KeyCode Lookup Table ─────────────────────────────────────────────
+// Maps user-facing key name strings (from TOML config) to Unity KeyCode values.
+// All names are compared after upper-casing the input (see Parse()).
 
 const std::unordered_map<std::string, KeyCode> Key::mappedKeys = {
     {"LALT", KeyCode::LeftAlt},
@@ -161,6 +173,8 @@ const std::unordered_map<std::string, KeyCode> Key::mappedKeys = {
     {"KEYPLUS", KeyCode::KeypadPlus},
 };
 
+// ─── Parsing & Classification ────────────────────────────────────────────────
+
 KeyCode Key::Parse(std::string_view key)
 {
   auto wantedKey = AsciiStrToUpper(key);
@@ -208,6 +222,8 @@ bool Key::IsModified()
   return cacheInputModified == 1;
 }
 
+// ─── Per-frame Cache Management ──────────────────────────────────────────────
+
 void Key::ResetCache()
 {
   Key::cacheInputFocused  = 0;
@@ -217,6 +233,8 @@ void Key::ResetCache()
     Key::cacheKeyPressed[i] = 0;
   }
 }
+// ─── Engine Key Queries (cached) ─────────────────────────────────────────────
+
 bool Key::Down(KeyCode key)
 {
   static auto GetKeyDownInt =
@@ -241,6 +259,8 @@ bool Key::Pressed(KeyCode key)
   return cacheKeyPressed[(int)key] == 1;
 }
 
+// ─── Input Focus Detection ───────────────────────────────────────────────────
+
 bool Key::IsInputFocused()
 {
   if (cacheInputFocused == 0) {
@@ -263,6 +283,8 @@ bool Key::IsInputFocused()
 
   return cacheInputFocused == 1;
 }
+
+// ─── Convenience Modifier Helpers ────────────────────────────────────────────
 
 bool Key::HasShift()
 {

--- a/mods/src/patches/key.h
+++ b/mods/src/patches/key.h
@@ -1,3 +1,15 @@
+/**
+ * @file key.h
+ * @brief Low-level key state tracking with per-frame caching.
+ *
+ * Key is the foundation of the input system. It wraps Unity's Input::GetKey
+ * and Input::GetKeyDown icalls behind a per-frame cache so each physical key
+ * is queried from the engine at most once per update. Higher layers (MapKey,
+ * ModifierKey) build on Key to implement configurable key bindings.
+ *
+ * @see MapKey   — maps cached key states to game functions.
+ * @see ModifierKey — groups left/right variants of Shift, Alt, Ctrl, etc.
+ */
 #pragma once
 
 #include <prime/KeyCode.h>
@@ -9,27 +21,52 @@
 class Key
 {
 private:
+  /// Lookup table from user-facing key name strings to Unity KeyCode values.
   static const std::unordered_map<std::string, KeyCode> mappedKeys;
 
-  static int cacheInputFocused;
-  static int cacheInputModified;
+  // ─── Per-frame Cache ─────────────────────────────────────────────────────
+  // Values use a tri-state int: 0 = unchecked, 1 = true, -1 = false.
+  // ResetCache() zeroes everything at the start of each frame.
 
-  static std::array<int, (int)KeyCode::Max> cacheKeyPressed;
-  static std::array<int, (int)KeyCode::Max> cacheKeyDown;
+  static int cacheInputFocused;  ///< Whether a TMP_InputField currently has focus.
+  static int cacheInputModified; ///< Whether any modifier key is held this frame.
+
+  static std::array<int, (int)KeyCode::Max> cacheKeyPressed; ///< Tri-state cache for GetKey (held).
+  static std::array<int, (int)KeyCode::Max> cacheKeyDown;    ///< Tri-state cache for GetKeyDown (just pressed).
 
 public:
+  /// Deselects the currently focused TMP_InputField, if any.
   static void    ClearInputFocus();
+
+  /// Resets all per-frame caches. Must be called once at the start of each update.
   static void    ResetCache();
+
+  /**
+   * @brief Converts a user-facing key name (e.g. "LSHIFT", "A") to a KeyCode.
+   * @param key  Case-insensitive key name from the config file.
+   * @return Matching KeyCode, or KeyCode::None if unrecognised.
+   */
   static KeyCode Parse(std::string_view key);
 
+  /// Returns true while the key is held down (cached GetKey).
   static bool Pressed(KeyCode key);
+
+  /// Returns true on the frame the key was first pressed (cached GetKeyDown).
   static bool Down(KeyCode key);
 
+  /// Returns true if @p key is any modifier (Shift, Ctrl, Alt, Cmd, Win).
   static bool IsModifier(KeyCode key);
 
+  /// Returns true if any modifier key is currently held.
   static bool IsModified();
+
+  /// Returns true if a TMP_InputField has keyboard focus (suppress hotkeys).
   static bool IsInputFocused();
+
+  /// @name Convenience modifier checks
+  /// @{
   static bool HasShift();
   static bool HasAlt();
   static bool HasCtrl();
+  /// @}
 };

--- a/mods/src/patches/mapkey.cc
+++ b/mods/src/patches/mapkey.cc
@@ -1,3 +1,7 @@
+/**
+ * @file mapkey.cc
+ * @brief Implementation of key-combo parsing, binding storage, and press detection.
+ */
 #include "mapkey.h"
 #include "gamefunctions.h"
 #include "modifierkey.h"
@@ -15,6 +19,8 @@ MapKey::MapKey()
   this->Key          = KeyCode::None;
   this->hasModifiers = false;
 }
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
 
 MapKey MapKey::Parse(std::string_view key)
 {
@@ -52,6 +58,8 @@ MapKey MapKey::Parse(std::string_view key)
   return *mapKey;
 }
 
+// ─── Shortcut Display ────────────────────────────────────────────────────────
+
 std::string MapKey::GetShortcuts(GameFunction gameFunction)
 {
   const auto &mapKeys = MapKey::mappedKeys[gameFunction];
@@ -70,10 +78,14 @@ std::string MapKey::GetShortcuts(GameFunction gameFunction)
   return shortcuts;
 }
 
+// ─── Binding Registration ────────────────────────────────────────────────────
+
 void MapKey::AddMappedKey(GameFunction gameFunction, MapKey mappedKey)
 {
   MapKey::mappedKeys[gameFunction].emplace_back(mappedKey);
 }
+
+// ─── Press Detection ────────────────────────────────────────────────────────
 
 bool MapKey::IsPressed(GameFunction gameFunction)
 {
@@ -106,6 +118,8 @@ bool MapKey::IsDown(GameFunction gameFunction)
 
   return false;
 }
+
+// ─── Modifier Validation ─────────────────────────────────────────────────────
 
 bool MapKey::HasCorrectModifiers(MapKey mapKey)
 {
@@ -146,6 +160,8 @@ std::string MapKey::GetParsedValues() const
 
   return output;
 }
+
+// ─── Static Storage ──────────────────────────────────────────────────────────
 
 std::array<std::vector<MapKey>, (int)GameFunction::Max> MapKey::mappedKeys = {};
 

--- a/mods/src/patches/mapkey.h
+++ b/mods/src/patches/mapkey.h
@@ -1,3 +1,18 @@
+/**
+ * @file mapkey.h
+ * @brief Maps physical key combinations to game functions.
+ *
+ * MapKey is the binding layer between raw input (Key) and game actions
+ * (GameFunction). Each MapKey holds one primary KeyCode plus zero or more
+ * ModifierKeys. The static side maintains an array of bindings per
+ * GameFunction, populated at startup from the TOML config, and exposes
+ * IsPressed / IsDown queries used by the patch hooks.
+ *
+ * Config syntax example: "CTRL-SHIFT-A" → ModifierKey(CTRL) + ModifierKey(SHIFT) + Key(A).
+ *
+ * @see Key         — low-level cached key queries.
+ * @see ModifierKey — left/right modifier grouping.
+ */
 #pragma once
 
 #include "modifierkey.h"
@@ -13,23 +28,42 @@ class MapKey
 public:
   MapKey();
 
+  /**
+   * @brief Parses a hyphen-delimited key string (e.g. "CTRL-A") into a MapKey.
+   * @param key  Key combo string from TOML config (case-insensitive).
+   * @return Parsed MapKey with Key and Modifiers populated.
+   */
   static MapKey Parse(std::string_view key);
+
+  /// Registers a parsed MapKey for the given game function.
   static void   AddMappedKey(GameFunction gameFunction, MapKey mappedKey);
+
+  /// Returns true if any binding for @p gameFunction is held this frame (with correct modifiers).
   static bool   IsPressed(GameFunction gameFunction);
+
+  /// Returns true on the frame any binding for @p gameFunction was first pressed.
   static bool   IsDown(GameFunction gameFunction);
+
+  /// Validates that exactly the required modifiers are held (and no extras).
   static bool   HasCorrectModifiers(MapKey mapKey);
 
+  /**
+   * @brief Builds a display string of all shortcuts for a game function.
+   * @return Pipe-separated shortcut list, e.g. "CTRL-A | F5".
+   */
   static std::string GetShortcuts(GameFunction gameFunction);
 
+  /// Returns this binding's shortcut string (e.g. "CTRL-A").
   std::string GetParsedValues() const;
 
-  std::vector<ModifierKey> Modifiers;
-  std::vector<std::string> Shortcuts;
+  std::vector<ModifierKey> Modifiers; ///< Modifier groups required for this binding.
+  std::vector<std::string> Shortcuts; ///< Individual segments of the parsed key string.
 
-  KeyCode Key;
+  KeyCode Key; ///< The primary (non-modifier) key.
 
 private:
+  /// All registered bindings, indexed by GameFunction ordinal.
   static std::array<std::vector<MapKey>, (int)GameFunction::Max> mappedKeys;
 
-  bool hasModifiers;
+  bool hasModifiers; ///< True if this binding requires at least one modifier.
 };

--- a/mods/src/patches/modifierkey.cc
+++ b/mods/src/patches/modifierkey.cc
@@ -1,3 +1,7 @@
+/**
+ * @file modifierkey.cc
+ * @brief Implementation of modifier key grouping and press detection.
+ */
 #include "config.h"
 #include "str_utils.h"
 #include "key.h"
@@ -19,6 +23,8 @@ ModifierKey::ModifierKey()
 {
   this->hasModifier = false;
 }
+
+// ─── Parsing ─────────────────────────────────────────────────────────────────
 
 ModifierKey ModifierKey::Parse(std::string_view key)
 {
@@ -52,6 +58,8 @@ ModifierKey ModifierKey::Parse(std::string_view key)
   return modifierKey;
 }
 
+// ─── Membership & Registration ───────────────────────────────────────────────
+
 bool ModifierKey::Contains(KeyCode modifier)
 {
   if (this->hasModifier) {
@@ -75,6 +83,8 @@ void ModifierKey::AddModifier(std::string_view shortcut, KeyCode modifier1, KeyC
     this->Shortcuts.emplace_back(shortcut);
   }
 }
+
+// ─── Press Detection ────────────────────────────────────────────────────────
 
 bool ModifierKey::IsPressed()
 {

--- a/mods/src/patches/modifierkey.h
+++ b/mods/src/patches/modifierkey.h
@@ -1,3 +1,16 @@
+/**
+ * @file modifierkey.h
+ * @brief Groups left/right physical modifier keys under a single logical name.
+ *
+ * When the user writes "SHIFT-A" in a key binding, ModifierKey::Parse creates
+ * a group containing both LeftShift and RightShift so that either physical key
+ * satisfies the modifier. Generic names ("SHIFT", "ALT", "CTRL", "CMD", "WIN",
+ * "APPLE") expand to both sides; specific names ("LSHIFT", "RCTRL") resolve to
+ * a single physical key via Key::Parse.
+ *
+ * @see Key    — raw per-frame key state cache.
+ * @see MapKey — composes ModifierKeys with a primary key into a full binding.
+ */
 #pragma once
 
 
@@ -14,18 +27,38 @@ struct ModifierKey
 public:
   ModifierKey();
 
+  /**
+   * @brief Parses a modifier name (e.g. "SHIFT", "LCTRL") into a ModifierKey.
+   * @param key  Modifier string segment, case-insensitive.
+   * @return ModifierKey with matching KeyCodes, or empty if not a modifier.
+   */
   static ModifierKey Parse(std::string_view key);
 
+  /**
+   * @brief Adds a left/right key pair under a single shortcut label.
+   * @param shortcut  Display name for the modifier (e.g. "SHIFT").
+   * @param modifier1 Primary physical key (e.g. LeftShift).
+   * @param modifier2 Secondary physical key (e.g. RightShift), or KeyCode::None.
+   */
   void AddModifier(std::string_view shortcut, KeyCode modifier1, KeyCode modifier2);
+
+  /// Returns true if @p modifier is already in this group.
   bool Contains(KeyCode modifier);
+
+  /// Returns true if any key in this modifier group is currently held.
   bool IsPressed();
+
+  /// Returns true on the frame any key in this group was first pressed.
   bool IsDown();
+
+  /// Returns true if at least one modifier KeyCode has been added.
   bool HasModifiers();
 
+  /// Returns the display string for this modifier group (e.g. "SHIFT").
   std::string GetParsedValues();
 
 private:
-  std::vector<KeyCode>     Modifiers;
-  std::vector<std::string> Shortcuts;
+  std::vector<KeyCode>     Modifiers; ///< Physical KeyCodes in this group.
+  std::vector<std::string> Shortcuts; ///< Display labels for each added modifier.
   bool                     hasModifier;
 };

--- a/mods/src/patches/navigation.cc
+++ b/mods/src/patches/navigation.cc
@@ -1,3 +1,10 @@
+/**
+ * @file navigation.cc
+ * @brief Section navigation helpers for hotkey-driven screen transitions.
+ *
+ * Wraps Hub::get_SectionManager() and NavigationSectionManager to provide
+ * simple section-change functions used by the dispatch table handlers.
+ */
 #include "errormsg.h"
 #include "config.h"
 

--- a/mods/src/patches/navigation.h
+++ b/mods/src/patches/navigation.h
@@ -1,7 +1,34 @@
+/**
+ * @file navigation.h
+ * @brief Section navigation helpers for hotkey-driven screen transitions.
+ *
+ * Wraps the game's SectionManager and NavigationSectionManager APIs to provide
+ * simple functions for navigating to any game section from a hotkey handler.
+ */
 #pragma once
 
 enum class SectionID : int;
 
+/**
+ * @brief Navigate directly to a game section by triggering a section change.
+ * @param sectionID Target section to navigate to.
+ * @param screen_data Optional opaque data passed to the section (default: nullptr).
+ */
 void GotoSection(SectionID sectionID, void* screen_data = nullptr);
+
+/**
+ * @brief Navigate to a navigation-layer section (Galaxy/System views).
+ *
+ * Attempts to restore persisted section state first; falls back to
+ * NavigationSectionManager::ChangeNavigationSection if no saved state exists.
+ *
+ * @param sectionID Target navigation section.
+ */
 void ChangeNavigationSection(SectionID sectionID);
+
+/**
+ * @brief Attempt to scroll the officer showcase canvas left or right.
+ * @param goLeft true to move left, false to move right.
+ * @return true if the canvas was moved (currently always returns false — stub).
+ */
 bool MoveOfficerCanvas(bool goLeft);

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -1,3 +1,11 @@
+/**
+ * @file notification_service.cc
+ * @brief OS-native notification delivery for in-game toast events.
+ *
+ * Resolves IL2CPP LanguageManager::Localize at init time, maps toast states
+ * to human-readable titles, strips Unity rich text tags from body text, and
+ * delivers Windows toast notifications via WinRT for configured toast types.
+ */
 #include "patches/notification_service.h"
 #include "patches/battle_notify_parser.h"
 
@@ -19,14 +27,18 @@
 #include <winrt/Windows.UI.Notifications.h>
 #endif
 
-// ---------------------------------------------------------------------------
-// IL2CPP method cache
-// ---------------------------------------------------------------------------
+// ─── IL2CPP Method Cache ──────────────────────────────────────────────────────────────
+
+/** Cached LanguageManager::Localize(out string, LocaleTextContext) method pointer. */
 static const MethodInfo* s_localize_ltc = nullptr;
 
-// ---------------------------------------------------------------------------
-// Toast state → human-readable title
-// ---------------------------------------------------------------------------
+// ─── Toast State → Human-Readable Title ───────────────────────────────────────────────
+
+/**
+ * @brief Map a numeric toast state to a notification title string.
+ * @param state The Toast::State enum value.
+ * @return Static title string, or nullptr for unmapped states.
+ */
 static const char* toast_state_title(int state)
 {
   switch (state) {
@@ -73,9 +85,7 @@ static const char* toast_state_title(int state)
   }
 }
 
-// ---------------------------------------------------------------------------
-// Platform notification delivery
-// ---------------------------------------------------------------------------
+// ─── Platform Notification Delivery ──────────────────────────────────────────────────
 #if _WIN32
 static void show_system_notification(const char* title, const char* body)
 {
@@ -99,9 +109,17 @@ static void show_system_notification(const char* title, const char* body)
 }
 #endif
 
-// ---------------------------------------------------------------------------
-// Resolve basic localized text from a Toast's TextLocaleTextContext
-// ---------------------------------------------------------------------------
+// ─── Toast Text Resolution ───────────────────────────────────────────────────────────
+
+/**
+ * @brief Resolve the localized body text from a Toast's TextLocaleTextContext.
+ *
+ * Invokes the cached LanguageManager::Localize method via il2cpp_runtime_invoke
+ * to produce a localized string from the toast's LTC data.
+ *
+ * @param toast The Toast to extract text from.
+ * @return Localized text string, or empty on failure.
+ */
 static std::string resolve_toast_text(Toast* toast)
 {
   if (!s_localize_ltc) return {};
@@ -121,9 +139,11 @@ static std::string resolve_toast_text(Toast* toast)
   return to_string(resolved);
 }
 
-// ---------------------------------------------------------------------------
-// Strip Unity rich text tags (e.g. <color=#FF0000>, <b>, </size>)
-// ---------------------------------------------------------------------------
+/**
+ * @brief Strip Unity rich text tags (e.g. \<color=#FF0000\>, \<b\>, \</size\>).
+ * @param s Input string potentially containing Unity markup.
+ * @return Clean string with all angle-bracket tags removed.
+ */
 static std::string strip_unity_rich_text(const std::string& s)
 {
   std::string result;
@@ -139,9 +159,7 @@ static std::string strip_unity_rich_text(const std::string& s)
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Public API
-// ---------------------------------------------------------------------------
+// ─── Public API ──────────────────────────────────────────────────────────────────────
 
 void notification_init()
 {

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -1,10 +1,32 @@
+/**
+ * @file notification_service.h
+ * @brief OS-native notification delivery for in-game toast events.
+ *
+ * Bridges the game's Toast system to platform notification APIs (Windows toast
+ * notifications via WinRT). Resolves IL2CPP LanguageManager methods at init
+ * time to localize toast text, then formats and delivers notifications for
+ * user-configured toast types.
+ */
 #pragma once
 
 struct Toast;
 
-// Initialize the notification service (resolve IL2CPP methods, init platform).
-// Call once during InstallToastBannerHooks().
+/**
+ * @brief One-time initialization: resolve IL2CPP methods and init the platform.
+ *
+ * Must be called once during InstallToastBannerHooks(). Resolves
+ * LanguageManager::Localize(out string, LocaleTextContext) for text
+ * localization and initializes WinRT on Windows.
+ */
 void notification_init();
 
-// Called from toast hooks — checks config, formats, and delivers notification.
+/**
+ * @brief Process a game toast for potential OS notification delivery.
+ *
+ * Checks the toast state against the user's configured notify_banner_types,
+ * builds a human-readable body (battle data or localized text), and delivers
+ * an OS-native notification if the toast type matches.
+ *
+ * @param toast The game Toast object from the hooked banner display method.
+ */
 void notification_handle_toast(Toast* toast);

--- a/mods/src/patches/parts/buff_fixes.cc
+++ b/mods/src/patches/parts/buff_fixes.cc
@@ -1,3 +1,13 @@
+/**
+ * @file buff_fixes.cc
+ * @brief Corrects buff condition evaluation for out-of-dock power display.
+ *
+ * The game's BuffService checks various conditions to decide which buffs apply.
+ * One condition (CondSelfAtStation) incorrectly gates certain power calculations,
+ * causing displayed power to differ from actual combat power when undocked.
+ * This patch forces that condition to return false so buff totals reflect
+ * true out-of-dock strength.
+ */
 #include "config.h"
 #include "errormsg.h"
 #include "prime_types.h"
@@ -8,6 +18,16 @@
 
 #include <spud/detour.h>
 
+/**
+ * @brief Hook: BuffService::IsBuffConditionMet
+ *
+ * Intercepts buff condition checks to fix out-of-dock power display.
+ * Original method: evaluates whether a buff condition is satisfied for the
+ *   current game state (e.g. "is the player docked at a station?").
+ * Our modification: forces CondSelfAtStation to always return false, so buffs
+ *   that would only apply when docked are excluded from power calculations,
+ *   giving an accurate undocked power reading.
+ */
 static bool BuffService_IsBuffConditionMet(auto original, void* _this, BuffCondition currentCondition,
                                            IBuffComparer *buffComparer, IBuffData *buffToCompare,
                                            bool excludeFactionBuffs, bool isAllianceLoyalty)
@@ -23,6 +43,12 @@ static bool BuffService_IsBuffConditionMet(auto original, void* _this, BuffCondi
   return original(_this, currentCondition, buffComparer, buffToCompare, excludeFactionBuffs, isAllianceLoyalty);
 }
 
+/**
+ * @brief Installs the buff condition fix hook.
+ *
+ * Only active when `use_out_of_dock_power` is enabled in config.
+ * Hooks BuffService::IsBuffConditionMet to correct power display.
+ */
 void InstallBuffFixHooks()
 {
   if (Config::Get().use_out_of_dock_power) {

--- a/mods/src/patches/parts/chat.cc
+++ b/mods/src/patches/parts/chat.cc
@@ -1,3 +1,18 @@
+/**
+ * @file chat.cc
+ * @brief Chat UI patches — disables galaxy and/or veil chat channels.
+ *
+ * The game has multiple chat channels (Cadet, Galaxy, Veil/Regional, Alliance).
+ * This patch lets users disable Galaxy and/or Veil chat by:
+ *   - Greying out the corresponding tab buttons in full-screen chat.
+ *   - Blocking tab selection for disabled channels.
+ *   - Redirecting the chat preview panel to Alliance chat.
+ *   - Suppressing incoming message callbacks for disabled channels.
+ *
+ * Tab indices are dynamic because Cadet and Veil tabs may or may not exist
+ * depending on the player's account state, so GetChatTabIndices() computes
+ * them at runtime.
+ */
 #include "prime/ChatPreviewController.h"
 #include "prime/FullScreenChatViewController.h"
 #include "prime/GenericButtonContext.h"
@@ -8,6 +23,10 @@
 #include <spud/detour.h>
 #include <tuple>
 
+/**
+ * @brief Computes dynamic chat tab indices based on the player's visible channels.
+ * @return Tuple of (cadetIdx, galaxyIdx, veilIdx, allianceIdx); -1 means absent.
+ */
 auto GetChatTabIndices()
 {
   if (const auto chat_manager = ChatManager::Instance(); chat_manager) {
@@ -24,6 +43,7 @@ auto GetChatTabIndices()
   return std::make_tuple(-1, 0, -1, 1);
 }
 
+/// Disables interactability on tab buttons for channels the user has turned off.
 void DisableButtons(FullScreenChatViewController* _this)
 {
   const auto disableGalaxyChat = Config::Get().disable_galaxy_chat;
@@ -68,12 +88,27 @@ void DisableButtons(FullScreenChatViewController* _this)
   }
 }
 
+/**
+ * @brief Hook: FullScreenChatViewController::AboutToShow
+ *
+ * Intercepts the full-screen chat open to disable tab buttons.
+ * Original method: prepares the chat UI for display.
+ * Our modification: after calling original, greys out Galaxy/Veil tabs.
+ */
 void FullScreenChatViewController_AboutToShow(auto original, FullScreenChatViewController* _this)
 {
   original(_this);
   DisableButtons(_this);
 }
 
+/**
+ * @brief Hook: FullScreenChatViewController::OnDidChangeSelectedTab
+ *
+ * Intercepts tab selection to block switching to disabled channels.
+ * Original method: switches the chat view to the selected tab.
+ * Our modification: if the selected tab is a disabled channel, silently
+ *   drops the event so the user stays on the previous tab.
+ */
 void FullScreenChatViewController_OnDidChangeSelectedTab(auto original, FullScreenChatViewController* _this, int32_t tabIdx, void* tab)
 {
   const auto [cadetChatIdx, galaxyChatIdx, veilChatIdx, allianceChatIdx] = GetChatTabIndices();
@@ -85,6 +120,14 @@ void FullScreenChatViewController_OnDidChangeSelectedTab(auto original, FullScre
   original(_this, tabIdx, tab);
 }
 
+/**
+ * @brief Hook: ChatPreviewController::AboutToShow
+ *
+ * Intercepts the chat preview panel open to redirect away from disabled channels.
+ * Original method: initializes the chat preview and shows the default channel.
+ * Our modification: forces focus to Alliance chat when Galaxy/Veil is disabled,
+ *   using FocusOnInstantly to snap without animation.
+ */
 void ChatPreviewController_AboutToShow(auto original, ChatPreviewController* _this)
 {
   original(_this);
@@ -99,6 +142,14 @@ void ChatPreviewController_AboutToShow(auto original, ChatPreviewController* _th
   }
 }
 
+/**
+ * @brief Hook: ChatPreviewController::OnPanelFocused
+ *
+ * Intercepts panel-focus events to prevent swiping to disabled channels.
+ * Original method: handles a swipe/focus change to a new chat panel.
+ * Our modification: redirects focus to Alliance chat if the target panel
+ *   is a disabled channel, snapping the scroller instantly.
+ */
 void ChatPreviewController_OnPanelFocused(auto original, ChatPreviewController* _this, int32_t index)
 {
   static const auto disableGalaxyChat = Config::Get().disable_galaxy_chat;
@@ -124,6 +175,13 @@ void ChatPreviewController_OnPanelFocused(auto original, ChatPreviewController* 
   original(_this, index);
 }
 
+/**
+ * @brief Hook: ChatPreviewController::OnGlobalMessageReceived
+ *
+ * Suppresses Galaxy chat message callbacks when Galaxy chat is disabled.
+ * Original method: processes an incoming Galaxy (global) chat message.
+ * Our modification: returns immediately if disable_galaxy_chat is set.
+ */
 void ChatPreviewController_OnGlobalMessageReceived(auto original, ChatPreviewController* _this, void* message)
 {
   if (Config::Get().disable_galaxy_chat)
@@ -132,6 +190,13 @@ void ChatPreviewController_OnGlobalMessageReceived(auto original, ChatPreviewCon
   original(_this, message);
 }
 
+/**
+ * @brief Hook: ChatPreviewController::OnRegionalMessageReceived
+ *
+ * Suppresses Veil chat message callbacks when Veil chat is disabled.
+ * Original method: processes an incoming Veil (regional) chat message.
+ * Our modification: returns immediately if disable_veil_chat is set.
+ */
 void ChatPreviewController_OnRegionalMessageReceived(auto original, ChatPreviewController* _this, void* message)
 {
   if (Config::Get().disable_veil_chat)
@@ -140,6 +205,16 @@ void ChatPreviewController_OnRegionalMessageReceived(auto original, ChatPreviewC
   original(_this, message);
 }
 
+// ─── Hook Installation ─────────────────────────────────────────────────────────
+
+/**
+ * @brief Installs all chat-related hooks.
+ *
+ * Hooks two controllers:
+ *   - FullScreenChatViewController: AboutToShow (disable tabs), OnDidChangeSelectedTab (block selection)
+ *   - ChatPreviewController: AboutToShow (redirect focus), OnPanelFocused (block swipe),
+ *     OnGlobalMessageReceived (suppress Galaxy), OnRegionalMessageReceived (suppress Veil)
+ */
 void InstallChatPatches()
 {
   if (auto fullscreen_controller =

--- a/mods/src/patches/parts/disable_banners.cc
+++ b/mods/src/patches/parts/disable_banners.cc
@@ -1,3 +1,12 @@
+/**
+ * @file disable_banners.cc
+ * @brief Filters in-game toast/banner notifications by type.
+ *
+ * The game displays pop-up "toast" banners for various events (rewards, offers,
+ * alliance activity, etc.). This patch intercepts the toast queue and drops any
+ * banner whose state matches the user's configured disabled_banner_types list.
+ * Toasts are also forwarded to the notification service for optional logging.
+ */
 #include "config.h"
 #include "errormsg.h"
 #include "patches/notification_service.h"
@@ -10,6 +19,14 @@
 struct ToastObserver {
 };
 
+/**
+ * @brief Hook: ToastObserver::EnqueueToast
+ *
+ * Intercepts single toast enqueue to filter unwanted banner types.
+ * Original method: adds a toast to the display queue unconditionally.
+ * Our modification: forwards the toast to the notification service, then
+ *   drops it silently if its state is in the user's disabled list.
+ */
 void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast *toast)
 {
   notification_handle_toast(toast);
@@ -22,6 +39,13 @@ void ToastObserver_EnqueueToast_Hook(auto original, ToastObserver *_this, Toast 
   original(_this, toast);
 }
 
+/**
+ * @brief Hook: ToastObserver::EnqueueOrCombineToast
+ *
+ * Intercepts the combine-or-enqueue path with the same filtering logic.
+ * Original method: merges a toast with an existing one or enqueues it.
+ * Our modification: same filter as EnqueueToast — drop if banner type disabled.
+ */
 void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_this, Toast *toast, uintptr_t cmpAction)
 {
   notification_handle_toast(toast);
@@ -34,6 +58,12 @@ void ToastObserver_EnqueueOrCombineToast_Hook(auto original, ToastObserver *_thi
   original(_this, toast, cmpAction);
 }
 
+/**
+ * @brief Installs toast/banner filtering hooks.
+ *
+ * Initializes the notification service and hooks both ToastObserver enqueue
+ * paths so banners can be selectively suppressed.
+ */
 void InstallToastBannerHooks()
 {
   notification_init();

--- a/mods/src/patches/parts/fix_pan.cc
+++ b/mods/src/patches/parts/fix_pan.cc
@@ -1,3 +1,13 @@
+/**
+ * @file fix_pan.cc
+ * @brief Fixes system-view camera panning and adds momentum falloff.
+ *
+ * The game's navigation pan has two issues this patch addresses:
+ * 1. Touch input that reports "Stationary" phase is ignored, causing jittery
+ *    panning — we reclassify it as "Moved" so the gesture stays smooth.
+ * 2. After releasing a pan, the camera stops abruptly. We add configurable
+ *    momentum falloff so the camera glides to a stop.
+ */
 #include "config.h"
 #include "errormsg.h"
 
@@ -8,6 +18,14 @@
 
 #include <spud/detour.h>
 
+/**
+ * @brief Hook: TKTouch::populateWithPosition
+ *
+ * Intercepts touch input population to fix jittery panning.
+ * Original method: populates a TKTouch struct with position and phase.
+ * Our modification: converts Stationary phase to Moved so the pan gesture
+ *   doesn't stall when the finger/cursor barely moves.
+ */
 TKTouch *TKTouch_populateWithPosition_Hook(auto original, TKTouch *_this, uintptr_t pos, TouchPhase phase)
 {
   auto r = original(_this, pos, phase);
@@ -17,6 +35,16 @@ TKTouch *TKTouch_populateWithPosition_Hook(auto original, TKTouch *_this, uintpt
   return r;
 }
 
+/**
+ * @brief Hook: NavigationPan::LateUpdate
+ *
+ * Intercepts the per-frame pan update to add momentum-based camera glide.
+ * Original method: processes pan input each frame and moves the camera.
+ * Our modification: when no touch/mouse input is active and the camera isn't
+ *   blocked or tracking a POI, applies a configurable falloff multiplier to
+ *   the last pan delta so the camera decelerates smoothly. Also locks the
+ *   extended far-zoom radius to the normal value.
+ */
 bool NavigationPan_LateUpdate_Hook(auto original, NavigationPan *_this)
 {
   auto d = _this->_lastDelta;
@@ -42,6 +70,12 @@ bool NavigationPan_LateUpdate_Hook(auto original, NavigationPan *_this)
   return true;
 }
 
+/**
+ * @brief Installs pan-fix and momentum hooks.
+ *
+ * Hooks TKTouch::populateWithPosition (Stationary → Moved fix) and
+ * NavigationPan::LateUpdate (momentum falloff).
+ */
 void InstallPanHooks()
 {
   if (auto touchHelper = il2cpp_get_class_helper("TouchKit", "", "TKTouch"); !touchHelper.isValidHelper()) {

--- a/mods/src/patches/parts/free_resize.cc
+++ b/mods/src/patches/parts/free_resize.cc
@@ -1,3 +1,15 @@
+/**
+ * @file free_resize.cc
+ * @brief Windows-only: enables free window resizing and borderless fullscreen (F11).
+ *
+ * The game ships as a fixed-size or pop-up window on Windows. This patch:
+ *   - Intercepts SetWindowLongW to replace the window style with WS_OVERLAPPEDWINDOW,
+ *     giving the user standard resize handles, minimize, and maximize buttons.
+ *   - Optionally installs a WndProc sub-class that toggles borderless fullscreen on F11.
+ *   - Hooks AspectRatioConstraintHandler to bypass Unity's aspect-ratio enforcement
+ *     and fix resolution detection when going fullscreen.
+ *   - Sets a custom window title from the user's config file.
+ */
 #if _WIN32
 #include <Windows.h>
 
@@ -11,6 +23,8 @@
 #include "prime/IList.h"
 #include "windowtitle.h"
 
+// ─── Globals ───────────────────────────────────────────────────────────────────
+
 static bool            WndProcInstalled  = false;
 static LONG_PTR        oWndProc          = NULL;
 static WINDOWPLACEMENT g_wpPrev          = {sizeof(g_wpPrev)};
@@ -18,6 +32,9 @@ LONG                   oldWindowStandard = 0;
 LONG                   oldWindowExtended = 0;
 HWND                   unityWindow       = nullptr;
 
+// ─── Borderless Fullscreen Toggle ───────────────────────────────────────────
+
+/// Toggles between borderless fullscreen and the previous windowed placement.
 void ToggleFullscreen(HWND hWnd)
 {
   // Get window styles
@@ -55,6 +72,7 @@ void ToggleFullscreen(HWND hWnd)
   }
 }
 
+/// WndProc sub-class that intercepts F11 for borderless fullscreen toggle.
 LRESULT __stdcall WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) // WndProc wrapper
 {
   switch (uMsg) {
@@ -67,7 +85,18 @@ LRESULT __stdcall WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) //
   return CallWindowProcW((WNDPROC)oWndProc, hWnd, uMsg, wParam, lParam);
 }
 
+// ─── Window Style Hook ────────────────────────────────────────────────────────
+
 decltype(SetWindowLongW)* oSetWindowLong = nullptr;
+/**
+ * @brief Hook: SetWindowLongW (Win32 API)
+ *
+ * Intercepts window style changes to inject free-resize and borderless support.
+ * Original behavior: Unity calls SetWindowLongW to set the game window style.
+ * Our modification: when the target is GWL_STYLE on the Unity window class,
+ *   replaces the style with WS_OVERLAPPEDWINDOW (if free_resize is enabled)
+ *   and installs the F11 WndProc sub-class (if borderless_fullscreen is enabled).
+ */
 LONG                      SetWindowLongW_Hook(_In_ HWND hWnd, _In_ int nIndex, _In_ LONG dwNewLong)
 {
   if (nIndex == GWL_STYLE) {
@@ -92,6 +121,8 @@ LONG                      SetWindowLongW_Hook(_In_ HWND hWnd, _In_ int nIndex, _
   return SetWindowLong(hWnd, nIndex, dwNewLong);
 }
 
+// ─── Aspect Ratio & Resolution Hooks ────────────────────────────────────────
+
 struct Resolution {
   int m_Width;
   int m_Height;
@@ -105,6 +136,16 @@ struct ResolutionArray {
   Resolution   data[1];
 };
 
+/**
+ * @brief Hook: AspectRatioConstraintHandler::Update
+ *
+ * Intercepts per-frame aspect-ratio enforcement.
+ * Original method: constrains the viewport to a fixed aspect ratio.
+ * Our modification: bypasses the original entirely. Instead, detects when
+ *   Unity reports 1024×768 while the monitor is larger (a common init quirk)
+ *   and forces the resolution to match the monitor. Also applies the user's
+ *   custom window title on the first call.
+ */
 void AspectRatioConstraintHandler_Update(auto original, void* _this)
 {
   static auto set_title       = true;
@@ -151,6 +192,14 @@ void AspectRatioConstraintHandler_Update(auto original, void* _this)
   // SetResolution(1920, 1080, 4, 60);
 }
 
+/**
+ * @brief Hook: AspectRatioConstraintHandler::WndProc
+ *
+ * Intercepts the game's custom WndProc for aspect-ratio messages.
+ * Original method: filters WM_SIZE/WM_MOVE to enforce aspect ratio.
+ * Our modification: when free_resize is enabled, bypasses the filter
+ *   and forwards messages directly to Unity's original WndProc.
+ */
 intptr_t AspectRatioConstraintHandler_WndProc(auto original, HWND hWnd, uint32_t msg, intptr_t wParam, intptr_t lParam)
 {
   if (Config::Get().free_resize) {
@@ -159,6 +208,13 @@ intptr_t AspectRatioConstraintHandler_WndProc(auto original, HWND hWnd, uint32_t
   return original(hWnd, msg, wParam, lParam);
 }
 
+/**
+ * @brief Installs window resize and aspect-ratio bypass hooks.
+ *
+ * Hooks AspectRatioConstraintHandler::Update (resolution fix + title) and
+ * AspectRatioConstraintHandler::WndProc (bypass aspect enforcement).
+ * Note: SetWindowLongW is hooked separately at a lower level by the proxy DLL.
+ */
 void InstallFreeResizeHooks()
 {
   auto AspectRatioConstraintHandler_helper =

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -1,3 +1,13 @@
+/**
+ * @file hotkeys.cc
+ * @brief Thin SPUD hook layer for keyboard shortcut processing.
+ *
+ * This file installs game-method detours that delegate all actual input
+ * handling to the hotkey_router (hotkey_router.h / hotkey_router.cc).
+ * Each hook is intentionally minimal — it captures the call, forwards
+ * context to the router, and invokes the original method.
+ */
+
 #include "config.h"
 
 #include <spud/detour.h>
@@ -8,10 +18,16 @@
 #include "prime/PreScanTargetWidget.h"
 #include "prime/ScreenManager.h"
 
-// ---------------------------------------------------------------------------
-// Layer 1 — thin SPUD hooks that delegate to the router
-// ---------------------------------------------------------------------------
+// ─── SPUD Hook Delegates ─────────────────────────────────────────────────────
 
+/**
+ * @brief Hook: ScreenManager::Update
+ *
+ * Intercepts the per-frame UI update to process keyboard shortcuts.
+ * Original method: drives UI state machine each frame.
+ * Our modification: calls hotkey_router_screen_update() before the
+ * original; the router may consume the frame (return false → skip original).
+ */
 void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
 {
   if (hotkey_router_screen_update(_this)) {
@@ -19,6 +35,14 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
   }
 }
 
+/**
+ * @brief Hook: ShortcutsManager::InitializeActions
+ *
+ * Intercepts the game's shortcut initialization to let the router
+ * register its own action bindings first.
+ * Original method: populates the game's default shortcut map.
+ * Our modification: router may suppress original initialization.
+ */
 void InitializeActions_Hook(auto original, void* _this)
 {
   if (hotkey_router_init_actions()) {
@@ -26,19 +50,45 @@ void InitializeActions_Hook(auto original, void* _this)
   }
 }
 
+/**
+ * @brief Hook: RewardsButtonWidget::OnDidBindContext
+ *
+ * Intercepts the combat-rewards UI binding to let the router
+ * capture the widget reference for hotkey-driven reward collection.
+ * Original method: binds data context to the rewards button.
+ * Our modification: notifies the router after binding completes.
+ */
 void OnDidBindContext_Hook(auto original, RewardsButtonWidget* _this)
 {
   original(_this);
   hotkey_router_bind_context(_this);
 }
 
+/**
+ * @brief Hook: PreScanTargetWidget::ShowWithFleet
+ *
+ * Intercepts the pre-scan target overlay to let the router
+ * capture fleet data for hotkey-driven scan actions.
+ * Original method: displays the pre-scan UI for a fleet.
+ * Our modification: notifies the router after the widget is shown.
+ */
 void ShowWithFleet_Hook(auto original, PreScanTargetWidget* _this, void* a1)
 {
   original(_this, a1);
   hotkey_router_show_fleet(_this);
 }
 
-// Manual hook (not SPUD) — stays thin by nature
+// ─── Manual (Non-SPUD) Hook ─────────────────────────────────────────────────
+
+/**
+ * @brief Hook: ChatMessageListLocalViewController::AboutToShow
+ *
+ * Intercepts chat panel display to auto-focus the input field.
+ * This is a manual trampoline hook (not SPUD) because the class
+ * requires a different hooking approach.
+ * Original method: prepares the chat message list for display.
+ * Our modification: sends focus to the input field after show.
+ */
 void ChatMessageListLocalViewController_AboutToShow_Hook(ChatMessageListLocalViewController* _this);
 decltype(ChatMessageListLocalViewController_AboutToShow_Hook)* oChatMessageListLocalViewController_AboutToShow =
     nullptr;
@@ -50,10 +100,9 @@ void ChatMessageListLocalViewController_AboutToShow_Hook(ChatMessageListLocalVie
   }
 }
 
-// ---------------------------------------------------------------------------
-// Hook installation
-// ---------------------------------------------------------------------------
+// ─── Hook Installation ──────────────────────────────────────────────────────
 
+/** @brief Resolves IL2CPP class/method pointers and installs all hotkey hooks. */
 void InstallHotkeyHooks()
 {
   auto shortcuts_manager_helper =

--- a/mods/src/patches/parts/improve_responsiveness.cc
+++ b/mods/src/patches/parts/improve_responsiveness.cc
@@ -1,3 +1,12 @@
+/**
+ * @file improve_responsiveness.cc
+ * @brief Reduces screen-transition blur duration for snappier UI.
+ *
+ * The game plays a blur animation during scene transitions (e.g. opening menus).
+ * The default duration feels sluggish. This patch overrides the blur time in
+ * TransitionManager::Awake with a user-configurable value, clamped to a safe
+ * range to avoid visual glitches.
+ */
 #include "config.h"
 #include "errormsg.h"
 #include "prime/TransitionManager.h"
@@ -7,6 +16,14 @@
 #include <spdlog/spdlog.h>
 #include <spud/detour.h>
 
+/**
+ * @brief Hook: TransitionManager::Awake
+ *
+ * Intercepts transition manager initialization to override blur duration.
+ * Original method: initializes the TransitionManager and its blur controller.
+ * Our modification: after calling original, overwrites _blurTime with the
+ *   user's configured transition_time (clamped to [0.02, 1.0] seconds).
+ */
 int64_t TransitionManager_Awake(auto original, TransitionManager* a1)
 {
   spdlog::debug("Adjusting screen transitions to {}", Config::Get().transition_time);
@@ -15,11 +32,25 @@ int64_t TransitionManager_Awake(auto original, TransitionManager* a1)
   return r;
 }
 
+/**
+ * @brief Hook: TransitionManager::OnEnable
+ *
+ * Intercepts OnEnable to suppress additional transition re-init.
+ * Original method: performs setup when the TransitionManager becomes active.
+ * Our modification: returns immediately (no-op) to prevent the manager from
+ *   resetting blur state after Awake already configured it.
+ */
 int64_t TransitionManager_OnEnable(auto original, TransitionManager* a1)
 {
   return 0;
 }
 
+/**
+ * @brief Installs the screen-transition speed hook.
+ *
+ * Hooks TransitionManager::Awake to apply the user's transition_time setting.
+ * Note: OnEnable hook is defined but not installed here (unused).
+ */
 void InstallImproveResponsivenessHooks()
 {
   auto transition_manager_helper =

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -1,3 +1,16 @@
+/**
+ * @file misc.cc
+ * @brief Miscellaneous quality-of-life patches and crash fixes.
+ *
+ * A collection of independent patches that don't warrant their own file:
+ *   - Donation slider extension (raise the 50-item cap)
+ *   - Bundle cooldown bypass (click through to info view while on cooldown)
+ *   - Resolution list cleanup (deduplicate and normalize refresh rates)
+ *   - Buff extraction null-guard (prevent crash on null list entries)
+ *   - Shop reveal sequence skip
+ *   - First interstitial popup dismissal
+ *   - Action queue logging (diagnostic, currently disabled)
+ */
 #include "config.h"
 #include "errormsg.h"
 
@@ -20,6 +33,17 @@
 #include <prime/ActionQueueManager.h>
 #include <prime/InterstitialViewController.h>
 
+// ─── Donation Slider Extension ───────────────────────────────────────────────
+
+/**
+ * @brief Hook: InventoryForPopup::set_MaxItemsToUse
+ *
+ * Intercepts the donation slider cap to allow larger donations.
+ * Original method: sets the maximum slider value (hard-coded to 50 for donations).
+ * Our modification: when extend_donation_slider is enabled and the caller is a
+ *   donation popup with cap == 50, replaces it with the user's configured max
+ *   (or returns -1 for unlimited if max <= 0).
+ */
 int64_t InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, int64_t a2)
 {
   if (a1->IsDonationUse && a2 == 50 && Config::Get().extend_donation_slider) {
@@ -35,6 +59,16 @@ int64_t InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1
   return standard;
 }
 
+// ─── Bundle Cooldown Bypass ──────────────────────────────────────────────────
+
+/**
+ * @brief Hook: BundleDataWidget::OnActionButtonPressedCallback
+ *
+ * Intercepts shop bundle button presses to allow interaction during cooldown.
+ * Original method: triggers the bundle's primary action (purchase flow).
+ * Our modification: if the bundle is on cooldown, redirects to the auxiliary
+ *   info view instead of blocking the press entirely.
+ */
 void BundleDataWidget_OnActionButtonPressedCallback(auto original, BundleDataWidget* _this)
 {
   if (_this->CurrentState & BundleDataWidget::ItemState::CooldownTimerOn) {
@@ -44,6 +78,12 @@ void BundleDataWidget_OnActionButtonPressedCallback(auto original, BundleDataWid
   }
 }
 
+/**
+ * @brief Installs donation slider and bundle cooldown patches.
+ *
+ * Hooks InventoryForPopup::set_MaxItemsToUse (Windows only) and
+ * BundleDataWidget::OnActionButtonPressedCallback.
+ */
 void InstallMiscPatches()
 {
 #if _WIN32
@@ -72,6 +112,8 @@ void InstallMiscPatches()
   }
 }
 
+// ─── Resolution List Fix ─────────────────────────────────────────────────────
+
 struct Resolution {
   int m_Width;
   int m_Height;
@@ -90,6 +132,16 @@ struct ResolutionArray {
   Resolution   data[1];
 };
 
+/**
+ * @brief Hook: UnityEngine.Screen::get_resolutions
+ *
+ * Intercepts the resolution list to clean up duplicates and normalize refresh rates.
+ * Original method: returns the raw array of supported screen resolutions.
+ * Our modification: on Windows, finds the maximum refresh rate for the native
+ *   resolution and (if show_all_resolutions is set) normalizes all entries to
+ *   that rate, then deduplicates. This prevents the settings menu from showing
+ *   the same resolution multiple times at different refresh rates.
+ */
 ResolutionArray* GetResolutions_Hook(auto original)
 {
   auto resolutions = original();
@@ -131,6 +183,11 @@ ResolutionArray* GetResolutions_Hook(auto original)
   return resolutions;
 }
 
+/**
+ * @brief Installs the resolution list cleanup hook.
+ *
+ * Hooks UnityEngine.Screen::get_resolutions via IL2CPP icall resolution.
+ */
 void InstallResolutionListFix()
 {
   auto get_resolutions = il2cpp_resolve_icall_typed<ResolutionArray*()>("UnityEngine.Screen::get_resolutions()");
@@ -141,6 +198,17 @@ void InstallResolutionListFix()
   }
 }
 
+// ─── Crash Fixes & Misc Hooks ────────────────────────────────────────────────
+
+/**
+ * @brief Hook: BuffService::ExtractBuffsOfType
+ *
+ * Null-guard for buff list extraction to prevent crashes.
+ * Original method: filters a buff list by modifier type.
+ * Our modification: checks each list element for null before passing to
+ *   original; returns nullptr early if any entry is null (avoids a crash
+ *   deep in the buff processing pipeline).
+ */
 IList* ExtractBuffsOfType_Hook(auto original, ClientModifierType modifier, IList* list)
 {
   if (list) {
@@ -154,6 +222,14 @@ IList* ExtractBuffsOfType_Hook(auto original, ClientModifierType modifier, IList
   return original(modifier, list);
 }
 
+/**
+ * @brief Hook: ShopSceneManager::ShouldShowRevealSequence
+ *
+ * Optionally skips the chest-opening reveal animation.
+ * Original method: decides whether to play the reveal sequence.
+ * Our modification: if always_skip_reveal_sequence is set, returns false
+ *   regardless of the original result.
+ */
 bool ShouldShowRevealHook(auto original, void* _this, bool ignore)
 {
   auto result = original(_this, ignore);
@@ -162,6 +238,8 @@ bool ShouldShowRevealHook(auto original, void* _this, bool ignore)
   }
   return result;
 }
+
+// ─── IL2CPP Property Wrappers ────────────────────────────────────────────────
 
 struct ShopCategory {
 public:
@@ -250,6 +328,14 @@ public:
   }
 };
 
+/**
+ * @brief Hook: InterstitialViewController::AboutToShow
+ *
+ * Intercepts the first interstitial popup to auto-dismiss it.
+ * Original method: displays the interstitial (typically a promo offer).
+ * Our modification: if disable_first_popup is set and this is the first
+ *   interstitial since launch, calls CloseWhenReady() instead of showing it.
+ */
 bool isFirstInterstitial = true;
 
 void InterstitialViewController_AboutToShow(auto original, InterstitialViewController* _this)
@@ -262,6 +348,7 @@ void InterstitialViewController_AboutToShow(auto original, InterstitialViewContr
   }
 }
 
+/// Diagnostic hook for action queue logging (currently commented out in install).
 void ActionQueueManager_AddActionToQueue(auto original, ActionQueueManager* _this, long fleet_id)
 {
   spdlog::warn("ActionQueueManager_AddActionToQueue({})", fleet_id);
@@ -270,6 +357,15 @@ void ActionQueueManager_AddActionToQueue(auto original, ActionQueueManager* _thi
 
 //   const auto section_data = Hub::get_SectionManager()->_sectionStorage->GetState(sectionID);
 
+/**
+ * @brief Installs crash-fix and QoL hooks.
+ *
+ * Hooks:
+ *   - BuffService::ExtractBuffsOfType (null-guard crash fix)
+ *   - ShopSceneManager::ShouldShowRevealSequence (skip reveal animation)
+ *   - InterstitialViewController::AboutToShow (dismiss first popup)
+ *   - ActionQueueManager::AddActionToQueue (diagnostic, currently disabled)
+ */
 void InstallTempCrashFixes()
 {
   auto BuffService_helper =

--- a/mods/src/patches/parts/object_tracker.cc
+++ b/mods/src/patches/parts/object_tracker.cc
@@ -1,3 +1,23 @@
+/**
+ * @file object_tracker.cc
+ * @brief IL2CPP object lifecycle tracker — prevents premature GC of game objects.
+ *
+ * The game's IL2CPP garbage collector can finalize objects that the mod still
+ * holds references to (e.g. ObjectViewer widgets, FleetBarViewController).
+ * This module hooks object construction, destruction, and GC liveness
+ * calculation to maintain a parallel tracking map keyed by IL2CppClass.
+ *
+ * Architecture:
+ *  - track_ctor: hooks .ctor to register new objects and install a GC finalizer.
+ *  - track_destroy / track_free: hooks OnDestroy to remove objects from tracking.
+ *  - calc_liveness_hook: runs after the GC liveness pass to evict objects the
+ *    GC has marked for collection, keeping our map consistent.
+ *  - GC_register_finalizer_inner: resolved via signature scan so we can register
+ *    our own C-level GC callback without access to the Boehm GC headers.
+ *
+ * Thread safety: all map mutations are guarded by tracked_objects_mutex.
+ */
+
 #include <il2cpp/il2cpp_helper.h>
 
 #include "prime/AllianceStarbaseObjectViewerWidget.h"
@@ -23,9 +43,14 @@
 
 #include <mutex>
 
+// ─── Tracking State ──────────────────────────────────────────────────────────
+
 std::mutex                                                   tracked_objects_mutex;
 eastl::unordered_map<Il2CppClass*, eastl::vector<uintptr_t>> tracked_objects;
 
+// ─── Tracking Map Helpers ────────────────────────────────────────────────────
+
+/** @brief Registers an object pointer in the tracking map for its class and all parent classes. */
 void add_to_tracking_recursive(Il2CppClass* klass, void* _this)
 {
   if (!klass) {
@@ -38,6 +63,7 @@ void add_to_tracking_recursive(Il2CppClass* klass, void* _this)
   return add_to_tracking_recursive(klass->parent, _this);
 }
 
+/** @brief Removes an object from every class entry in the tracking map (brute-force). */
 void remove_from_tracking_all(void* _this)
 {
 #define GET_CLASS(obj) ((Il2CppClass*)(((size_t)obj) & ~(size_t)1))
@@ -47,6 +73,7 @@ void remove_from_tracking_all(void* _this)
 #undef GET_CLASS
 }
 
+/** @brief Removes an object from tracking by walking the class hierarchy upward. */
 void remove_from_tracking_recursive(Il2CppClass* klass, void* _this)
 {
 #define GET_CLASS(obj) ((Il2CppClass*)(((size_t)obj) & ~(size_t)1))
@@ -64,9 +91,13 @@ void remove_from_tracking_recursive(Il2CppClass* klass, void* _this)
 #undef GET_CLASS
 }
 
+// ─── GC Integration ─────────────────────────────────────────────────────────
+
+/// Function pointer resolved at runtime via signature scan (Boehm GC internal).
 void (*GC_register_finalizer_inner)(unsigned __int64 obj, void (*fn)(void*, void*), void* cd,
                                     void (**ofn)(void*, void*), void** ocd) = nullptr;
 
+/** @brief GC finalizer callback — removes the object from tracking when collected. */
 void track_finalizer(void* _this, void*)
 {
 #define GET_CLASS(obj) ((Il2CppClass*)(((size_t)obj) & ~(size_t)1))
@@ -75,6 +106,16 @@ void track_finalizer(void* _this, void*)
 #undef GET_CLASS
 }
 
+// ─── SPUD Hooks ─────────────────────────────────────────────────────────────
+
+/**
+ * @brief Hook: T::.ctor (generic for each tracked type)
+ *
+ * Intercepts object construction to register the new instance in the
+ * tracking map and install a GC finalizer that will clean it up.
+ * Original method: initializes the managed object.
+ * Our modification: adds the object to the tracking map post-construction.
+ */
 void* track_ctor(auto original, void* _this)
 {
   auto obj = original(_this);
@@ -94,6 +135,12 @@ void* track_ctor(auto original, void* _this)
   return obj;
 }
 
+/**
+ * @brief Hook: T::OnDestroy (generic for each tracked type)
+ *
+ * Intercepts Unity OnDestroy to eagerly remove the object from tracking
+ * before the GC finalizer runs, avoiding stale pointer access.
+ */
 void track_destroy(auto original, Il2CppObject* _this, uint64_t a2, uint64_t a3)
 {
 #define GET_CLASS(obj) ((Il2CppClass*)(((size_t)obj) & ~(size_t)1))
@@ -106,6 +153,7 @@ void track_destroy(auto original, Il2CppObject* _this, uint64_t a2, uint64_t a3)
 #undef GET_CLASS
 }
 
+/** @brief Hook: il2cpp_object_free — removes the object from tracking before deallocation. */
 void track_free(auto original, void* _this)
 {
 #define GET_CLASS(obj) ((Il2CppClass*)(((size_t)obj) & ~(size_t)1))
@@ -118,6 +166,13 @@ void track_free(auto original, void* _this)
 #undef GET_CLASS
 }
 
+/**
+ * @brief Hook: il2cpp_unity_liveness_finalize
+ *
+ * Runs after the GC liveness calculation. Objects whose klass pointer has
+ * the low bit set (IS_MARKED) have been collected — we remove them from
+ * the tracking map to prevent dangling references.
+ */
 void calc_liveness_hook(auto original, void* state)
 {
   original(state);
@@ -147,9 +202,19 @@ void calc_liveness_hook(auto original, void* state)
   tracked_objects = tracked_objects;
 }
 
+// ─── Hook Installation ──────────────────────────────────────────────────────
+
+/// Guards against double-hooking when multiple types share a base method.
 static eastl::unordered_set<void*> seen_ctor;
 static eastl::unordered_set<void*> seen_destroy;
 
+/**
+ * @brief Installs .ctor and OnDestroy hooks for a single tracked type.
+ * @tparam T Game class (must expose get_class_helper()).
+ *
+ * Deduplicates hooks via seen_ctor / seen_destroy so that shared base
+ * methods are only detoured once.
+ */
 template <typename T> void TrackObject()
 {
   auto& object_class = T::get_class_helper();
@@ -166,6 +231,11 @@ template <typename T> void TrackObject()
   }
 }
 
+/**
+ * @brief Registers all tracked game object types, hooks the GC liveness
+ *        finalizer, and resolves the Boehm GC internal finalizer registration
+ *        function via platform-specific signature scanning.
+ */
 void InstallObjectTrackers()
 {
   TrackObject<PreScanTargetWidget>();

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -1,3 +1,47 @@
+/**
+ * @file sync.cc
+ * @brief Data synchronization engine — external HTTP sync of game state.
+ *
+ * Intercepts the game's protobuf and JSON entity-group processing to extract
+ * player data (inventories, officers, research, ships, battle logs, etc.) and
+ * forward it to user-configured external sync targets over HTTP.
+ *
+ * Architecture:
+ *  ┌─────────────────────────────────────────────────────────────┐
+ *  │ Game hooks (DataContainer::ParseBinaryObject, etc.)         │
+ *  │   → HandleEntityGroup() dispatches by EntityGroup::Type     │
+ *  │       → process_* functions parse protobuf/JSON             │
+ *  │           → queue_data() enqueues to sync_data_queue        │
+ *  │               → ship_sync_data() thread dequeues & sends    │
+ *  │                   → http::send_data() → per-target workers  │
+ *  └─────────────────────────────────────────────────────────────┘
+ *
+ * Battle logs follow a separate pipeline:
+ *  process_battle_headers() → combat_log_data_queue
+ *    → ship_combat_log_data() thread fetches full journal from Scopely
+ *    → resolves player/alliance names via cache or API
+ *    → sends enriched battle data via http::send_data()
+ *
+ * Threading model:
+ *  - ship_sync_data:       long-lived consumer for the main sync queue
+ *  - ship_combat_log_data: long-lived consumer for combat log enrichment
+ *  - target_worker_thread: one per sync target (created lazily), owns its
+ *                          own cpr::Session and request queue
+ *  - process_* functions:  each invoked on a detached std::thread from
+ *                          HandleEntityGroup's submit_async lambda
+ *
+ * Each process_* function maintains its own static state map (with mutex)
+ * and only emits data when values actually change (delta-based sync).
+ *
+ * Config keys (sync_targets[name]):
+ *  - url, token, proxy, verify_ssl: per-target connection settings
+ *  - enabled types: battlelogs, resources, ships, buildings, inventory, etc.
+ * Config keys (sync_options):
+ *  - proxy, verify_ssl: Scopely API proxy for combat log enrichment
+ *  - sync_resolver_cache_ttl: TTL for player/alliance name caches
+ *  - sync_logging, sync_debug: log verbosity toggles
+ */
+
 #include "config.h"
 #include "errormsg.h"
 #include "file.h"
@@ -69,6 +113,8 @@ struct WinRtApartmentGuard {
 namespace http
 {
 
+// ─── HTTP Session State ─────────────────────────────────────────────────────
+
 namespace headers
 {
   static std::string    gameServerUrl;
@@ -79,6 +125,7 @@ namespace headers
   static constexpr char poweredBy[] = "stfc community patch/" VER_FILE_VERSION_STR;
 } // namespace headers
 
+/** @brief Generates a random UUID string (platform-specific implementation). */
 [[nodiscard]] static std::string newUUID()
 {
 #ifdef _WIN32
@@ -100,7 +147,13 @@ namespace headers
   return s;
 }
 
-// Simple URL manipulation class to replace boost::url
+/**
+ * @brief Lightweight URL builder wrapping libcurl's URL API.
+ *
+ * Used to modify the path component of the game server URL when making
+ * Scopely API requests (e.g. /journals/get, /user_profile/profiles).
+ * Move-only to prevent double-free of the CURLU handle.
+ */
 class Url
 {
 public:
@@ -170,6 +223,9 @@ private:
   std::string m_url;
 };
 
+// ─── Sync Logging Helpers ───────────────────────────────────────────────────
+
+/// All sync_log_* functions are guarded by Config::sync_logging / sync_debug.
 static void sync_log_error(const std::string& type, const std::string& target, const std::string& text)
 {
   if (Config::Get().sync_logging) {
@@ -208,7 +264,15 @@ static void sync_log_trace(const std::string& type, const std::string& target, c
 static const std::string CURL_TYPE_UPLOAD   = "UPLOAD";
 static const std::string CURL_TYPE_DOWNLOAD = "DOWNLOAD";
 
-// Per-target worker thread infrastructure
+// ─── Per-Target Worker Threads ─────────────────────────────────────────────
+
+/**
+ * @brief Owns a dedicated HTTP session and work queue for one sync target.
+ *
+ * Each sync target URL gets its own TargetWorker so that slow or failing
+ * targets don't block other targets. The worker thread dequeues requests
+ * and posts them synchronously via cpr.
+ */
 struct TargetWorker {
   TargetWorker() = default;
   TargetWorker(const TargetWorker&) = delete;
@@ -227,6 +291,7 @@ struct TargetWorker {
 static std::unordered_map<std::string, std::shared_ptr<TargetWorker>> target_workers;
 static std::mutex target_workers_mtx;
 
+/** @brief Worker thread loop: dequeues requests and POSTs them to the target. */
 static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
 {
 #if _WIN32
@@ -301,6 +366,13 @@ static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
   }
 }
 
+/**
+ * @brief Returns (or lazily creates) the per-target worker for the given target name.
+ *
+ * Creates a new cpr::Session configured from the target's sync config
+ * (URL, token, proxy, SSL, timeouts) and spawns a worker thread.
+ * Thread-safe: guarded by target_workers_mtx.
+ */
 static std::shared_ptr<TargetWorker> get_curl_client_sync(const std::string& target)
 {
   std::lock_guard lk(target_workers_mtx);
@@ -351,6 +423,12 @@ static std::shared_ptr<TargetWorker> get_curl_client_sync(const std::string& tar
   return worker;
 }
 
+/**
+ * @brief Fans out a sync payload to all enabled targets for the given data type.
+ *
+ * Iterates over Config::sync_targets, filters by type, and enqueues
+ * the request into each matching target's worker queue.
+ */
 static void send_data(SyncConfig::Type type, const std::string& post_data, bool is_first_sync)
 {
   static std::once_flag emit_warning;
@@ -390,6 +468,16 @@ static void send_data(SyncConfig::Type type, const std::string& post_data, bool 
   }
 }
 
+// ─── Scopely Game Server Client ───────────────────────────────────────────
+
+/**
+ * @brief Returns (or lazily creates) the singleton cpr::Session for Scopely API calls.
+ *
+ * Configured to mimic the real Unity game client's HTTP headers
+ * (User-Agent, X-AUTH-SESSION-ID, X-PRIME-VERSION, etc.) so the
+ * game server accepts our requests for combat log journals and profiles.
+ * Thread-safe via std::call_once.
+ */
 static std::shared_ptr<cpr::Session> get_curl_client_scopely()
 {
   static std::shared_ptr<cpr::Session> session{nullptr};
@@ -428,6 +516,15 @@ static std::shared_ptr<cpr::Session> get_curl_client_scopely()
   return session;
 }
 
+/**
+ * @brief POSTs to a Scopely game-server endpoint and returns the response body.
+ * @param path      API path (appended to the game server URL).
+ * @param post_data JSON body to send.
+ *
+ * Used by the combat log pipeline to fetch journal data and resolve
+ * player/alliance names. Guarded by a client_mutex so only one
+ * Scopely request is in-flight at a time.
+ */
 static std::string get_scopely_data(const std::string& path, const std::string& post_data)
 {
   static std::once_flag emit_warning;
@@ -489,6 +586,8 @@ static std::string get_scopely_data(const std::string& path, const std::string& 
 
 } // namespace http
 
+// ─── JSON Serialization for Protobuf Types ─────────────────────────────────
+
 NLOHMANN_JSON_NAMESPACE_BEGIN
 template <typename T> struct adl_serializer<google::protobuf::RepeatedField<T>> {
   static void to_json(json& j, const google::protobuf::RepeatedField<T>& proto)
@@ -539,14 +638,19 @@ template <> struct adl_serializer<SyncConfig::Type> {
 };
 NLOHMANN_JSON_NAMESPACE_END
 
+// ─── Sync Queues & Caches ──────────────────────────────────────────────────
+
+/// Main sync queue: process_* functions produce; ship_sync_data() consumes.
 std::mutex                                                  sync_data_mtx;
 std::condition_variable                                     sync_data_cv;
 std::queue<std::tuple<SyncConfig::Type, std::string, bool>> sync_data_queue;
 
+/// Combat log queue: process_battle_headers() produces; ship_combat_log_data() consumes.
 std::mutex              combat_log_data_mtx;
 std::condition_variable combat_log_data_cv;
 std::queue<uint64_t>    combat_log_data_queue;
 
+/// TTL-based cache for resolved player names (player_id → name + alliance).
 struct CachedPlayerData {
   std::string                           name;
   int64_t                               alliance{-1};
@@ -556,6 +660,7 @@ struct CachedPlayerData {
 std::unordered_map<std::string, CachedPlayerData> player_data_cache;
 std::mutex                                        player_data_cache_mtx;
 
+/// TTL-based cache for resolved alliance names (alliance_id → name + tag).
 struct CachedAllianceData {
   std::string                           name;
   std::string                           tag;
@@ -565,6 +670,7 @@ struct CachedAllianceData {
 std::unordered_map<int64_t, CachedAllianceData> alliance_data_cache;
 std::mutex                                      alliance_data_cache_mtx;
 
+/** @brief Enqueues typed data (string) for the main sync thread and wakes it. */
 void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync = false)
 {
   {
@@ -576,6 +682,7 @@ void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sy
   sync_data_cv.notify_all();
 }
 
+/** @brief Enqueues typed data (JSON, auto-dumped) for the main sync thread. */
 void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync = false)
 {
   {
@@ -587,6 +694,9 @@ void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first
   sync_data_cv.notify_all();
 }
 
+// ─── Delta-Tracking State Types ─────────────────────────────────────────────
+
+/// Tracks officer/tech rank+level for delta detection.
 struct RankLevelState {
   explicit RankLevelState(const int32_t r = -1, const int32_t l = -1)
       : rank(r)
@@ -604,6 +714,7 @@ private:
   int64_t level = -1;
 };
 
+/// Tracks officer/tech rank+level+shards for delta detection.
 struct RankLevelShardsState {
   explicit RankLevelShardsState(const int32_t r = -1, const int32_t l = -1, const int32_t s = -1)
       : rank(r)
@@ -623,6 +734,7 @@ private:
   int32_t shards = -1;
 };
 
+/// Tracks ship tier/level/components for delta detection.
 struct ShipState {
   explicit ShipState(const int32_t t = -1, const int32_t l = -1, const double_t lp = -1.0,
                      const std::vector<int64_t>& c = {})
@@ -653,9 +765,13 @@ struct pairhash {
   }
 };
 
+// ─── Battle Log Persistence ─────────────────────────────────────────────────
+
+/// Ring buffer of recently-sent battle IDs (persisted to disk as JSON).
 static eastl::ring_buffer<uint64_t> previously_sent_battlelogs;
 static std::mutex                   previously_sent_battlelogs_mtx;
 
+/** @brief Loads the previously-sent battle log IDs from the JSON cache on disk. */
 static void load_previously_sent_logs()
 {
   using json = nlohmann::json;
@@ -683,6 +799,7 @@ static void load_previously_sent_logs()
   }
 }
 
+/** @brief Persists the battle log ring buffer to disk as JSON. */
 static void save_previously_sent_logs()
 {
   using json           = nlohmann::json;
@@ -712,6 +829,17 @@ static void save_previously_sent_logs()
   }
 }
 
+// ─── Protobuf Entity Processors ─────────────────────────────────────────────
+//
+// Each process_* function below:
+//  1. Parses a protobuf or JSON payload from a unique_ptr<string>
+//  2. Compares against a static local state map (with its own mutex)
+//  3. Emits only changed entries via queue_data()
+//
+// This delta-based approach avoids flooding sync targets with redundant data.
+// ─────────────────────────────────────────────────────────────────────────
+
+/** @brief Processes ActiveMissionsResponse — emits current set of active mission IDs on change. */
 void process_active_missions(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -751,6 +879,7 @@ void process_active_missions(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes CompletedMissionsResponse — emits newly completed mission IDs (append-only diff). */
 void process_completed_missions(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -790,6 +919,7 @@ void process_completed_missions(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes InventoryResponse — emits items whose count changed. Marks first sync. */
 void process_player_inventories(std::unique_ptr<std::string>&& bytes)
 {
   using json   = nlohmann::json;
@@ -835,6 +965,7 @@ void process_player_inventories(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes ResearchTreesState — emits research projects whose level changed. */
 void process_research_trees_state(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -866,6 +997,7 @@ void process_research_trees_state(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes OfficersResponse — emits officers whose rank/level/shards changed. */
 void process_officers(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -903,6 +1035,7 @@ void process_officers(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes ForbiddenTechsResponse — emits forbidden/chaos techs whose tier/level/shards changed. */
 void process_forbidden_techs(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -940,6 +1073,7 @@ void process_forbidden_techs(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes OfficerTraitsResponse — emits officer trait level changes. */
 void process_active_officer_traits(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -978,6 +1112,7 @@ void process_active_officer_traits(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes GlobalActiveBuffsResponse — emits buff add/update/expire events. */
 void process_global_active_buffs(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -1062,6 +1197,7 @@ inline std::optional<std::chrono::time_point<std::chrono::system_clock>> parse_t
 #endif
 }
 
+/** @brief Processes EntitySlots (protobuf) — emits slot changes for consumables, presets, skills, etc. */
 void process_entity_slots(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -1143,6 +1279,7 @@ void process_entity_slots(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes entity slot updates from real-time (RTC) JSON payloads. */
 void process_entity_slots_rtc(std::unique_ptr<std::string>&& json_payload)
 {
   using json = nlohmann::json;
@@ -1234,6 +1371,7 @@ void process_entity_slots_rtc(std::unique_ptr<std::string>&& json_payload)
   }
 }
 
+/** @brief Processes JobResponse — emits new/completed jobs (research, construction, tier-up, scrap). */
 void process_jobs(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -1322,6 +1460,7 @@ void process_jobs(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Processes AllianceGamePropertiesResponse — emits Emerald Chain loyalty level changes. */
 void process_alliance_games_props(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -1351,6 +1490,14 @@ void process_alliance_games_props(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+// ─── JSON Entity Processors ──────────────────────────────────────────────────
+
+/**
+ * @brief Enqueues unseen battle IDs for the combat log enrichment pipeline.
+ *
+ * Checks each battle ID against the ring buffer of previously-sent IDs
+ * and queues new ones on combat_log_data_queue for ship_combat_log_data().
+ */
 void process_battle_headers(const nlohmann::json& section)
 {
   http::sync_log_trace("PROCESS", "battle headers", STR_FORMAT("Processing {} battle headers", section.size()));
@@ -1392,6 +1539,7 @@ void process_battle_headers(const nlohmann::json& section)
   }
 }
 
+/** @brief Processes the resources JSON section — emits resource amount changes. */
 void process_resources(const nlohmann::json& section)
 {
   using json = nlohmann::json;
@@ -1422,6 +1570,7 @@ void process_resources(const nlohmann::json& section)
   }
 }
 
+/** @brief Processes the starbase_modules JSON section — emits building level changes. */
 void process_starbase_modules(const nlohmann::json& section)
 {
   using json = nlohmann::json;
@@ -1450,6 +1599,7 @@ void process_starbase_modules(const nlohmann::json& section)
   }
 }
 
+/** @brief Processes the ships JSON section — emits ship tier/level/component changes. */
 void process_ships(const nlohmann::json& section)
 {
   using json = nlohmann::json;
@@ -1490,6 +1640,12 @@ void process_ships(const nlohmann::json& section)
   }
 }
 
+/**
+ * @brief Top-level JSON entity dispatcher.
+ *
+ * Parses the JSON blob and routes each key (battle_result_headers, resources,
+ * starbase_modules, ships) to its respective processor, respecting sync_options.
+ */
 void process_json(std::unique_ptr<std::string>&& bytes)
 {
   using json = nlohmann::json;
@@ -1532,6 +1688,9 @@ void process_json(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+// ─── Player / Alliance Name Resolution ──────────────────────────────────────
+
+/** @brief Caches player names from a UserProfilesResponse protobuf (opportunistic pre-cache). */
 void cache_player_names(std::unique_ptr<std::string>&& bytes)
 {
   if (auto response = Digit::PrimeServer::Models::UserProfilesResponse(); response.ParseFromString(*bytes)) {
@@ -1553,6 +1712,7 @@ void cache_player_names(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+/** @brief Caches alliance names from a GetAllianceProfilesResponse protobuf. */
 void cache_alliance_names(std::unique_ptr<std::string>&& bytes)
 {
   if (auto response = Digit::PrimeServer::Models::GetAllianceProfilesResponse(); response.ParseFromString(*bytes)) {
@@ -1577,6 +1737,14 @@ void cache_alliance_names(std::unique_ptr<std::string>&& bytes)
   }
 }
 
+// ─── Background Consumer Threads ────────────────────────────────────────────
+
+/**
+ * @brief Main sync consumer thread — dequeues from sync_data_queue and calls send_data().
+ *
+ * Runs for the lifetime of the process. Blocks on sync_data_cv when idle.
+ * Exceptions are caught and logged to prevent thread termination.
+ */
 void ship_sync_data()
 {
 #if _WIN32
@@ -1639,6 +1807,13 @@ inline void collect_alliance_ids(const nlohmann::json& names, std::unordered_set
   }
 }
 
+/**
+ * @brief Resolves player names from cache or marks them for API fetch.
+ * @param user_ids     Set of player IDs to resolve.
+ * @param out_names    JSON object to populate with cached hits.
+ * @param out_request_ids JSON array to populate with cache misses (for API fetch).
+ * @param now          Current time for TTL comparison.
+ */
 void resolve_player_names(const std::unordered_set<std::string>& user_ids, nlohmann::json& out_names,
                           nlohmann::json& out_request_ids, const std::chrono::time_point<std::chrono::steady_clock> now)
 {
@@ -1664,6 +1839,13 @@ void resolve_player_names(const std::unordered_set<std::string>& user_ids, nlohm
   }
 }
 
+/**
+ * @brief Resolves alliance names from cache or marks them for API fetch.
+ * @param alliance_ids Set of alliance IDs to resolve.
+ * @param out_names    JSON object to enrich with alliance name/tag from cache.
+ * @param out_request_ids JSON array to populate with cache misses.
+ * @param now          Current time for TTL comparison.
+ */
 void resolve_alliance_names(const std::unordered_set<int64_t>& alliance_ids, nlohmann::json& out_names,
                             nlohmann::json&                                          out_request_ids,
                             const std::chrono::time_point<std::chrono::steady_clock> now)
@@ -1693,6 +1875,14 @@ void resolve_alliance_names(const std::unordered_set<int64_t>& alliance_ids, nlo
   }
 }
 
+/**
+ * @brief Combat log enrichment consumer thread.
+ *
+ * Dequeues battle IDs from combat_log_data_queue, fetches the full journal
+ * from the Scopely game server, resolves player and alliance names (using
+ * cache + API fallback), and sends the enriched battle data to sync targets.
+ * Runs for the lifetime of the process.
+ */
 void ship_combat_log_data()
 {
   using json = nlohmann::json;
@@ -1847,6 +2037,15 @@ void ship_combat_log_data()
   }
 }
 
+// ─── Entity Group Dispatch ───────────────────────────────────────────────────
+
+/**
+ * @brief Central dispatcher for entity group data.
+ *
+ * Routes each EntityGroup by type to the appropriate process_* function,
+ * spawning each on a detached thread via submit_async. Checks the
+ * corresponding sync_options flag before dispatching.
+ */
 void HandleEntityGroup(EntityGroup* entity_group)
 {
   if (entity_group == nullptr || entity_group->Group == nullptr || entity_group->Group->bytes == nullptr
@@ -1954,12 +2153,28 @@ void HandleEntityGroup(EntityGroup* entity_group)
   }
 }
 
+// ─── SPUD Hooks ─────────────────────────────────────────────────────────────
+
+/**
+ * @brief Hook: DataContainer::ParseBinaryObject
+ *
+ * Intercepts binary entity group parsing to extract data before the game processes it.
+ * Original method: deserializes a protobuf entity group into the data container.
+ * Our modification: calls HandleEntityGroup() first, then the original.
+ */
 void DataContainer_ParseBinaryObject(auto original, void* _this, EntityGroup* group, bool isPlayerData)
 {
   HandleEntityGroup(group);
   return original(_this, group, isPlayerData);
 }
 
+/**
+ * @brief Hook: SlotDataContainer::ParseSlotUpdatedJson / ParseSlotRemovedJson
+ *
+ * Intercepts real-time slot update/removal notifications (RTC channel).
+ * Original method: parses a JSON payload for slot changes.
+ * Our modification: spawns process_entity_slots_rtc() on a detached thread.
+ */
 void DataContainer_ParseRtcPayload(auto original, void* _this, bool incrementalJsonParsing, RealtimeDataPayload* data)
 {
   original(_this, incrementalJsonParsing, data);
@@ -1992,6 +2207,13 @@ void DataContainer_ParseRtcPayload(auto original, void* _this, bool incrementalJ
   }).detach();
 }
 
+/**
+ * @brief Hook: GameServerModelRegistry::ProcessResultInternal
+ *
+ * Intercepts HTTP response processing to extract entity groups from the response.
+ * Original method: processes the service response and invokes callbacks.
+ * Our modification: iterates entity groups and calls HandleEntityGroup() before original.
+ */
 void GameServerModelRegistry_ProcessResultInternal(auto original, void* _this, HttpResponse* http_response,
                                                    ServiceResponse* service_response, void* callback,
                                                    void* callback_error)
@@ -2005,6 +2227,12 @@ void GameServerModelRegistry_ProcessResultInternal(auto original, void* _this, H
   return original(_this, http_response, service_response, callback, callback_error);
 }
 
+/**
+ * @brief Hook: GameServerModelRegistry::HandleBinaryObjects
+ *
+ * Intercepts bulk binary object handling to extract entity groups.
+ * Same pattern as ProcessResultInternal but for binary-only responses.
+ */
 void GameServerModelRegistry_HandleBinaryObjects(auto original, void* _this, ServiceResponse* service_response)
 {
   const auto entity_groups = service_response->EntityGroups;
@@ -2016,6 +2244,12 @@ void GameServerModelRegistry_HandleBinaryObjects(auto original, void* _this, Ser
   return original(_this, service_response);
 }
 
+/**
+ * @brief Hook: PrimeApp::InitPrimeServer
+ *
+ * Captures the game server URL and session ID so we can make authenticated
+ * requests to the Scopely API for combat log enrichment.
+ */
 void PrimeApp_InitPrimeServer(auto original, void* _this, Il2CppString* gameServerUrl, Il2CppString* gatewayServerUrl,
                               Il2CppString* sessionId, Il2CppString* serverRegion)
 {
@@ -2024,6 +2258,7 @@ void PrimeApp_InitPrimeServer(auto original, void* _this, Il2CppString* gameServ
   http::headers::gameServerUrl     = to_string(to_wstring(gameServerUrl));
 }
 
+/** @brief Hook: GameServer::Initialise — captures the game version string for HTTP headers. */
 void GameServer_Initialise(auto original, void* _this, Il2CppString* sessionId, Il2CppString* gameVersion,
                            bool encryptRequests, Il2CppString* serverRegion)
 {
@@ -2031,12 +2266,24 @@ void GameServer_Initialise(auto original, void* _this, Il2CppString* sessionId, 
   http::headers::primeVersion = to_string(to_wstring(gameVersion));
 }
 
+/** @brief Hook: GameServer::SetInstanceIdHeader — captures the instance ID for HTTP headers. */
 void GameServer_SetInstanceIdHeader(auto original, void* _this, int32_t instanceId)
 {
   original(_this, instanceId);
   http::headers::instanceId = instanceId;
 }
 
+// ─── Hook Installation ──────────────────────────────────────────────────────
+
+/**
+ * @brief Installs all sync-related hooks and starts background threads.
+ *
+ * Hooks multiple DataContainer::ParseBinaryObject variants to intercept
+ * entity group data, hooks PrimeApp/GameServer for session credentials,
+ * and spawns the two long-lived consumer threads:
+ *  - ship_sync_data (main sync queue consumer)
+ *  - ship_combat_log_data (combat log enrichment consumer)
+ */
 void InstallSyncPatches()
 {
   load_previously_sent_logs();

--- a/mods/src/patches/parts/testing.cc
+++ b/mods/src/patches/parts/testing.cc
@@ -1,3 +1,15 @@
+/**
+ * @file testing.cc
+ * @brief Development and testing hooks.
+ *
+ * Contains hooks primarily used during mod development and testing:
+ *   - Cursor override: replaces Unity's custom cursor with the OS default arrow.
+ *   - Config URL override: injects custom platform settings and asset URLs.
+ *   - SetActive deduplication: guards against redundant GameObject activation calls.
+ *   - Action queue toggle: allows disabling the game's action queue feature.
+ *
+ * These patches are gated behind the installTestPatches config flag.
+ */
 #include "config.h"
 #include "errormsg.h"
 
@@ -25,6 +37,9 @@
 #include <spud/detour.h>
 #include <spud/signature.h>
 
+// ─── IL2CPP Wrapper Classes ──────────────────────────────────────────────────
+
+/// Wrapper for Digit.Client.Core.AppConfig — exposes platform URL properties.
 class AppConfig
 {
 public:
@@ -78,6 +93,7 @@ public:
   }
 };
 
+/// Wrapper for Digit.Client.Core.Model — provides access to AppConfig.
 class Model
 {
 public:
@@ -98,6 +114,16 @@ public:
   }
 };
 
+// ─── Hook Functions ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Hook: UnityEngine.Cursor::SetCursor_Injected
+ *
+ * Intercepts cursor rendering to force the OS default arrow.
+ * Original method: sets a custom cursor texture, hotspot, and mode.
+ * Our modification: when allow_cursor is false (Windows only), replaces the
+ *   cursor with IDC_ARROW and releases any Unity cursor clipping.
+ */
 void Cursor_SetCursor(auto original, void* _this, ptrdiff_t texture, Vector2* hotspot, int cursorMode)
 {
 #if _WIN32
@@ -111,6 +137,14 @@ void Cursor_SetCursor(auto original, void* _this, ptrdiff_t texture, Vector2* ho
   return original(_this, texture, hotspot, cursorMode);
 }
 
+/**
+ * @brief Hook: Model::LoadConfigs
+ *
+ * Intercepts app config loading to inject custom platform/asset URLs.
+ * Original method: reads and returns the game's AppConfig.
+ * Our modification: after calling original, overwrites PlatformSettingsUrl
+ *   and/or AssetUrlOverride if the user has configured custom values.
+ */
 AppConfig* Model_LoadConfigs(auto original, Model* _this)
 {
   original(_this);
@@ -129,6 +163,14 @@ AppConfig* Model_LoadConfigs(auto original, Model* _this)
   return config;
 }
 
+/**
+ * @brief Hook: UnityEngine.GameObject::SetActive
+ *
+ * Guards against redundant activation calls that can cause issues.
+ * Original method: activates or deactivates a GameObject.
+ * Our modification: skips the call if the object is already in the
+ *   requested active state (avoids re-triggering OnEnable cascades).
+ */
 void SetActive_hook(auto original, void* _this, bool active)
 {
   static auto IsActiveSelf = il2cpp_resolve_icall_typed<bool(void*)>("UnityEngine.GameObject::get_activeSelf()");
@@ -140,6 +182,14 @@ void SetActive_hook(auto original, void* _this, bool active)
   return original(_this, active);
 }
 
+/**
+ * @brief Hook: ActionQueueManager::IsQueueUnlocked
+ *
+ * Allows disabling the action queue feature entirely.
+ * Original method: returns whether the action queue is unlocked for the player.
+ * Our modification: returns false when queue_enabled config is off,
+ *   effectively hiding the queue UI.
+ */
 bool IsQueueEnabled(auto original, void* _this)
 {
   if (Config::Get().queue_enabled) {
@@ -149,6 +199,17 @@ bool IsQueueEnabled(auto original, void* _this)
   return false;
 }
 
+// ─── Hook Installation ───────────────────────────────────────────────────────
+
+/**
+ * @brief Installs development/testing hooks.
+ *
+ * Hooks:
+ *   - Cursor::SetCursor_Injected (cursor override)
+ *   - Model::LoadConfigs (config URL injection)
+ *   - GameObject::SetActive (activation dedup guard)
+ *   - ActionQueueManager::IsQueueUnlocked (queue toggle)
+ */
 void InstallTestPatches()
 {
   auto cursorManager = il2cpp_get_class_helper("UnityEngine.CoreModule", "UnityEngine", "Cursor");

--- a/mods/src/patches/parts/ui_scale.cc
+++ b/mods/src/patches/parts/ui_scale.cc
@@ -1,3 +1,18 @@
+/**
+ * @file ui_scale.cc
+ * @brief DPI-aware UI scaling system.
+ *
+ * Hooks ScreenManager::UpdateCanvasRootScaleFactor and CanvasController::Show
+ * to apply user-configured UI scale factors. Accounts for screen resolution,
+ * DPI, and provides a separate scale override for the ObjectViewer canvas.
+ *
+ * Config keys:
+ *  - ui_scale:        global canvas scale multiplier (0 = disabled)
+ *  - adjust_scale_res: whether to adjust for resolution vs. 1080p reference
+ *  - ui_scale_viewer: separate scale for the ObjectViewer canvas (0 = disabled)
+ *  - allow_cursor:    on Windows, whether to allow the system cursor to change
+ */
+
 #include "errormsg.h"
 #include <config.h>
 
@@ -13,6 +28,18 @@
 #include <prime/Vector3.h>
 #include <str_utils.h>
 
+// ─── SPUD Hooks ─────────────────────────────────────────────────────────────
+
+/**
+ * @brief Hook: ScreenManager::UpdateCanvasRootScaleFactor
+ *
+ * Intercepts the per-frame canvas scale update to apply a custom DPI-aware
+ * scale factor.
+ * Original method: recalculates and sets the root canvas scaler.
+ * Our modification: overrides scaleFactor with (ui_scale * resolution_ratio * DPI),
+ *                   clamped to [0.1, 5.0]. Also resets the Windows cursor to
+ *                   arrow when allow_cursor is disabled.
+ */
 void ScreenManager_UpdateCanvasRootScaleFactor_Hook(auto original, ScreenManager* _this)
 {
   original(_this);
@@ -51,6 +78,14 @@ void ScreenManager_UpdateCanvasRootScaleFactor_Hook(auto original, ScreenManager
   }
 }
 
+/**
+ * @brief Hook: CanvasController::Show(int, bool)
+ *
+ * Intercepts canvas display to apply a separate scale for the ObjectViewer.
+ * Original method: shows a UI canvas with the given entry point.
+ * Our modification: sets localScale on the ObjectViewerTemplate_Canvas
+ *                   transform when ui_scale_viewer is configured.
+ */
 void CanvasController_Show(auto original, CanvasController* _this, int desiredEntryPoint, bool instant)
 {
   const auto ui_scale_viewer = Config::Get().ui_scale_viewer;
@@ -65,6 +100,9 @@ void CanvasController_Show(auto original, CanvasController* _this, int desiredEn
   return original(_this, desiredEntryPoint, instant);
 }
 
+// ─── Hook Installation ──────────────────────────────────────────────────────
+
+/** @brief Resolves IL2CPP methods and installs UI scaling hooks; refreshes DPI on startup. */
 void InstallUiScaleHooks()
 {
   auto screen_manager_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "ScreenManager");

--- a/mods/src/patches/parts/zoom.cc
+++ b/mods/src/patches/parts/zoom.cc
@@ -1,3 +1,23 @@
+/**
+ * @file zoom.cc
+ * @brief Camera zoom controls — presets, keyboard zoom, and far-clip extension.
+ *
+ * Hooks NavigationZoom methods to provide:
+ *  - Five user-assignable zoom presets (store/recall via hotkeys)
+ *  - Smooth keyboard-driven zoom in/out with configurable speed
+ *  - Extended maximum zoom range (controlled by Config::Get().zoom)
+ *  - Automatic far-clip plane adjustment so distant objects remain visible
+ *  - Optional "use preset as default" behavior
+ *
+ * Config keys:
+ *  - zoom:                   maximum zoom distance
+ *  - keyboard_zoom_speed:    zoom delta per second for keyboard zoom
+ *  - system_zoom_preset_1–5: stored zoom preset values
+ *  - default_system_zoom:    zoom level applied on system entry / reset
+ *  - hotkeys_extended:       enables ZoomReset / ZoomMin / ZoomMax keys
+ *  - use_presets_as_default: automatically updates default zoom after preset recall
+ */
+
 #include "config.h"
 #include "errormsg.h"
 
@@ -11,6 +31,9 @@
 #include <spdlog/spdlog.h>
 #include <spud/detour.h>
 
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** @brief Calls IL2CPP MathUtils::GetMouseWorldPos to project screen coords to world space. */
 vec3 GetMouseWorldPos(void *cam, vec3 *pos)
 {
   static auto class_helper = il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.Client.Core", "MathUtils");
@@ -22,8 +45,18 @@ vec3 GetMouseWorldPos(void *cam, vec3 *pos)
   return *(vec3 *)(il2cpp_object_unbox(result));
 }
 
+/// Flag set by depth/view hooks to trigger a zoom-to-default on the next Update.
 auto do_default_zoom = false;
 
+/**
+ * @brief Saves the current zoom distance as a named preset.
+ * @param label  Human-readable preset name (for log output).
+ * @param zoom   Reference to the config preset slot to update.
+ * @param _this  NavigationZoom instance to read current distance from.
+ *
+ * Normalizes distance into a [0, Config::zoom] range for portability across
+ * systems with different _minimum/_maximum values.
+ */
 inline void StoreZoom(std::string label, float &zoom, NavigationZoom *_this)
 {
   auto old_zoom = zoom;
@@ -31,6 +64,20 @@ inline void StoreZoom(std::string label, float &zoom, NavigationZoom *_this)
   spdlog::info("Changing {} from {} to {}", label, old_zoom, zoom);
 }
 
+// ─── Main Zoom Hook ─────────────────────────────────────────────────────────
+
+/**
+ * @brief Hook: NavigationZoom::Update
+ *
+ * Intercepts the per-frame zoom update to process keyboard-driven zoom
+ * inputs (presets, smooth zoom in/out, reset, min/max).
+ * Original method: updates camera zoom from touch/pinch input.
+ * Our modification: reads MapKey state each frame; for preset keys it
+ *                   stores or recalls a preset; for zoom keys it computes
+ *                   a per-frame delta (or absolute target) and calls
+ *                   ZoomCameraAtWorldPoint() to apply the zoom anchored
+ *                   at the mouse position.
+ */
 void NavigationZoom_Update_Hook(auto original, NavigationZoom *_this)
 {
   static auto GetMousePosition =
@@ -132,6 +179,15 @@ void NavigationZoom_Update_Hook(auto original, NavigationZoom *_this)
   original(_this);
 }
 
+// ─── View Parameter / Depth Hooks ──────────────────────────────────────────
+
+/**
+ * @brief Hook: NavigationZoom::SetViewParameters
+ *
+ * Intercepts system-view setup to extend the zoom range and far-clip plane
+ * proportionally to Config::zoom / radius. Only modifies SolarSystem depth;
+ * galaxy/sector views pass through unmodified.
+ */
 void NavigationZoom_SetViewParameters_Hook(auto original, NavigationZoom *_this, float radius, NodeDepth depth)
 {
   if (depth == NodeDepth::SolarSystem) {
@@ -146,6 +202,13 @@ void NavigationZoom_SetViewParameters_Hook(auto original, NavigationZoom *_this,
   }
 }
 
+/**
+ * @brief Hook: NavigationZoom::ApplyRangeChanges
+ *
+ * Same far-ratio / far-clip extension as SetViewParameters, but triggered
+ * when the game recalculates range after a dynamic change.
+ * Currently commented out in hook installation (kept for reference).
+ */
 void NavigationZoom_ApplyRangeChanges_Hook(auto original, NavigationZoom *_this)
 {
   if (_this->_depth == NodeDepth::SolarSystem) {
@@ -160,6 +223,13 @@ void NavigationZoom_ApplyRangeChanges_Hook(auto original, NavigationZoom *_this)
   }
 }
 
+/**
+ * @brief Hook: NavigationZoom::SetDepth
+ *
+ * Intercepts depth transitions to adjust far-ratio and far-clip for the
+ * solar-system view. Sets do_default_zoom so the next Update applies the
+ * user's default zoom level upon entering a system.
+ */
 void NavigationZoom_SetDepth_Hook(auto original, NavigationZoom *_this, NodeDepth depth)
 {
   if (depth == NodeDepth::SolarSystem) {
@@ -175,6 +245,13 @@ void NavigationZoom_SetDepth_Hook(auto original, NavigationZoom *_this, NodeDept
   }
 }
 
+/**
+ * @brief Hook: NavigationCamera::SetSystemViewSizeData
+ *
+ * Alternative entry point for system-view setup (accesses NavigationZoom
+ * at a fixed offset from the NavigationCamera pointer).
+ * Currently commented out in hook installation.
+ */
 void NavigationCamera_SetSystemViewSizeData_Hook(auto original, uint8_t *_this_cam, float radius, Vector3 *systemPos,
                                                  NodeDepth depth)
 {
@@ -191,6 +268,9 @@ void NavigationCamera_SetSystemViewSizeData_Hook(auto original, uint8_t *_this_c
   }
 }
 
+// ─── Hook Installation ──────────────────────────────────────────────────────
+
+/** @brief Resolves NavigationZoom IL2CPP methods and installs all zoom hooks. */
 void InstallZoomHooks()
 {
   auto screen_manager_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Navigation", "NavigationZoom");

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -1,3 +1,15 @@
+/**
+ * @file patches.cc
+ * @brief Patch system coordinator — bootstraps logging, config, and all hook modules.
+ *
+ * This is the top-level orchestrator for the community patch. It detours the game's
+ * il2cpp_init entry point so that, once the IL2CPP runtime is initialized, we can:
+ *   1. Set up file paths and logging (spdlog).
+ *   2. Load user configuration (Config::Get()).
+ *   3. Iterate a table of patch modules, installing each one whose config flag is enabled.
+ *
+ * Each patch module is a self-contained Install*Hooks() function defined in parts/.
+ */
 #include "patches.h"
 #include "file.h"
 #include "version.h"
@@ -18,6 +30,8 @@
 #include <mach-o/dyld.h>
 #endif
 
+// ─── Forward Declarations — per-module install functions ─────────────────────
+
 void InstallUiScaleHooks();
 void InstallZoomHooks();
 void InstallBuffFixHooks();
@@ -36,6 +50,16 @@ void InstallTempCrashFixes();
 void InstallSyncPatches();
 void InstallObjectTrackers();
 
+/**
+ * @brief Hook: il2cpp_init
+ *
+ * Intercepts the IL2CPP runtime initialization to inject all community patches.
+ * Original method: initializes the IL2CPP virtual machine for the given domain.
+ * Our modification: after calling the original, sets up logging and config, then
+ *   iterates a table of PatchEntry structs. Each entry pairs an Install*Hooks()
+ *   function with a config boolean; only enabled patches are installed. This is
+ *   the single entry point for all mod functionality.
+ */
 __int64 il2cpp_init_hook(auto original, const char* domain_name)
 {
   struct PatchEntry {
@@ -153,6 +177,16 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
   return r;
 }
 
+// ─── Patch Entry Point ───────────────────────────────────────────────────────
+
+/**
+ * @brief Loads GameAssembly and detours il2cpp_init.
+ *
+ * Platform-specific: on Windows loads GameAssembly.dll via LoadLibrary;
+ * on macOS loads GameAssembly.dylib via dlopen relative to the executable.
+ * Once loaded, resolves the il2cpp_init export and installs the main hook
+ * (il2cpp_init_hook) which in turn bootstraps all patch modules.
+ */
 void ApplyPatches()
 {
 #if _WIN32

--- a/mods/src/patches/patches.h
+++ b/mods/src/patches/patches.h
@@ -1,3 +1,11 @@
+/**
+ * @file patches.h
+ * @brief Entry point for the community patch hook system.
+ *
+ * Declares the top-level function that bootstraps all game modifications
+ * by detouring il2cpp_init and installing individual patch modules.
+ */
 #pragma once
 
+/// Load GameAssembly, detour il2cpp_init, and register all patch hooks.
 void ApplyPatches();

--- a/mods/src/patches/viewer_mgmt.cc
+++ b/mods/src/patches/viewer_mgmt.cc
@@ -1,3 +1,12 @@
+/**
+ * @file viewer_mgmt.cc
+ * @brief Object viewer visibility management and rewards panel toggling.
+ *
+ * Manages the lifecycle of object viewer overlays (alliance starbase, armada,
+ * celestial, embassy, housing, mining, missions, pre-scan target). Provides
+ * Escape-to-dismiss, rewards screen dismissal, and the multi-frame
+ * cargo/rewards info panel toggle (ActionView key).
+ */
 #include "errormsg.h"
 #include "config.h"
 
@@ -16,11 +25,10 @@
 
 #include "prime/AnimatedRewardsScreenViewController.h"
 
+/** Frame counter for multi-frame info panel display. */
 static int show_info_pending = 0;
 
-// ---------------------------------------------------------------------------
-// CanHideViewers / DidHideViewers
-// ---------------------------------------------------------------------------
+// ─── Viewer Visibility Queries & Hide ───────────────────────────────────────────────
 
 // NOTE: If you change this loop functionality, also change DoHideViewersOfType template
 template <typename T>
@@ -81,9 +89,7 @@ bool DidHideViewers()
          || DidHideViewersOfType<HousingObjectViewerWidget>();
 }
 
-// ---------------------------------------------------------------------------
-// Rewards screen dismiss
-// ---------------------------------------------------------------------------
+// ─── Rewards Screen Dismiss ──────────────────────────────────────────────────────────
 
 bool TryDismissRewardsScreen()
 {
@@ -96,9 +102,7 @@ bool TryDismissRewardsScreen()
   return false;
 }
 
-// ---------------------------------------------------------------------------
-// ActionView / info pending
-// ---------------------------------------------------------------------------
+// ─── ActionView / Info Pending ────────────────────────────────────────────────────────
 
 void HandleActionView()
 {

--- a/mods/src/patches/viewer_mgmt.h
+++ b/mods/src/patches/viewer_mgmt.h
@@ -1,8 +1,46 @@
+/**
+ * @file viewer_mgmt.h
+ * @brief Object viewer visibility management and rewards panel toggling.
+ *
+ * Provides utilities for hiding all visible object viewer overlays (used by
+ * Escape key handling), dismissing the animated rewards screen, and toggling
+ * the cargo/rewards info panel with multi-frame show support.
+ */
 #pragma once
 
+/** @brief Check if any object viewer overlay is currently visible. */
 bool CanHideViewers();
+
+/**
+ * @brief Hide all visible object viewer overlays.
+ * @return true if at least one viewer was hidden.
+ */
 bool DidHideViewers();
+
+/**
+ * @brief Dismiss the golden animated rewards screen if it is active.
+ * @return true if the rewards screen was dismissed.
+ */
 bool TryDismissRewardsScreen();
+
+/**
+ * @brief Toggle the cargo/rewards info panel on visible pre-scan targets.
+ *
+ * If the panel is hidden, queues it to show over the next several frames;
+ * if already visible, hides it immediately.
+ */
 void HandleActionView();
+
+/**
+ * @brief Decrement the info-pending counter and show cargo panels while active.
+ *
+ * Called every frame from the router. When the counter is positive, attempts
+ * to make the rewards panel visible on all pre-scan target widgets.
+ */
 void TickInfoPending();
+
+/**
+ * @brief Set the info-pending frame counter for multi-frame panel display.
+ * @param frames Number of frames to keep attempting to show the panel.
+ */
 void SetInfoPending(int frames);

--- a/mods/src/prime/BattleResultHeader.h
+++ b/mods/src/prime/BattleResultHeader.h
@@ -1,7 +1,17 @@
+/**
+ * @file BattleResultHeader.h
+ * @brief Battle result data structures and enumerations.
+ *
+ * Mirrors Digit.PrimeServer.Models.BattleResultHeader and the associated
+ * enums (BattleType, BattleResultType, FleetDataType). Used by the battle-
+ * log mod to extract combatant ship hull IDs and user profiles from combat
+ * reports.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/** @brief Categorises the type of battle (fleet vs. base, PvP vs. PvE, armada, etc.). */
 enum class BattleType {
   Fleet                          = 0,
   Base                           = 1,
@@ -22,18 +32,27 @@ enum class BattleType {
   PvpChainShot                   = 16
 };
 
+/** @brief Outcome of a battle from the player's perspective. */
 enum class BattleResultType {
   Defeat         = 0,
   Victory        = 1,
   PartialVictory = 2
 };
 
+/** @brief Identifies the type of fleet data (deployed fleet, starbase, or armada). */
 enum class FleetDataType {
   DeployedFleet = 0,
   Starbase      = 1,
   Armada        = 2
 };
 
+/**
+ * @brief Header data for a single battle result.
+ *
+ * Contains the player's and enemy's ship hull IDs, user profiles, and
+ * a reference to the SpecService for resolving hull details. Accessed
+ * from combat report screens and battle-log export functionality.
+ */
 struct BattleResultHeader {
 public:
   __declspec(property(get = __get_PlayerShipHullId)) long PlayerShipHullId;

--- a/mods/src/prime/Canvas.h
+++ b/mods/src/prime/Canvas.h
@@ -1,7 +1,15 @@
+/**
+ * @file Canvas.h
+ * @brief Unity Canvas wrapper.
+ *
+ * Mirrors UnityEngine.UI.Canvas. Exposes the scaleFactor property,
+ * used by mods that adjust UI scaling.
+ */
 #pragma once
 
 #include "il2cpp/il2cpp_helper.h"
 
+/** @brief Wrapper for Unity's Canvas component. Provides access to the UI scale factor. */
 struct Canvas {
 public:
   __declspec(property(get = __get_scaleFactor, put = __set_scaleFactor)) float scaleFactor;

--- a/mods/src/prime/ChatManager.h
+++ b/mods/src/prime/ChatManager.h
@@ -1,3 +1,10 @@
+/**
+ * @file ChatManager.h
+ * @brief Chat system singleton and related enumerations.
+ *
+ * Mirrors Digit.Prime.Chat.ChatManager — manages opening/closing chat
+ * channels, side-chat state, and view mode (fullscreen vs. side panel).
+ */
 #pragma once
 
 #include "errormsg.h"
@@ -6,6 +13,7 @@
 
 #include "MonoSingleton.h"
 
+/** @brief Chat channel categories available in the game. */
 enum class ChatChannelCategory : int32_t {
   None            = -1,
   Newbie          = 0,
@@ -17,11 +25,19 @@ enum class ChatChannelCategory : int32_t {
   Regional        = 6,
 };
 
+/** @brief Whether the chat UI is displayed fullscreen or as a side panel. */
 enum class ChatViewMode : int32_t {
   Fullscreen = 0,
   Side       = 1,
 };
 
+/**
+ * @brief Singleton managing the in-game chat system.
+ *
+ * Provides methods to open specific chat channels (alliance, private, etc.),
+ * query side-chat availability, and toggle between fullscreen and side
+ * panel view modes. Also exposes newbie/regional chat visibility checks.
+ */
 struct ChatManager : MonoSingleton<ChatManager> {
   friend struct MonoSingleton;
 

--- a/mods/src/prime/FleetBarViewController.h
+++ b/mods/src/prime/FleetBarViewController.h
@@ -1,9 +1,19 @@
+/**
+ * @file FleetBarViewController.h
+ * @brief HUD fleet-selection bar UI controller.
+ *
+ * Mirrors Digit.Prime.HUD.FleetBarViewController and FleetBarContext.
+ * The fleet bar is the row of fleet slot buttons at the bottom of the
+ * navigation screen. This header exposes slot selection, index checking,
+ * and access to the underlying fleet panel controller.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
 #include "FleetLocalViewController.h"
 
+/** @brief Context object for the fleet bar, providing the currently selected fleet. */
 struct FleetBarContext {
 public:
   __declspec(property(get = __get_CurrentFleet)) void* CurrentFleet;
@@ -23,6 +33,13 @@ public:
   }
 };
 
+/**
+ * @brief UI controller for the fleet selection bar in the HUD.
+ *
+ * Drives fleet slot selection, checks which index is active, and provides
+ * access to the canvas context and underlying fleet panel controller.
+ * Tracked by ObjectFinder for global lookup.
+ */
 struct FleetBarViewController {
 public:
   __declspec(property(get = __get__fleetPanelController)) FleetLocalViewController* _fleetPanelController;

--- a/mods/src/prime/FleetsManager.h
+++ b/mods/src/prime/FleetsManager.h
@@ -1,3 +1,11 @@
+/**
+ * @file FleetsManager.h
+ * @brief Fleet management singleton.
+ *
+ * Mirrors Digit.Prime.FleetManagement.FleetsManager — handles fleet
+ * operations such as viewing, recalling, towing, and accessing per-fleet
+ * player data. Includes a nested IEnumerator_Tow coroutine wrapper.
+ */
 #pragma once
 
 #include "CallbackContainer.h"
@@ -10,6 +18,13 @@
 
 #include <il2cpp/il2cpp_helper.h>
 
+/**
+ * @brief Singleton that manages all fleet operations for the local player.
+ *
+ * Provides methods for viewing, recalling, and towing fleets, as well as
+ * querying per-fleet data. The target fleet (e.g. the one being viewed in
+ * a combat report) is accessible via the targetFleetData property.
+ */
 struct FleetsManager : MonoSingleton<FleetsManager> {
   friend struct MonoSingleton<FleetsManager>;
 

--- a/mods/src/prime/GameObject.h
+++ b/mods/src/prime/GameObject.h
@@ -1,5 +1,21 @@
+/**
+ * @file GameObject.h
+ * @brief Unity GameObject wrapper.
+ *
+ * Mirrors UnityEngine.GameObject. Provides typed GetComponent() calls
+ * (both reflection-invoke and direct-pointer variants), and access to
+ * the activeInHierarchy flag and scene reference.
+ */
 #pragma once
 
+/**
+ * @brief Wrapper for Unity's GameObject, the fundamental scene-graph node.
+ *
+ * GetComponentFastPath() and GetComponentFastPath2() resolve a component
+ * by its System.Type, matching Unity's generic GetComponent<T>() from C#.
+ * The "2" variant uses il2cpp_runtime_invoke while the primary variant
+ * calls the native method pointer directly.
+ */
 struct GameObject {
 public:
   __declspec(property(get = __get_activeInHierarchy)) bool activeInHierarchy;

--- a/mods/src/prime/Hub.h
+++ b/mods/src/prime/Hub.h
@@ -1,7 +1,17 @@
+/**
+ * @file Hub.h
+ * @brief Central game singleton and section/navigation management types.
+ *
+ * Mirrors the C# Digit.Client.Core.Hub static class, which is the top-level
+ * access point for game services. Also defines SectionID (every UI screen in
+ * the game), SectionManager (navigation state machine), and supporting types
+ * like SectionStorage, SectionNavHistory, PrimeApp, and GSServiceRegistry.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/** @brief Identifies every UI section / screen in the game. Values are stable hashes from the C# enum. */
 enum class SectionID {
   ArtifactHall_Inventory                   = -2058246328,
   Alliance_Contribution                    = -2035860712,
@@ -142,8 +152,10 @@ enum class SectionID {
   Tournament_Group_Selection               = 2138751318,
 };
 
+/** @brief Provides per-section persistent state storage. */
 struct SectionStorage {
 public:
+  /** @brief Retrieve the stored state object for the given section. */
   void* GetState(SectionID section)
   {
     static auto GetStateMethod = get_class_helper().GetMethod<void*(SectionStorage*, SectionID)>("GetState");
@@ -167,8 +179,10 @@ private:
   }
 };
 
+/** @brief Tracks the back-stack of visited sections for navigation history. */
 struct SectionNavHistory {
 public:
+  /** @brief Check whether the given section exists anywhere in the history stack. */
   bool Contains(SectionID section)
   {
     static auto ContainsMethod = get_class_helper().GetMethod<bool(SectionNavHistory*, SectionID)>("Contains");
@@ -192,6 +206,7 @@ private:
   }
 };
 
+/** @brief Manages the current UI section and section transitions. */
 struct SectionManager {
 public:
   __declspec(property(get = __get_CurrentSection)) SectionID CurrentSection;
@@ -241,6 +256,7 @@ public:
   }
 };
 
+/** @brief Wrapper for the game's service registry (network, data, etc.). */
 struct GSServiceRegistry {
 private:
   static IL2CppClassHelper& get_class_helper()
@@ -250,6 +266,7 @@ private:
   }
 };
 
+/** @brief Top-level application object; owns the service registry. */
 struct PrimeApp {
   GSServiceRegistry* get_Services()
   {
@@ -265,6 +282,14 @@ private:
   }
 };
 
+/**
+ * @brief Central static game singleton (Digit.Client.Core.Hub).
+ *
+ * Provides static accessors for the section manager, application instance,
+ * and convenience queries for the current navigation state. This is the
+ * primary entry point for most mod code that needs to inspect or change
+ * the game's UI state.
+ */
 struct Hub {
   static SectionManager* get_SectionManager()
   {

--- a/mods/src/prime/HullSpec.h
+++ b/mods/src/prime/HullSpec.h
@@ -1,7 +1,16 @@
+/**
+ * @file HullSpec.h
+ * @brief Ship hull specification data.
+ *
+ * Mirrors Digit.PrimeServer.Models.HullSpec. Each ship type in the game
+ * has a HullSpec describing its ID, display name, and hull classification
+ * (destroyer, survey, explorer, etc.).
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/** @brief Ship hull classification. */
 enum class HullType {
   Any          = -1,
   Destroyer    = 0,
@@ -12,6 +21,12 @@ enum class HullType {
   ArmadaTarget = 5
 };
 
+/**
+ * @brief Specification data for a single ship hull type.
+ *
+ * Provides the hull's numeric ID (matches server data), localised display
+ * name, and classification type. Obtained via SpecService::GetHull().
+ */
 struct HullSpec {
 public:
   __declspec(property(get = __get_Id)) long Id;

--- a/mods/src/prime/KeyCode.h
+++ b/mods/src/prime/KeyCode.h
@@ -1,5 +1,13 @@
+/**
+ * @file KeyCode.h
+ * @brief Unity KeyCode enumeration.
+ *
+ * 1:1 mirror of UnityEngine.KeyCode. Used by the keyboard input handling
+ * mod to map key presses to game actions.
+ */
 #pragma once
 
+/** @brief Unity key codes. Values match UnityEngine.KeyCode exactly. */
 enum class KeyCode {
   None              = 0,
   Backspace         = 8,

--- a/mods/src/prime/NavigationManager.h
+++ b/mods/src/prime/NavigationManager.h
@@ -1,5 +1,18 @@
+/**
+ * @file NavigationManager.h
+ * @brief Navigation interaction manager.
+ *
+ * Mirrors Digit.Prime.Navigation.NavigationManager — controls the
+ * visibility of the in-space interaction UI (tap-on-object panels).
+ */
 #pragma once
 
+/**
+ * @brief Manages the navigation interaction UI overlay.
+ *
+ * Provides methods to hide the currently displayed interaction panel
+ * (e.g. the tap-on-fleet or tap-on-station popup).
+ */
 struct NavigationManager {
 public:
   void HideInteraction()

--- a/mods/src/prime/NavigationPan.h
+++ b/mods/src/prime/NavigationPan.h
@@ -1,15 +1,31 @@
+/**
+ * @file NavigationPan.h
+ * @brief Camera pan state for in-space navigation.
+ *
+ * Mirrors Digit.Prime.Navigation.NavigationPan. Exposes pan delta,
+ * tracking POI, magnetic radius ratios (for edge-pan boundaries), and
+ * the MoveCamera() method. Also defines the packed vec3 helper struct.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
 #include "Vector2.h"
 
+/** @brief Packed 3-component float vector (no padding). */
 #pragma pack(push, 1)
 struct vec3 {
   float x, y, z;
 };
 #pragma pack(pop)
 
+/**
+ * @brief Camera pan controller for the navigation scene.
+ *
+ * Provides access to pan delta values, the currently tracked point-of-interest,
+ * magnetic radius ratios that control edge-pan boundaries in system view, and
+ * a static BlockPan flag. MoveCamera() drives the actual camera translation.
+ */
 struct NavigationPan {
 public:
   __declspec(property(get = __get__lastDelta)) Vector2* _lastDelta;

--- a/mods/src/prime/NavigationZoom.h
+++ b/mods/src/prime/NavigationZoom.h
@@ -1,3 +1,12 @@
+/**
+ * @file NavigationZoom.h
+ * @brief Camera zoom state for in-space navigation.
+ *
+ * Mirrors Digit.Prime.Navigation.NavigationZoom and the NodeDepth enum.
+ * Exposes zoom distance, min/max bounds, view radius, and the scene
+ * camera reference. Used by mods that alter zoom behaviour (e.g. extended
+ * zoom range).
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
@@ -8,6 +17,7 @@
 #include "Camera.h"
 #include "NavigationPan.h"
 
+/** @brief Depth level of the current navigation view. Bit-flag style values. */
 enum class NodeDepth {
   Galaxy       = 1,
   SolarSystem  = 2,
@@ -15,6 +25,14 @@ enum class NodeDepth {
   Starbase     = 8,
 };
 
+/**
+ * @brief Camera zoom controller for the navigation scene.
+ *
+ * Provides read/write access to zoom distance, delta, min/max bounds,
+ * view radius, stored zoom ratios, and the scene camera. Also exposes
+ * SetViewParameters() and ZoomCameraAtWorldPoint() for programmatic
+ * zoom changes.
+ */
 struct NavigationZoom {
 public:
   void SetViewParameters(float radius, NodeDepth depth)

--- a/mods/src/prime/ScreenManager.h
+++ b/mods/src/prime/ScreenManager.h
@@ -1,9 +1,22 @@
+/**
+ * @file ScreenManager.h
+ * @brief Screen/display management singleton.
+ *
+ * Mirrors Digit.Client.UI.ScreenManager — a MonoSingleton that owns the
+ * root canvas scaler and provides access to canvas scale factor limits.
+ */
 #pragma once
 
 #include "CanvasController.h"
 #include "CanvasScaler.h"
 #include "MonoSingleton.h"
 
+/**
+ * @brief Manages the game's root canvas and UI scaling.
+ *
+ * Exposes the root CanvasScaler, min/max scale factors, and a method
+ * to retrieve the topmost visible canvas controller.
+ */
 struct ScreenManager : MonoSingleton<ScreenManager> {
 public:
   __declspec(property(get = __get_m_canvasRootScaler)) CanvasScaler* m_canvasRootScaler;

--- a/mods/src/prime/SpecService.h
+++ b/mods/src/prime/SpecService.h
@@ -1,8 +1,22 @@
+/**
+ * @file SpecService.h
+ * @brief Game data specification lookup service.
+ *
+ * Mirrors Digit.PrimeServer.Services.SpecService. Acts as a registry
+ * for static game data specifications (ship hulls, etc.). Mod code uses
+ * this to resolve numeric IDs into rich spec objects.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 #include "HullSpec.h"
 
+/**
+ * @brief Service for looking up static game data specifications.
+ *
+ * Currently exposes GetHull() to resolve a hull ID to its HullSpec.
+ * The service instance is typically obtained from the game's service registry.
+ */
 struct SpecService {
 public:
   HullSpec* GetHull(long hullId)

--- a/mods/src/prime/Toast.h
+++ b/mods/src/prime/Toast.h
@@ -1,7 +1,15 @@
+/**
+ * @file Toast.h
+ * @brief Toast notification data and state enumeration.
+ *
+ * Mirrors Digit.Prime.HUD.Toast — the in-game popup notifications for
+ * battles, faction events, armada status, territory capture, etc.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/** @brief Identifies the visual style / category of a toast notification. */
 enum ToastState {
   Standard                  = 0,
   FactionWarning            = 1,
@@ -48,6 +56,12 @@ enum ToastState {
   SurgeTimeLeft             = 43,
 };
 
+/**
+ * @brief A single toast notification displayed in the HUD.
+ *
+ * Provides access to the notification's locale text context, attached data
+ * payload, and display state (e.g. victory, defeat, incoming attack).
+ */
 struct Toast {
 public:
   void* get_TextLocaleTextContext()

--- a/mods/src/prime/Transform.h
+++ b/mods/src/prime/Transform.h
@@ -1,9 +1,17 @@
+/**
+ * @file Transform.h
+ * @brief Unity Transform wrapper.
+ *
+ * Mirrors UnityEngine.Transform. Exposes the localScale property for
+ * reading and writing via IL2CPP reflection.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
 #include "Vector3.h"
 
+/** @brief Wrapper for Unity's Transform component (position, rotation, scale). */
 struct Transform {
   __declspec(property(get = __get_LocalScale, put = __set_LocalScale)) Vector3* localScale;
 

--- a/mods/src/prime/UserProfile.h
+++ b/mods/src/prime/UserProfile.h
@@ -1,7 +1,20 @@
+/**
+ * @file UserProfile.h
+ * @brief Player profile data.
+ *
+ * Mirrors Digit.PrimeServer.Models.UserProfile. Provides the player's
+ * location ID and display name, used in battle reports and UI displays.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/**
+ * @brief Profile data for a game player.
+ *
+ * Contains the player's server-side location ID and their display name.
+ * Typically retrieved from BattleResultHeader or other combat data.
+ */
 struct UserProfile {
 public:
   __declspec(property(get = __get_LocaId)) long LocaId;

--- a/mods/src/prime/ViewController.h
+++ b/mods/src/prime/ViewController.h
@@ -1,7 +1,24 @@
+/**
+ * @file ViewController.h
+ * @brief Base view controller template.
+ *
+ * Mirrors the generic Digit.Client.UI.ViewController<T> base class.
+ * Provides access to the canvas context (the data model backing the view).
+ * Concrete view controllers inherit from this via CRTP.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/**
+ * @brief Generic base for game view controllers.
+ *
+ * Resolves the ViewController`1 parent class from the concrete subclass Y's
+ * class helper, and exposes the CanvasContext property typed as T*.
+ *
+ * @tparam T The context/data-model type for this view.
+ * @tparam Y The concrete derived class (CRTP), must expose get_class_helper().
+ */
 template <typename T, typename Y> struct ViewController {
 public:
   __declspec(property(get = __get_CanvasContext)) T* CanvasContext;

--- a/mods/src/prime/Widget.h
+++ b/mods/src/prime/Widget.h
@@ -1,7 +1,24 @@
+/**
+ * @file Widget.h
+ * @brief Base widget template.
+ *
+ * Mirrors the generic Digit.Client.UI.Widget<T> base class. Exposes the
+ * widget context, enabled state, and IsActive() check. Concrete widgets
+ * inherit from this via CRTP.
+ */
 #pragma once
 
 #include <il2cpp/il2cpp_helper.h>
 
+/**
+ * @brief Generic base for game UI widgets.
+ *
+ * Resolves the Widget`1 parent class from the concrete subclass Y's
+ * class helper, and exposes Context, enabled, and isActiveAndEnabled.
+ *
+ * @tparam T The context/data-model type.
+ * @tparam Y The concrete derived class (CRTP), must expose get_class_helper().
+ */
 template <typename T, typename Y> struct Widget {
 public:
   __declspec(property(get = __get_Context)) T* Context;

--- a/mods/src/prime_types.h
+++ b/mods/src/prime_types.h
@@ -1,7 +1,16 @@
+/**
+ * @file prime_types.h
+ * @brief Forward declarations and layout definitions for key game types.
+ *
+ * Defines Faction, BuffCondition enums and the SpecManager vtable layout
+ * used to call into the game's IL2CPP runtime.  Struct layouts use
+ * #pragma pack(push, 1) to match the game's memory layout exactly.
+ */
 #pragma once
 
 #include <cstdint>
 
+/// In-game faction identifiers.
 enum Faction
 {
     None = -1,
@@ -16,7 +25,9 @@ struct HullSpec;
 class SpecManager;
 using GetHull_t = HullSpec *(*)(SpecManager *_this, uint64_t, void *);
 
+// IL2CPP: Packed to match the game's vtable layout exactly.
 #pragma pack(push, 1)
+/** @brief Vtable layout for SpecManager, positioned so GetHull is at offset 0x1C8. */
 struct SpecManagerVtbl
 {
     char pad0[0x1C8];
@@ -35,6 +46,13 @@ public:
 #pragma pack(pop)
 
 
+/**
+ * @brief Buff condition IDs used by the game's combat/buff system.
+ *
+ * These values are hard-coded in the game binary and correspond to
+ * specific combat triggers, hull checks, and status effects.
+ * Many IDs have gaps — presumably server-only or deprecated conditions.
+ */
 enum BuffCondition
 {
     Invalid = -1,

--- a/mods/src/str_utils.h
+++ b/mods/src/str_utils.h
@@ -1,3 +1,13 @@
+/**
+ * @file str_utils.h
+ * @brief String utilities: whitespace stripping, case conversion, splitting,
+ *        and cross-platform IL2CPP string conversion.
+ *
+ * Provides helpers to convert between IL2CPP's Il2CppString (UTF-16 on
+ * Windows, UTF-32 on macOS/Linux), std::wstring, and std::string (UTF-8).
+ * Uses simdutf for fast SIMD-accelerated encoding conversion on non-Windows
+ * platforms; on Windows, delegates to WinRT / WideCharToMultiByte.
+ */
 #pragma once
 
 #include <algorithm>
@@ -12,6 +22,7 @@
 #include <winrt/base.h>
 #endif
 
+/** @brief Fast ASCII-only whitespace check (avoids locale-dependent UB on signed char). */
 inline bool ascii_isspace(unsigned char c)
 {
   return std::isspace(static_cast<unsigned char>(c));
@@ -41,6 +52,10 @@ constexpr std::string AsciiStrToUpper(const std::string_view s)
   return str;
 }
 
+/**
+ * @brief Split @p input on @p delimiter, trimming trailing whitespace from the last element.
+ * @note Empty segments between consecutive delimiters are skipped.
+ */
 constexpr std::vector<std::string> StrSplit(const std::string& input, const char delimiter)
 {
   std::vector<std::string> result;
@@ -67,6 +82,11 @@ constexpr std::vector<std::string> StrSplit(const std::string& input, const char
   return result;
 }
 
+// ─── IL2CPP / Platform String Conversions ───────────────────────────────────────
+// IL2CPP: wchar_t is UTF-16 on Windows, UTF-32 on macOS/Linux.
+// These overloads abstract that difference using simdutf on non-Windows.
+
+/** @brief Convert a UTF-8 std::string to std::wstring (platform-aware encoding). */
 inline std::wstring to_wstring(const std::string& str)
 {
 #if _WIN32
@@ -79,6 +99,7 @@ inline std::wstring to_wstring(const std::string& str)
 #endif
 }
 
+/** @brief Convert an IL2CPP string to std::wstring. */
 inline std::wstring to_wstring(Il2CppString* str)
 {
 #if _WIN32
@@ -91,6 +112,7 @@ inline std::wstring to_wstring(Il2CppString* str)
 #endif
 }
 
+/** @brief Convert std::wstring to UTF-8 std::string. */
 inline std::string to_string(const std::wstring& str)
 {
 #if _WIN32
@@ -106,6 +128,7 @@ inline std::string to_string(const std::wstring& str)
 #endif
 }
 
+/** @brief Convert an IL2CPP string to UTF-8 std::string (convenience overload). */
 inline std::string to_string(Il2CppString* str)
 {
   const auto s = to_wstring(str);

--- a/mods/src/titlelinux.h
+++ b/mods/src/titlelinux.h
@@ -1,3 +1,10 @@
+/**
+ * @file titlelinux.h
+ * @brief Linux (X11) implementation of WindowTitle::Get() and Set().
+ *
+ * Reads/writes _NET_WM_NAME on the root window via Xlib.  Compiled only
+ * on non-Windows, non-Apple targets.
+ */
 #pragma once
 #ifdef _WIN32
 #elif defined(__APPLE__)

--- a/mods/src/titlewindows.h
+++ b/mods/src/titlewindows.h
@@ -1,3 +1,10 @@
+/**
+ * @file titlewindows.h
+ * @brief Windows implementation of WindowTitle::Get() and Set() via Win32 API.
+ *
+ * Uses Config::WindowHandle() to locate the game's top-level HWND, then
+ * GetWindowTextW / SetWindowTextW to read/write the title bar.
+ */
 #pragma once
 
 #ifdef _WIN32

--- a/mods/src/version.h
+++ b/mods/src/version.h
@@ -1,3 +1,10 @@
+/**
+ * @file version.h
+ * @brief Compile-time version constants and PE resource macros.
+ *
+ * VERSION_MAJOR/MINOR/REVISION/PATCH are substituted by the build system
+ * (see docs/VERSION_SUBSTITUTION.md).  VERSION_PATCH > 0 marks a beta build.
+ */
 #pragma once
 
 // clang-format off

--- a/mods/src/windowtitle.h
+++ b/mods/src/windowtitle.h
@@ -1,11 +1,24 @@
+/**
+ * @file windowtitle.h
+ * @brief Platform-agnostic interface for reading and setting the game window title.
+ *
+ * The struct declares Get() and Set(); platform-specific inline implementations
+ * live in titlewindows.h (Win32 API), titlelinux.h (X11), and are stubbed on macOS.
+ */
 #pragma once
 #include <string>
 
+/**
+ * @brief Platform-dispatched window title accessor.
+ *
+ * Inline implementations are conditionally included from titlewindows.h
+ * (Win32), titlelinux.h (X11).  macOS is currently stubbed.
+ */
 struct WindowTitle {
-  // Get the window title
+  /** @brief Read the current game window title. Returns empty on failure. */
   static std::wstring Get();
 
-  // Set the window title
+  /** @brief Set the game window title. Returns false on failure. */
   static bool Set(const std::wstring& title);
 };
 

--- a/mods/xmake.lua
+++ b/mods/xmake.lua
@@ -1,3 +1,10 @@
+-- @file xmake.lua
+-- @brief Build target for the "mods" static library.
+--
+-- Compiles all patch logic (C++ sources, protobuf definitions) into a static
+-- library consumed by both the Windows proxy DLL and the macOS dylib targets.
+-- Platform-specific flags handle bigobj on MSVC and Objective-C++ on macOS.
+
 target("mods")
 do
     add_ldflags("-v")

--- a/win-proxy-dll/src/main.cc
+++ b/win-proxy-dll/src/main.cc
@@ -1,3 +1,13 @@
+/**
+ * @file main.cc
+ * @brief Windows DLL entry point for the STFC community patch.
+ *
+ * This module is compiled as version.dll and placed in the game directory.
+ * Windows loads it as a DLL proxy: the game thinks it is the real version.dll,
+ * but DllMain bootstraps the patch (forwarding real version API calls to the
+ * system DLL via VersionDllInit, then applying mod hooks via ApplyPatches).
+ */
+
 #include <Windows.h>
 
 #include <filesystem>
@@ -6,6 +16,16 @@
 
 void VersionDllInit();
 
+/**
+ * @brief DLL entry point — bootstraps the community patch on process attach.
+ *
+ * Only activates when the host executable name starts with "prime" (the STFC
+ * game binary). Loads the real system version.dll forwards, then applies all
+ * mod patches.
+ *
+ * @param hinstDLL  Handle to this DLL instance.
+ * @param fdwReason Reason the entry point was called (attach/detach).
+ */
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID /*lpReserved*/)
 {
   std::filesystem::path game_path;
@@ -36,6 +56,10 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID /*lpReserved*/)
   }
   return TRUE;
 }
+
+// ─── EASTL operator new[] Overloads ──────────────────────────────────────────
+// EASTL requires custom operator new[] with extended signatures for its
+// allocator. These forward to malloc, satisfying the linker.
 
 void* operator new[](size_t size, const char* /*name*/, int /*flags*/, unsigned /*debugFlags*/, const char* /*file*/,
                      int /*line*/)

--- a/win-proxy-dll/src/version.cc
+++ b/win-proxy-dll/src/version.cc
@@ -1,4 +1,17 @@
+/**
+ * @file version.cc
+ * @brief Proxy stubs for every export of the real system version.dll.
+ *
+ * Each function is a thin pass-through: it stores the original proc address
+ * (resolved by VersionDllInit) in a global function pointer, and the exported
+ * wrapper simply forwards all arguments.  This lets the game (and anything
+ * else that links version.dll) work normally while our DllMain in main.cc
+ * gets early process-attach execution.
+ */
+
 #include <Windows.h>
+
+// ─── Forwarded version.dll Exports ───────────────────────────────────────────
 
 typedef DWORD(WINAPI *ORIG_FUNCTION_VerFindFileA)(DWORD, LPCSTR, LPCSTR, LPCSTR, LPSTR, PUINT, LPSTR, PUINT);
 ORIG_FUNCTION_VerFindFileA orig_VerFindFileA;
@@ -165,6 +178,13 @@ void WINAPI                              GetFileVersionInfoByHandle()
   (orig_GetFileVersionInfoByHandle)();
 }
 
+// ─── Initialization ──────────────────────────────────────────────────────────
+
+/**
+ * @brief Loads the real system version.dll and resolves all original exports.
+ *
+ * Called once from DllMain on DLL_PROCESS_ATTACH, before ApplyPatches.
+ */
 void VersionDllInit()
 {
   HMODULE hOriginalDll = LoadLibraryW(L"C:\\Windows\\system32\\version.dll");

--- a/win-proxy-dll/xmake.lua
+++ b/win-proxy-dll/xmake.lua
@@ -1,3 +1,10 @@
+-- @file xmake.lua
+-- @brief Build target for the Windows version.dll proxy (shared library).
+--
+-- Produces stfc-community-patch.dll, which is deployed as version.dll beside
+-- the game executable.  Links the "mods" static library and exports the real
+-- version.dll symbols via version.def so the game's import table is satisfied.
+
 target("stfc-community-patch")
 do
     set_kind("shared")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,8 +1,20 @@
+-- @file xmake.lua
+-- @brief Root build configuration for the STFC community patch.
+--
+-- Declares project-wide settings (C++23, static runtime, dependencies),
+-- conditionally includes platform-specific targets (win-proxy-dll on Windows,
+-- macos-dylib / macos-loader / macos-launcher on macOS), and pulls in the
+-- shared "mods" static library that contains all patch logic.
+
+-- ─── Project Settings ────────────────────────────────────────────────────────
+
 set_project("stfc-community-patch")
 
 set_languages("c++23")
 
 set_runtimes("MT") -- Set the default build to multi-threaded static
+
+-- ─── Third-Party Dependencies ────────────────────────────────────────────────
 
 add_requires("eastl")
 add_requires("spdlog")
@@ -11,6 +23,8 @@ add_requires("nlohmann_json")
 add_requires("cpr")
 add_requireconfs("cpr.libcurl", { configs = { zlib = true } })
 add_requires("protobuf 32.1")
+
+-- ─── Platform-Specific Targets & Dependencies ────────────────────────────────
 
 if is_plat("windows") then
     includes("win-proxy-dll")
@@ -27,9 +41,13 @@ if is_plat("macosx") then
     includes("macos-launcher")
 end
 
+-- ─── Build Modes ─────────────────────────────────────────────────────────────
+
 add_rules("mode.debug")
 add_rules("mode.release")
 add_rules("mode.releasedbg")
+
+-- ─── Local / Vendored Packages ───────────────────────────────────────────────
 
 package("libil2cpp")
 on_fetch(function(package, opt)
@@ -41,8 +59,12 @@ add_requires("spud v0.2.0-2")
 add_requires("libil2cpp")
 add_requires("simdutf", { system = false })
 
+-- ─── Sub-Targets ─────────────────────────────────────────────────────────────
+
 -- includes("launcher")
 includes("mods")
+
+-- ─── Package Repositories ────────────────────────────────────────────────────
 
 -- add_repositories("local-repo build")
 add_repositories("stfc-community-patch-repo xmake-packages")


### PR DESCRIPTION
## What

Comprehensive documentation sweep across 86 source files. Adds file headers, function docblocks, section markers, and inline comments. **Zero behavior changes** — documentation only.

Closes #6

## Why

1. **Remove technical/institutional debt** — The codebase had grown with minimal documentation. Hook patterns, config propagation, the key dispatch pipeline, IL2CPP integration patterns — none of it was documented.
2. **Learn the system** — This sweep doubled as a deep audit. Every module was read fresh by an independent reviewer to avoid assumption contamination.

## How

### Style Conventions Established
- **Doxygen-compatible**: `@file`, `@brief`, `@param`, `@return`, `@note`
- **IL2CPP hook pattern**: Every hook documents what game method it intercepts, what the original does, and what the mod changes
- **Section markers**: `// ─── Section Name ───` for files >100 lines
- **Config key docs**: Default value, valid range, and user-facing effect
- **Enum docs**: `///< Brief description` for non-obvious values

### Coverage by Module Group

| Module Group | Files | Key Additions |
|---|---|---|
| Core infrastructure | config.*, file.*, str_utils, errormsg, version | Class/struct docblocks, config key defaults, platform notes |
| Small patch modules | patches.cc + 10 parts/*.cc files | Hook pattern docs (game method → mod behavior), Install*Hooks docs |
| Large patch modules | hotkeys.cc, sync.cc, object_tracker.cc, ui_scale.cc, zoom.cc | Section markers, threading/safety notes (sync.cc), ASCII architecture diagram (sync.cc) |
| Higher-level patches | hotkey_dispatch/router, notification_service, battle_notify_parser, navigation, cargo_display, fleet_actions, viewer_mgmt | All .h + .cc pairs: file headers, function docs, section markers |
| Input system | key, mapkey, modifierkey, gamefunctions | Design relationship docs, 14 section markers in gamefunctions.h, config syntax examples |
| IL2CPP layer | il2cpp-functions, il2cpp_helper | X-macro pattern doc, template parameter docs, all 20+ helper methods documented |
| Prime wrappers | 23 key headers (Hub, Toast, ScreenManager, NavigationZoom, etc.) | File headers + struct-level docs explaining game object relationships |
| Platform entry points | win-proxy-dll, macos-dylib, macos-loader | DLL proxy concept, DYLD injection, CLI loader flow |
| Build system | 6 xmake.lua files | File headers, section markers for dependency groups |
| CI workflows | ci.yaml, release.yaml | File headers describing workflow purpose and triggers |

### Stats
- **86 files** modified
- **+2,607 lines** added / **-173 lines** removed (existing comments upgraded)
- **Build verified**: compiles clean on Windows (41.8s)

### NOT in scope
- No behavior changes, no refactoring
- Third-party code (third_party/, libil2cpp/) untouched
- Auto-generated files (compile_commands.json, vsxmake2022/) untouched
- ~120 remaining prime/ headers not in the "key 23" — they're mostly small IL2CPP stubs