### PR TITLE
Add fleet-bar arrival notifications

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -564,6 +564,7 @@ void Config::Load()
   this->installResolutionListFix = get_config_or_default(config, parsed, "patches", "resolutionlistfix", DCP::resolutionlistfix, write_config);
   this->installSyncPatches       = get_config_or_default(config, parsed, "patches", "syncpatches", DCP::syncpatches, write_config);
   this->installObjectTracker     = get_config_or_default(config, parsed, "patches", "objecttracker", DCP::objecttracker, write_config);
+  this->installFleetArrivalHooks = get_config_or_default(config, parsed, "patches", "fleetarrivalhooks", DCP::fleetarrivalhooks, write_config);
   spdlog::debug("");
 #else
   this->installUiScaleHooks               = true;
@@ -581,6 +582,7 @@ void Config::Load()
   this->installResolutionListFix          = true;
   this->installSyncPatches                = true;
   this->installObjectTracker              = true;
+  this->installFleetArrivalHooks          = true;
 #endif
   
   this->queue_enabled       = get_config_or_default(config, parsed, "control", "queue_enabled", DCC::queue_enabled, write_config);

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -258,6 +258,7 @@ public:
   bool installResolutionListFix;
   bool installSyncPatches;
   bool installObjectTracker;
+  bool installFleetArrivalHooks;
 
   std::string config_settings_url;
   std::string config_assets_url_override;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -90,6 +90,7 @@ namespace Patches
   constexpr bool improveresponsivenesshooks = true;  ///< Input-responsiveness improvements.
   constexpr bool miscpatches                = true;  ///< Misc one-off fixes.
   constexpr bool objecttracker              = true;  ///< In-system object tracking overlay.
+  constexpr bool fleetarrivalhooks          = true;  ///< Fleet arrival detection from the bottom fleet bar.
   constexpr bool panhooks                   = true;  ///< Pan-momentum hooks.
   constexpr bool resolutionlistfix          = true;  ///< Resolution-list population fix.
   constexpr bool syncpatches                = true;  ///< Data-sync network hooks.

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -30,6 +30,7 @@
 
 /** Cached LanguageManager::Localize(out string, LocaleTextContext) method pointer. */
 static const MethodInfo* s_localize_ltc = nullptr;
+static bool              s_notification_initialized = false;
 
 // ─── Toast State → Human-Readable Title ───────────────────────────────────────────────
 
@@ -162,6 +163,10 @@ static std::string strip_unity_rich_text(const std::string& s)
 
 void notification_init()
 {
+  if (s_notification_initialized) {
+    return;
+  }
+
   // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
   // 2-parameter overload that takes an LTC and returns a localized string.
   auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
@@ -190,6 +195,15 @@ void notification_init()
   spdlog::info("[Notify] Windows notification service initialized");
 #else
   spdlog::info("[Notify] Notification service: platform not supported (no-op)");
+#endif
+
+  s_notification_initialized = true;
+}
+
+void notification_show(const char* title, const char* body)
+{
+#if _WIN32
+  show_system_notification(title, body);
 #endif
 }
 

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -30,3 +30,13 @@ void notification_init();
  * @param toast The game Toast object from the hooked banner display method.
  */
 void notification_handle_toast(Toast* toast);
