### PR TITLE
Fix PlatformInvoke CodeQL string-type casts

### DIFF
--- a/third_party/libil2cpp/vm/PlatformInvoke.cpp
+++ b/third_party/libil2cpp/vm/PlatformInvoke.cpp
@@ -207,7 +207,7 @@ namespace vm
             if (currentBuilder == NULL)
                 break;
 
-            const Il2CppChar *str = (Il2CppChar*)il2cpp::vm::Array::GetFirstElementAddress(currentBuilder->chunkChars);
+            const Il2CppChar* str = il2cpp_array_addr(currentBuilder->chunkChars, Il2CppChar, 0);
             std::string utf8String = utils::StringUtils::Utf16ToUtf8(str, (int)currentBuilder->chunkChars->max_length);
 
             utf8Chunks.push_back(utf8String);
@@ -308,7 +308,7 @@ namespace vm
                 if (currentBuilder == NULL)
                     break;
 
-                const Il2CppChar *str = (Il2CppChar*)il2cpp::vm::Array::GetFirstElementAddress(currentBuilder->chunkChars);
+                const Il2CppChar* str = il2cpp_array_addr(currentBuilder->chunkChars, Il2CppChar, 0);
 
                 memcpy(nativeString + currentBuilder->chunkOffset, str, (int)currentBuilder->chunkChars->max_length * sizeof(Il2CppChar));
 


### PR DESCRIPTION
## Summary
Use the typed IL2CPP array accessor in `PlatformInvoke` instead of casting `Array::GetFirstElementAddress()` from `char *` to `Il2CppChar *`.

This resolves the two open CodeQL `cpp/incorrect-string-type-conversion` alerts in the checked-in mod code without pulling the separate `PLzmaSDK` submodule work into this PR.

## Changes
- replace the two `GetFirstElementAddress()` casts in `third_party/libil2cpp/vm/PlatformInvoke.cpp`
- use `il2cpp_array_addr(..., Il2CppChar, 0)` at both UTF-16 builder access sites
- keep the rest of the marshaling logic unchanged

## Validation
- `xmake -P .`

Fixes #17