### PR TITLE
Split hotkey fallthrough policies

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -93,6 +93,17 @@ use_scopely_hotkeys = false
 # Enable experimental features
 enable_experimental = false
 
+# Subgroup: Input
+# -----------------
+
+[input]
+
+# Scopely shortcut initialization policy: off, native, or fallback
+scopely_shortcuts = "off"
+
+# Original ScreenManager frame policy: mod, fallthrough_unhandled, or fallthrough_all
+original_frame_policy = "mod"
+
 #  <[============================================================]>
 #
 #        ****                       *        *

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -49,6 +49,8 @@ static_assert(!DCS::allow_unsafe_tls_without_certificate_validation,
 // Standalone flag — NOT in Config struct to avoid struct layout sensitivity.
 // See: fix/lto-and-sync-crashes for context on why Config struct changes crash.
 static bool g_allow_key_fallthrough          = false;
+static ScopelyShortcutPolicy g_scopely_shortcuts_policy = ScopelyShortcutPolicy::Off;
+static OriginalFramePolicy   g_original_frame_policy    = OriginalFramePolicy::Mod;
 static bool g_live_debug_channel             = false;
 static bool g_battle_log_decoder_enabled     = false;
 static bool g_battle_log_decoder_segments    = true;
@@ -60,6 +62,12 @@ static bool g_mod_impact_monitor             = DCD::mod_impact_monitor;
 /** @brief Accessor for the file-scope allow_key_fallthrough flag. */
 bool AllowKeyFallthrough()
 { return g_allow_key_fallthrough; }
+
+ScopelyShortcutPolicy ScopelyShortcutsPolicy()
+{ return g_scopely_shortcuts_policy; }
+
+OriginalFramePolicy OriginalFramePolicySetting()
+{ return g_original_frame_policy; }
 
 bool LiveDebugChannelEnabled()
 { return g_live_debug_channel; }
@@ -601,6 +609,74 @@ std::optional<bool> read_bool_config_value_if_present(toml::table& config, std::
   return std::nullopt;
 }
 
+std::optional<std::string> read_string_config_value_if_present(toml::table& config,
+                                                               std::string_view section,
+                                                               std::string_view key,
+                                                               std::string_view docs)
+{
+  auto* section_table = config[section].as_table();
+  if (!section_table || !section_table->contains(key)) {
+    return std::nullopt;
+  }
+
+  auto* node = section_table->get(key);
+  if (!node) {
+    return std::nullopt;
+  }
+
+  if (auto value = node->value<std::string>(); value.has_value()) {
+    return value.value();
+  }
+
+  spdlog::warn("Invalid string config [{}].{} ({}). Found {}; using default.", section, key,
+               docs.empty() ? "string setting" : docs, get_config_type_as_string(node->type()));
+  return std::nullopt;
+}
+
+std::optional<ScopelyShortcutPolicy> parse_scopely_shortcut_policy(std::string_view value)
+{
+  if (value == "off") {
+    return ScopelyShortcutPolicy::Off;
+  }
+
+  if (value == "native") {
+    return ScopelyShortcutPolicy::Native;
+  }
+
+  if (value == "fallback") {
+    return ScopelyShortcutPolicy::Fallback;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<OriginalFramePolicy> parse_original_frame_policy(std::string_view value)
+{
+  if (value == "mod") {
+    return OriginalFramePolicy::Mod;
+  }
+
+  if (value == "fallthrough_unhandled") {
+    return OriginalFramePolicy::FallthroughUnhandled;
+  }
+
+  if (value == "fallthrough_all") {
+    return OriginalFramePolicy::FallthroughAll;
+  }
+
+  return std::nullopt;
+}
+
+void write_input_policy_config(toml::table& new_config,
+                               const ScopelyShortcutPolicy scopely_shortcuts,
+                               const OriginalFramePolicy original_frame_policy)
+{
+  new_config.emplace<toml::table>("input", toml::table());
+  auto* input = new_config["input"].as_table();
+  input->insert_or_assign("scopely_shortcuts", scopely_shortcut_policy_name(scopely_shortcuts));
+  input->insert_or_assign("original_frame_policy", original_frame_policy_name(original_frame_policy));
+}
+
 bool read_bool_config_entry(toml::table& config, toml::table& new_config, std::string_view section,
                             std::string_view key, std::string_view runtime_key, bool default_value,
                             std::string_view docs, bool write_log)
@@ -1065,14 +1141,52 @@ void Config::Load()
       get_config_or_default(config, parsed, "control", "enable_experimental", DCC::enable_experimental, write_config);
 
   g_allow_key_fallthrough = read_bool_config_entry(config, parsed, kAllowKeyFallthroughConfig, write_config);
+  g_scopely_shortcuts_policy = resolve_scopely_shortcut_policy(this->use_scopely_hotkeys, g_allow_key_fallthrough);
+  g_original_frame_policy    = resolve_original_frame_policy(g_allow_key_fallthrough);
+
+  const auto explicit_scopely_policy = config_key_exists(config, "input", "scopely_shortcuts");
+  if (auto policy_value = read_string_config_value_if_present(config,
+                                                              "input",
+                                                              "scopely_shortcuts",
+                                                              "Scopely shortcut initialization policy.")) {
+    if (auto policy = parse_scopely_shortcut_policy(*policy_value)) {
+      g_scopely_shortcuts_policy = *policy;
+    } else {
+      spdlog::warn("Invalid string config [input].scopely_shortcuts value='{}'; expected off, native, or fallback. "
+                   "Using {}.",
+                   *policy_value,
+                   scopely_shortcut_policy_name(g_scopely_shortcuts_policy));
+    }
+  }
+
+  const auto explicit_frame_policy = config_key_exists(config, "input", "original_frame_policy");
+  if (auto policy_value = read_string_config_value_if_present(config,
+                                                              "input",
+                                                              "original_frame_policy",
+                                                              "Original ScreenManager::Update call policy.")) {
+    if (auto policy = parse_original_frame_policy(*policy_value)) {
+      g_original_frame_policy = *policy;
+    } else {
+      spdlog::warn("Invalid string config [input].original_frame_policy value='{}'; expected mod, "
+                   "fallthrough_unhandled, or fallthrough_all. Using {}.",
+                   *policy_value,
+                   original_frame_policy_name(g_original_frame_policy));
+    }
+  }
+
+  write_input_policy_config(parsed, g_scopely_shortcuts_policy, g_original_frame_policy);
 
   spdlog::info(
-      "[Hotkeys] config installHotkeyHooks={} hotkeys_enabled={} use_scopely_hotkeys={} allow_key_fallthrough={}",
-      this->installHotkeyHooks, this->hotkeys_enabled, this->use_scopely_hotkeys, g_allow_key_fallthrough);
+      "[Hotkeys] config installHotkeyHooks={} hotkeys_enabled={} use_scopely_hotkeys={} allow_key_fallthrough={} "
+      "scopely_shortcuts={} original_frame_policy={}",
+      this->installHotkeyHooks, this->hotkeys_enabled, this->use_scopely_hotkeys, g_allow_key_fallthrough,
+      scopely_shortcut_policy_name(g_scopely_shortcuts_policy), original_frame_policy_name(g_original_frame_policy));
 
-  if (g_allow_key_fallthrough && !this->use_scopely_hotkeys) {
-    spdlog::warn("[Hotkeys] allow_key_fallthrough is enabled without use_scopely_hotkeys; unhandled frames will pass "
-                 "through and Scopely shortcut actions will initialize for fallthrough.");
+  if (g_allow_key_fallthrough && !this->use_scopely_hotkeys && !explicit_scopely_policy && !explicit_frame_policy) {
+    spdlog::warn("[Hotkeys] legacy allow_key_fallthrough=true maps to scopely_shortcuts={} and "
+                 "original_frame_policy={}. Set [input] policies to split those behaviors explicitly.",
+                 scopely_shortcut_policy_name(g_scopely_shortcuts_policy),
+                 original_frame_policy_name(g_original_frame_policy));
   }
 
   spdlog::debug("");

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -16,6 +16,8 @@
 
 #include <toml++/toml.h>
 
+#include "patches/hotkey_policy.h"
+
 #if _WIN32
 #include <Windows.h>
 #endif
@@ -337,6 +339,16 @@ public:
  * @see fix/lto-and-sync-crashes
  */
 bool AllowKeyFallthrough();
+
+/**
+ * @brief Resolved Scopely shortcut initialization policy.
+ */
+ScopelyShortcutPolicy ScopelyShortcutsPolicy();
+
+/**
+ * @brief Resolved per-frame original ScreenManager::Update policy.
+ */
+OriginalFramePolicy OriginalFramePolicySetting();
 
 /**
  * @brief Whether the file-backed live debug channel is enabled.

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -35,6 +35,10 @@ namespace Control
   constexpr bool hotkeys_extended = true;
   /// When true, use Scopely's built-in hotkey layer instead of the mod's. Default: false.
   constexpr bool use_scopely_hotkeys = false;
+  /// Explicit Scopely shortcut initialization policy: off, native, fallback.
+  constexpr const char* scopely_shortcuts = "off";
+  /// Explicit original frame policy: mod, fallthrough_unhandled, fallthrough_all.
+  constexpr const char* original_frame_policy = "mod";
   /// Enable the action queue system. Default: true.
   constexpr bool queue_enabled = true;
   /// Delay in ms before a tap is registered as a select action. Default: 500.

--- a/mods/src/patches/hotkey_policy.h
+++ b/mods/src/patches/hotkey_policy.h
@@ -1,0 +1,13 @@
+#pragma once
+
+enum class ScopelyShortcutPolicy {
+  Off = 0,
+  Native,
+  Fallback,
+};
+
+enum class OriginalFramePolicy {
+  Mod = 0,
+  FallthroughUnhandled,
+  FallthroughAll,
+};

--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -394,7 +394,7 @@ void dispatch_runtime_bound_simple_fleet_action(const input_binding::InputAction
 }
 
 HotkeyRouterStartupAction startup_action_from_runtime_bindings(const input_binding::DispatchPlan& plan,
-                                                               bool use_scopely_hotkeys,
+                                                               ScopelyShortcutPolicy scopely_shortcuts,
                                                                bool hotkeys_enabled)
 {
   return hotkey_router_startup_action(runtime_binding_winner_present(plan,
@@ -403,7 +403,7 @@ HotkeyRouterStartupAction startup_action_from_runtime_bindings(const input_bindi
                                       runtime_binding_winner_present(plan,
                                                                      input_binding::InputActionId::HotkeysEnable,
                                                                      input_binding::InputLayer::Global),
-                                      use_scopely_hotkeys,
+                                      scopely_shortcuts,
                                       hotkeys_enabled);
 }
 }
@@ -418,7 +418,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   const auto runtime_dispatch_plan = frame_runtime_dispatch_plan();
 
   switch (startup_action_from_runtime_bindings(runtime_dispatch_plan,
-                                               Config::Get().use_scopely_hotkeys,
+                                               ScopelyShortcutsPolicy(),
                                                Config::Get().hotkeys_enabled)) {
     case HotkeyRouterStartupAction::DisableHotkeys:
       Config::Get().hotkeys_enabled = false;
@@ -632,12 +632,12 @@ bool hotkey_router_screen_update(ScreenManager* _this)
 
 bool hotkey_router_should_call_original_initialize_actions()
 {
-  return should_call_original_initialize_actions(Config::Get().use_scopely_hotkeys, AllowKeyFallthrough());
+  return should_call_original_initialize_actions(ScopelyShortcutsPolicy());
 }
 
 bool hotkey_router_should_call_original_screen_update(bool routerAllowsOriginal)
 {
-  return should_call_original_screen_update(routerAllowsOriginal, AllowKeyFallthrough());
+  return should_call_original_screen_update(routerAllowsOriginal, OriginalFramePolicySetting());
 }
 
 void hotkey_router_bind_context(RewardsButtonWidget* _this)

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -36,15 +36,7 @@ constexpr bool kEnableNavigationSetCourseHook = true;
 
 const char* initialize_actions_reason()
 {
-  if (Config::Get().use_scopely_hotkeys) {
-    return "use_scopely_hotkeys";
-  }
-
-  if (AllowKeyFallthrough()) {
-    return "allow_key_fallthrough";
-  }
-
-  return "mod-hotkeys-only";
+  return scopely_shortcut_policy_name(ScopelyShortcutsPolicy());
 }
 
 constexpr HookDescriptor kInitializeActionsHook = {
@@ -185,11 +177,14 @@ bool should_suppress_escape_exit_back_button(void* section_manager)
 void InitializeActions_Hook(auto original, void* _this)
 {
   const auto should_call_original = hotkey_router_should_call_original_initialize_actions();
-  spdlog::info("[Hotkeys] ShortcutsManager.InitializeActions original={} reason={} use_scopely_hotkeys={} allow_key_fallthrough={}",
+  spdlog::info("[Hotkeys] ShortcutsManager.InitializeActions original={} reason={} use_scopely_hotkeys={} "
+               "allow_key_fallthrough={} scopely_shortcuts={} original_frame_policy={}",
                should_call_original ? "called" : "suppressed",
                initialize_actions_reason(),
                Config::Get().use_scopely_hotkeys,
-               AllowKeyFallthrough());
+               AllowKeyFallthrough(),
+               scopely_shortcut_policy_name(ScopelyShortcutsPolicy()),
+               original_frame_policy_name(OriginalFramePolicySetting()));
 
   if (should_call_original) {
     return original(_this);
@@ -272,11 +267,15 @@ void InstallHotkeyHooks()
 {
   HookModuleHealth hooks("HotkeyHooks");
 
-  spdlog::info("[Hotkeys] startup config installHotkeyHooks={} hotkeys_enabled={} use_scopely_hotkeys={} allow_key_fallthrough={} frame_owner=FrameTickHooks initialize_actions_hook={}",
+  spdlog::info("[Hotkeys] startup config installHotkeyHooks={} hotkeys_enabled={} use_scopely_hotkeys={} "
+               "allow_key_fallthrough={} scopely_shortcuts={} original_frame_policy={} frame_owner=FrameTickHooks "
+               "initialize_actions_hook={}",
                Config::Get().installHotkeyHooks,
                Config::Get().hotkeys_enabled,
                Config::Get().use_scopely_hotkeys,
                AllowKeyFallthrough(),
+               scopely_shortcut_policy_name(ScopelyShortcutsPolicy()),
+               original_frame_policy_name(OriginalFramePolicySetting()),
                kEnableShortcutInitializeHook);
 
   if (kEnableShortcutInitializeHook) {

--- a/mods/src/testable_functions.cc
+++ b/mods/src/testable_functions.cc
@@ -15,12 +15,70 @@
 // ---------------------------------------------------------------------------
 bool should_call_original_initialize_actions(bool use_scopely_hotkeys, bool allow_key_fallthrough)
 {
-  return use_scopely_hotkeys || allow_key_fallthrough;
+  return should_call_original_initialize_actions(resolve_scopely_shortcut_policy(use_scopely_hotkeys,
+                                                                                 allow_key_fallthrough));
+}
+
+bool should_call_original_initialize_actions(const ScopelyShortcutPolicy policy)
+{
+  return policy != ScopelyShortcutPolicy::Off;
 }
 
 bool should_call_original_screen_update(bool router_allows_original, bool allow_key_fallthrough)
 {
-  return router_allows_original || allow_key_fallthrough;
+  return should_call_original_screen_update(router_allows_original, resolve_original_frame_policy(allow_key_fallthrough));
+}
+
+bool should_call_original_screen_update(const bool router_allows_original, const OriginalFramePolicy policy)
+{
+  if (policy == OriginalFramePolicy::FallthroughAll) {
+    return true;
+  }
+
+  return router_allows_original;
+}
+
+ScopelyShortcutPolicy resolve_scopely_shortcut_policy(const bool use_scopely_hotkeys,
+                                                      const bool allow_key_fallthrough)
+{
+  if (use_scopely_hotkeys) {
+    return ScopelyShortcutPolicy::Native;
+  }
+
+  return allow_key_fallthrough ? ScopelyShortcutPolicy::Fallback : ScopelyShortcutPolicy::Off;
+}
+
+OriginalFramePolicy resolve_original_frame_policy(const bool allow_key_fallthrough)
+{
+  return allow_key_fallthrough ? OriginalFramePolicy::FallthroughAll : OriginalFramePolicy::Mod;
+}
+
+const char* scopely_shortcut_policy_name(const ScopelyShortcutPolicy policy)
+{
+  switch (policy) {
+    case ScopelyShortcutPolicy::Off:
+      return "off";
+    case ScopelyShortcutPolicy::Native:
+      return "native";
+    case ScopelyShortcutPolicy::Fallback:
+      return "fallback";
+  }
+
+  return "unknown";
+}
+
+const char* original_frame_policy_name(const OriginalFramePolicy policy)
+{
+  switch (policy) {
+    case OriginalFramePolicy::Mod:
+      return "mod";
+    case OriginalFramePolicy::FallthroughUnhandled:
+      return "fallthrough_unhandled";
+    case OriginalFramePolicy::FallthroughAll:
+      return "fallthrough_all";
+  }
+
+  return "unknown";
 }
 
 bool should_suppress_escape_exit(bool disable_escape_exit,
@@ -130,6 +188,18 @@ HotkeyRouterStartupAction hotkey_router_startup_action(bool disable_hotkeys_pres
                                                        bool use_scopely_hotkeys,
                                                        bool hotkeys_enabled)
 {
+  return hotkey_router_startup_action(disable_hotkeys_pressed,
+                                      enable_hotkeys_pressed,
+                                      use_scopely_hotkeys ? ScopelyShortcutPolicy::Native
+                                                          : ScopelyShortcutPolicy::Off,
+                                      hotkeys_enabled);
+}
+
+HotkeyRouterStartupAction hotkey_router_startup_action(bool disable_hotkeys_pressed,
+                                                       bool enable_hotkeys_pressed,
+                                                       ScopelyShortcutPolicy scopely_shortcuts,
+                                                       bool hotkeys_enabled)
+{
   if (disable_hotkeys_pressed) {
     return HotkeyRouterStartupAction::DisableHotkeys;
   }
@@ -138,7 +208,7 @@ HotkeyRouterStartupAction hotkey_router_startup_action(bool disable_hotkeys_pres
     return HotkeyRouterStartupAction::EnableHotkeys;
   }
 
-  if (use_scopely_hotkeys && hotkeys_enabled) {
+  if (scopely_shortcuts == ScopelyShortcutPolicy::Native && hotkeys_enabled) {
     return HotkeyRouterStartupAction::AllowOriginal;
   }
 

--- a/mods/src/testable_functions.h
+++ b/mods/src/testable_functions.h
@@ -5,6 +5,8 @@
 
 #include "patches/space_action_inputs.h"
 
+#include "patches/hotkey_policy.h"
+
 #include "bounded_ttl_cache.h"
 
 #include <array>
@@ -36,9 +38,16 @@ struct HotkeyDisableShortcutAliasDecision {
 // Startup shortcut policy: Scopely's shortcut map must initialize whenever the
 // original game input path is expected to handle shortcuts.
 bool should_call_original_initialize_actions(bool use_scopely_hotkeys, bool allow_key_fallthrough);
+bool should_call_original_initialize_actions(ScopelyShortcutPolicy policy);
 
 // Per-frame ScreenManager::Update policy after the router has made its decision.
 bool should_call_original_screen_update(bool router_allows_original, bool allow_key_fallthrough);
+bool should_call_original_screen_update(bool router_allows_original, OriginalFramePolicy policy);
+
+ScopelyShortcutPolicy resolve_scopely_shortcut_policy(bool use_scopely_hotkeys, bool allow_key_fallthrough);
+OriginalFramePolicy   resolve_original_frame_policy(bool allow_key_fallthrough);
+const char*           scopely_shortcut_policy_name(ScopelyShortcutPolicy policy);
+const char*           original_frame_policy_name(OriginalFramePolicy policy);
 
 // Escape-exit policy at the real back-button seam. Returns true when the current
 // Escape-triggered back-button press should be suppressed instead of letting the
@@ -84,6 +93,10 @@ enum class HotkeyRouterDispatchAction {
 HotkeyRouterStartupAction hotkey_router_startup_action(bool disable_hotkeys_pressed,
                                                        bool enable_hotkeys_pressed,
                                                        bool use_scopely_hotkeys,
+                                                       bool hotkeys_enabled);
+HotkeyRouterStartupAction hotkey_router_startup_action(bool disable_hotkeys_pressed,
+                                                       bool enable_hotkeys_pressed,
+                                                       ScopelyShortcutPolicy scopely_shortcuts,
                                                        bool hotkeys_enabled);
 int hotkey_router_ship_select_request(const std::array<bool, 8>& ship_select_keys_down);
 bool hotkey_router_should_clear_input_focus(bool escape_pressed, bool input_focused, bool is_in_chat);

--- a/tests/src/test_fleet_input_policy.cc
+++ b/tests/src/test_fleet_input_policy.cc
@@ -255,6 +255,10 @@ TEST_SUITE("hotkey_decisions")
     CHECK(should_call_original_initialize_actions(false, true));
     CHECK(should_call_original_initialize_actions(true, false));
     CHECK(should_call_original_initialize_actions(true, true));
+
+    CHECK_FALSE(should_call_original_initialize_actions(ScopelyShortcutPolicy::Off));
+    CHECK(should_call_original_initialize_actions(ScopelyShortcutPolicy::Native));
+    CHECK(should_call_original_initialize_actions(ScopelyShortcutPolicy::Fallback));
   }
 
   TEST_CASE("per-frame fallthrough can allow original ScreenManager update")
@@ -263,6 +267,27 @@ TEST_SUITE("hotkey_decisions")
     CHECK(should_call_original_screen_update(false, true));
     CHECK(should_call_original_screen_update(true, false));
     CHECK(should_call_original_screen_update(true, true));
+
+    CHECK_FALSE(should_call_original_screen_update(false, OriginalFramePolicy::Mod));
+    CHECK(should_call_original_screen_update(true, OriginalFramePolicy::Mod));
+    CHECK_FALSE(should_call_original_screen_update(false, OriginalFramePolicy::FallthroughUnhandled));
+    CHECK(should_call_original_screen_update(true, OriginalFramePolicy::FallthroughUnhandled));
+    CHECK(should_call_original_screen_update(false, OriginalFramePolicy::FallthroughAll));
+    CHECK(should_call_original_screen_update(true, OriginalFramePolicy::FallthroughAll));
+  }
+
+  TEST_CASE("legacy fallthrough booleans map to split policy lanes")
+  {
+    CHECK(resolve_scopely_shortcut_policy(false, false) == ScopelyShortcutPolicy::Off);
+    CHECK(resolve_scopely_shortcut_policy(true, false) == ScopelyShortcutPolicy::Native);
+    CHECK(resolve_scopely_shortcut_policy(false, true) == ScopelyShortcutPolicy::Fallback);
+    CHECK(resolve_scopely_shortcut_policy(true, true) == ScopelyShortcutPolicy::Native);
+
+    CHECK(resolve_original_frame_policy(false) == OriginalFramePolicy::Mod);
+    CHECK(resolve_original_frame_policy(true) == OriginalFramePolicy::FallthroughAll);
+
+    CHECK(std::string(scopely_shortcut_policy_name(ScopelyShortcutPolicy::Fallback)) == "fallback");
+    CHECK(std::string(original_frame_policy_name(OriginalFramePolicy::FallthroughAll)) == "fallthrough_all");
   }
 
   TEST_CASE("Escape exit suppression only blocks Escape-triggered exit outside the double-tap window")
@@ -285,6 +310,13 @@ TEST_SUITE("hotkey_decisions")
     CHECK(hotkey_router_startup_action(false, false, true, true) == HotkeyRouterStartupAction::AllowOriginal);
     CHECK(hotkey_router_startup_action(false, false, false, false) == HotkeyRouterStartupAction::SuppressOriginal);
     CHECK(hotkey_router_startup_action(false, false, false, true) == HotkeyRouterStartupAction::Continue);
+
+    CHECK(hotkey_router_startup_action(false, false, ScopelyShortcutPolicy::Native, true)
+          == HotkeyRouterStartupAction::AllowOriginal);
+    CHECK(hotkey_router_startup_action(false, false, ScopelyShortcutPolicy::Fallback, true)
+          == HotkeyRouterStartupAction::Continue);
+    CHECK(hotkey_router_startup_action(false, false, ScopelyShortcutPolicy::Fallback, false)
+          == HotkeyRouterStartupAction::SuppressOriginal);
   }
 
   TEST_CASE("ship selection returns the first active fleet hotkey")


### PR DESCRIPTION
Splits the legacy `allow_key_fallthrough` coupling into explicit policy lanes for Scopely shortcut initialization and original frame execution.

Summary:
- adds explicit `ScopelyShortcutPolicy` and `OriginalFramePolicy` enums plus pure decision helpers
- resolves new `[input]` settings while preserving legacy `use_scopely_hotkeys` / `allow_key_fallthrough` behavior
- routes `InitializeActions` and `ScreenManager.Update` decisions through the resolved split policies
- updates startup/hook logging and the example config so policy reasons are visible
- expands pure hotkey decision tests for the compatibility matrix

Validation run:
- `xmake run -y stfc-mod-tests` passed: 152 test cases / 1015 assertions
- `xmake build -y stfc-community-mod` passed
- `git diff --check` passed

Closes #48