+
+/**
+ * @brief Send an arbitrary OS-native notification with the given title and body.
+ *
+ * Requires notification_init() to have been called first. No-op on non-Windows.
+ *
+ * @param title Notification title text.
+ * @param body  Notification body text.
+ */
+void notification_show(const char* title, const char* body);

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -1,0 +1,141 @@
+/**
+ * @file fleet_arrival.cc
+ * @brief Fleet arrival detection driven by the bottom fleet bar state widgets.
+ *
+ * Hooks FleetStateWidget::SetWidgetData and watches FleetPlayerData state
+ * transitions. The most useful arrival signal is Warping -> Impulsing, which
+ * means the ship has dropped out of warp and entered the destination system.
+ */
+#include "errormsg.h"
+
+#include <hook/hook.h>
+#include <il2cpp/il2cpp_helper.h>
+
+#include <patches/notification_service.h>
+#include <prime/FleetPlayerData.h>
+
+#include <spdlog/spdlog.h>
+#include <str_utils.h>
+
+#include <string_view>
+#include <unordered_map>
+
+static std::unordered_map<uint64_t, FleetState> s_fleet_bar_states;
+
+static const char* fleet_bar_state_str(FleetState state)
+{
+  switch (state) {
+    case FleetState::Unknown:      return "Unknown";
+    case FleetState::IdleInSpace:  return "IdleInSpace";
+    case FleetState::Docked:       return "Docked";
+    case FleetState::Mining:       return "Mining";
+    case FleetState::Destroyed:    return "Destroyed";
+    case FleetState::TieringUp:    return "TieringUp";
+    case FleetState::Repairing:    return "Repairing";
+    case FleetState::Battling:     return "Battling";
+    case FleetState::WarpCharging: return "WarpCharging";
+    case FleetState::Warping:      return "Warping";
+    case FleetState::Impulsing:    return "Impulsing";
+    case FleetState::Capturing:    return "Capturing";
+    default:                       return "Composite";
+  }
+}
+
+static std::string fleet_bar_ship_name(FleetPlayerData* fleet)
+{
+  auto* hull = fleet ? fleet->Hull : nullptr;
+  auto  name = (hull && hull->Name) ? to_string(hull->Name) : std::string{"?"};
+
+  constexpr std::string_view live_suffix = "_LIVE";
+  if (name.size() >= live_suffix.size() &&
+      name.compare(name.size() - live_suffix.size(), live_suffix.size(), live_suffix) == 0) {
+    name.erase(name.size() - live_suffix.size());
+  }
+
+  for (auto& ch : name) {
+    if (ch == '_') {
+      ch = ' ';
+    }
+  }
+
+  return name;
+}
+
+static FleetPlayerData* fleet_bar_widget_context(void* self)
+{
+  if (!self) {
+    return nullptr;
+  }
+
+  auto helper      = IL2CppClassHelper{((Il2CppObject*)self)->klass};
+  auto get_context = helper.GetMethod<FleetPlayerData*(void*)>("get_Context", 0);
+  return get_context ? get_context(self) : nullptr;
+}
+
+static void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName,
+                                              FleetState oldState, FleetState newState)
+{
+  if (oldState == FleetState::Warping && newState == FleetState::Impulsing) {
+    auto body = "Your " + shipName + " has arrived in-system";
+    spdlog::info("[FleetBar] ARRIVED_IN_SYSTEM id={} ship='{}'", fleetId, shipName);
+    notification_show("Fleet Arrived", body.c_str());
+    return;
+  }
+
+  if (oldState == FleetState::Impulsing && newState == FleetState::IdleInSpace) {
+    spdlog::info("[FleetBar] ARRIVED_AT_DESTINATION id={} ship='{}'", fleetId, shipName);
+    return;
+  }
+
+  if (oldState == FleetState::Warping && newState == FleetState::Docked) {
+    spdlog::info("[FleetBar] DOCKED_AFTER_WARP id={} ship='{}'", fleetId, shipName);
+  }
+}
+
+typedef void (*FleetStateWidget_SetWidgetData_fn)(void*);
+static FleetStateWidget_SetWidgetData_fn FleetStateWidget_SetWidgetData_original = nullptr;
+
+static void FleetStateWidget_SetWidgetData_Hook(void* self)
+{
+  auto* fleet = fleet_bar_widget_context(self);
+  if (fleet) {
+    auto fleetId      = fleet->Id;
+    auto currentState = fleet->CurrentState;
+    auto shipName     = fleet_bar_ship_name(fleet);
+
+    auto it = s_fleet_bar_states.find(fleetId);
+    if (it == s_fleet_bar_states.end()) {
+      spdlog::info("[FleetBar] SetWidgetData snapshot id={} ship='{}' state={}({})",
+                   fleetId, shipName, fleet_bar_state_str(currentState), (int)currentState);
+    } else if (it->second != currentState) {
+      spdlog::info("[FleetBar] SetWidgetData state id={} ship='{}' {}({}) -> {}({})",
+                   fleetId, shipName,
+                   fleet_bar_state_str(it->second), (int)it->second,
+                   fleet_bar_state_str(currentState), (int)currentState);
+      maybe_notify_fleet_bar_transition(fleetId, shipName, it->second, currentState);
+    }
+
+    s_fleet_bar_states[fleetId] = currentState;
+  }
+
+  FleetStateWidget_SetWidgetData_original(self);
+}
+
+void InstallFleetArrivalHooks()
+{
+  notification_init();
+
+  auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
+  if (!fleet_state_widget.isValidHelper()) {
+    ErrorMsg::MissingHelper("Digit.Prime.HUD", "FleetStateWidget");
+    return;
+  }
+
+  auto set_widget_data = fleet_state_widget.GetMethod("SetWidgetData");
+  if (set_widget_data == nullptr) {
+    ErrorMsg::MissingMethod("FleetStateWidget", "SetWidgetData");
+    return;
+  }
+
+  mh_install(set_widget_data, (void*)FleetStateWidget_SetWidgetData_Hook, (void**)&FleetStateWidget_SetWidgetData_original);
+}

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -49,6 +49,7 @@ void InstallResolutionListFix();
 void InstallTempCrashFixes();
 void InstallSyncPatches();
 void InstallObjectTrackers();
+void InstallFleetArrivalHooks();
 
 /**
  * @brief Hook: il2cpp_init
@@ -144,6 +145,7 @@ __int64 il2cpp_init_hook(const char* domain_name)
       {"ResolutionListFix", {InstallResolutionListFix, &cfg.installResolutionListFix}},
       {"SyncPatches", {InstallSyncPatches, &cfg.installSyncPatches}},
       {"ObjectTracker", {InstallObjectTrackers, &cfg.installObjectTracker}},
+        {"FleetArrival", {InstallFleetArrivalHooks, &cfg.installFleetArrivalHooks}},
   };
   printf("il2cpp_init_hook(%s)\n", domain_name);
 


### PR DESCRIPTION
Adds a dedicated FleetArrival patch driven by bottom fleet bar state transitions instead of system-view events.

What changed:
- hook `FleetStateWidget::SetWidgetData`
- detect `Warping -> Impulsing` as the primary `arrived in system` signal
- log `ARRIVED_IN_SYSTEM` and keep `ARRIVED_AT_DESTINATION` as observational follow-up data
- wire the feature behind a dedicated `FleetArrival` patch/config entry

Why:
System-view hooks only reflected fleets in viewed systems and produced false confidence. The fleet bar updates globally for the player's fleet roster and provides the reliable signal we actually want.

Validation:
- built with `xmake build mods`
- verified in-game via `[FleetBar] ARRIVED_IN_SYSTEM ...` log lines
- user also observed the Windows toast once desktop notification settings were fixed

Closes #13
Follow-up: #12