### PR TITLE
Route ship selection through input dispatcher

### DIFF
--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -8,8 +8,8 @@
  * table-driven dispatch system. Escape-driven exit suppression is enforced at
  * SectionManager::BackButtonPressed rather than this frame router.
  */
-#include "errormsg.h"
 #include "config.h"
+#include "errormsg.h"
 
 #include "patches/hotkey_router.h"
 
@@ -43,18 +43,30 @@
 #include <array>
 #include <vector>
 
-namespace {
+namespace
+{
 constexpr std::array kHotkeyStartupActions{
     input_binding::InputActionId::HotkeysDisable,
     input_binding::InputActionId::HotkeysEnable,
 };
 
 constexpr std::array kHotkeyQuitActions{
-  input_binding::InputActionId::Quit,
+    input_binding::InputActionId::Quit,
 };
 
 constexpr std::array kHotkeyQueueActions{
-  input_binding::InputActionId::FleetQueueToggle,
+    input_binding::InputActionId::FleetQueueToggle,
+};
+
+constexpr std::array kHotkeyShipSelectionActions{
+    input_binding::InputActionId::SelectShip1, input_binding::InputActionId::SelectShip2,
+    input_binding::InputActionId::SelectShip3, input_binding::InputActionId::SelectShip4,
+    input_binding::InputActionId::SelectShip5, input_binding::InputActionId::SelectShip6,
+    input_binding::InputActionId::SelectShip7, input_binding::InputActionId::SelectShip8,
+};
+
+constexpr std::array kHotkeySelectCurrentActions{
+    input_binding::InputActionId::SelectCurrent,
 };
 
 constexpr std::array kHotkeySimpleFleetActions{
@@ -63,64 +75,63 @@ constexpr std::array kHotkeySimpleFleetActions{
 };
 
 constexpr std::array kHotkeyRuntimeSpaceActions{
-  input_binding::InputActionId::FleetPrimary,
-  input_binding::InputActionId::FleetSecondary,
-  input_binding::InputActionId::FleetService,
+    input_binding::InputActionId::FleetPrimary,
+    input_binding::InputActionId::FleetSecondary,
+    input_binding::InputActionId::FleetService,
 };
 
 constexpr std::array kHotkeyTableDispatchActions{
-  input_binding::InputActionId::ShowQTrials,
-  input_binding::InputActionId::ShowBookmarks,
-  input_binding::InputActionId::ShowLookup,
-  input_binding::InputActionId::ShowRefinery,
-  input_binding::InputActionId::ShowFactions,
-  input_binding::InputActionId::ShowStationExterior,
-  input_binding::InputActionId::ShowGalaxy,
-  input_binding::InputActionId::ShowStationInterior,
-  input_binding::InputActionId::ShowSystem,
-  input_binding::InputActionId::ShowArtifacts,
-  input_binding::InputActionId::ShowInventory,
-  input_binding::InputActionId::ShowMissions,
-  input_binding::InputActionId::ShowResearch,
-  input_binding::InputActionId::ShowScrapYard,
-  input_binding::InputActionId::ShowOfficers,
-  input_binding::InputActionId::ShowCommander,
-  input_binding::InputActionId::ShowAwayTeam,
-  input_binding::InputActionId::ShowEvents,
-  input_binding::InputActionId::ShowExoComp,
-  input_binding::InputActionId::ShowDaily,
-  input_binding::InputActionId::ShowGifts,
-  input_binding::InputActionId::ShowAlliance,
-  input_binding::InputActionId::ShowAllianceHelp,
-  input_binding::InputActionId::ShowAllianceArmada,
-  input_binding::InputActionId::ShowSettings,
-  input_binding::InputActionId::UiScaleUp,
-  input_binding::InputActionId::UiScaleDown,
-  input_binding::InputActionId::UiViewerScaleUp,
-  input_binding::InputActionId::UiViewerScaleDown,
-  input_binding::InputActionId::TogglePreviewLocate,
-  input_binding::InputActionId::TogglePreviewRecall,
-  input_binding::InputActionId::ToggleCargoDefault,
-  input_binding::InputActionId::ToggleCargoPlayer,
-  input_binding::InputActionId::ToggleCargoStation,
-  input_binding::InputActionId::ToggleCargoHostile,
-  input_binding::InputActionId::ToggleCargoArmada,
-  input_binding::InputActionId::LogOff,
-  input_binding::InputActionId::LogError,
-  input_binding::InputActionId::LogWarn,
-  input_binding::InputActionId::LogInfo,
-  input_binding::InputActionId::LogDebug,
-  input_binding::InputActionId::LogTrace,
-  input_binding::InputActionId::ShowShips,
+    input_binding::InputActionId::ShowQTrials,
+    input_binding::InputActionId::ShowBookmarks,
+    input_binding::InputActionId::ShowLookup,
+    input_binding::InputActionId::ShowRefinery,
+    input_binding::InputActionId::ShowFactions,
+    input_binding::InputActionId::ShowStationExterior,
+    input_binding::InputActionId::ShowGalaxy,
+    input_binding::InputActionId::ShowStationInterior,
+    input_binding::InputActionId::ShowSystem,
+    input_binding::InputActionId::ShowArtifacts,
+    input_binding::InputActionId::ShowInventory,
+    input_binding::InputActionId::ShowMissions,
+    input_binding::InputActionId::ShowResearch,
+    input_binding::InputActionId::ShowScrapYard,
+    input_binding::InputActionId::ShowOfficers,
+    input_binding::InputActionId::ShowCommander,
+    input_binding::InputActionId::ShowAwayTeam,
+    input_binding::InputActionId::ShowEvents,
+    input_binding::InputActionId::ShowExoComp,
+    input_binding::InputActionId::ShowDaily,
+    input_binding::InputActionId::ShowGifts,
+    input_binding::InputActionId::ShowAlliance,
+    input_binding::InputActionId::ShowAllianceHelp,
+    input_binding::InputActionId::ShowAllianceArmada,
+    input_binding::InputActionId::ShowSettings,
+    input_binding::InputActionId::UiScaleUp,
+    input_binding::InputActionId::UiScaleDown,
+    input_binding::InputActionId::UiViewerScaleUp,
+    input_binding::InputActionId::UiViewerScaleDown,
+    input_binding::InputActionId::TogglePreviewLocate,
+    input_binding::InputActionId::TogglePreviewRecall,
+    input_binding::InputActionId::ToggleCargoDefault,
+    input_binding::InputActionId::ToggleCargoPlayer,
+    input_binding::InputActionId::ToggleCargoStation,
+    input_binding::InputActionId::ToggleCargoHostile,
+    input_binding::InputActionId::ToggleCargoArmada,
+    input_binding::InputActionId::LogOff,
+    input_binding::InputActionId::LogError,
+    input_binding::InputActionId::LogWarn,
+    input_binding::InputActionId::LogInfo,
+    input_binding::InputActionId::LogDebug,
+    input_binding::InputActionId::LogTrace,
+    input_binding::InputActionId::ShowShips,
 };
 
 constexpr auto kHotkeyFrameActions = [] {
-  std::array<input_binding::InputActionId,
-             kHotkeyStartupActions.size() + kHotkeyQuitActions.size() + kHotkeyQueueActions.size()
-                 + kHotkeySimpleFleetActions.size()
-           + kHotkeyRuntimeSpaceActions.size()
-                 + kHotkeyTableDispatchActions.size()>
-      actions{};
+  std::array<input_binding::InputActionId, kHotkeyStartupActions.size() + kHotkeyQuitActions.size()
+                                               + kHotkeyQueueActions.size() + kHotkeyShipSelectionActions.size()
+                                               + kHotkeySelectCurrentActions.size() + kHotkeySimpleFleetActions.size()
+                                               + kHotkeyRuntimeSpaceActions.size() + kHotkeyTableDispatchActions.size()>
+       actions{};
   auto output = actions.begin();
 
   for (const auto action : kHotkeyStartupActions) {
@@ -130,6 +141,12 @@ constexpr auto kHotkeyFrameActions = [] {
     *output++ = action;
   }
   for (const auto action : kHotkeyQueueActions) {
+    *output++ = action;
+  }
+  for (const auto action : kHotkeyShipSelectionActions) {
+    *output++ = action;
+  }
+  for (const auto action : kHotkeySelectCurrentActions) {
     *output++ = action;
   }
   for (const auto action : kHotkeySimpleFleetActions) {
@@ -148,17 +165,9 @@ constexpr auto kHotkeyFrameActions = [] {
 input_binding::ModifierMask held_modifier_mask()
 {
   input_binding::ModifierMask modifiers;
-  for (const auto modifier_key : {KeyCode::LeftShift,
-                                  KeyCode::RightShift,
-                                  KeyCode::LeftControl,
-                                  KeyCode::RightControl,
-                                  KeyCode::LeftAlt,
-                                  KeyCode::RightAlt,
-                                  KeyCode::LeftWindows,
-                                  KeyCode::RightWindows,
-                                  KeyCode::LeftCommand,
-                                  KeyCode::RightCommand,
-                                  KeyCode::AltGr}) {
+  for (const auto modifier_key : {KeyCode::LeftShift, KeyCode::RightShift, KeyCode::LeftControl, KeyCode::RightControl,
+                                  KeyCode::LeftAlt, KeyCode::RightAlt, KeyCode::LeftWindows, KeyCode::RightWindows,
+                                  KeyCode::LeftCommand, KeyCode::RightCommand, KeyCode::AltGr}) {
     if (Key::Pressed(modifier_key)) {
       modifiers.Merge(input_binding::ModifierMask::FromPressedKey(modifier_key));
     }
@@ -183,32 +192,42 @@ std::vector<input_binding::DispatchKeyState> build_dispatch_key_snapshot(std::sp
 input_binding::DispatchPlan frame_runtime_dispatch_plan()
 {
   const auto& runtime_bindings = input_binding::RuntimeBindingModel();
-  const auto watched_keys =
+  const auto  watched_keys =
       input_binding::WatchedKeysForActions(runtime_bindings, input_binding::InputPhase::Frame, kHotkeyFrameActions);
 
   const auto key_states = build_dispatch_key_snapshot(watched_keys);
-  return input_binding::PlanDispatchSnapshot(runtime_bindings,
-                                             input_binding::InputPhase::Frame,
-                                             input_binding::ActiveLayers::All(),
-                                             key_states);
+  return input_binding::PlanDispatchSnapshot(runtime_bindings, input_binding::InputPhase::Frame,
+                                             input_binding::ActiveLayers::All(), key_states);
 }
 
-bool runtime_binding_winner_present(const input_binding::DispatchPlan& plan,
-                                    const input_binding::InputActionId action,
+bool runtime_binding_winner_present(const input_binding::DispatchPlan& plan, const input_binding::InputActionId action,
                                     const input_binding::InputLayer layer)
 {
-  return std::ranges::any_of(plan.winners, [action, layer](const auto& winner) {
-    return winner.action == action && winner.layer == layer;
-  });
+  return std::ranges::any_of(
+      plan.winners, [action, layer](const auto& winner) { return winner.action == action && winner.layer == layer; });
 }
 
-input_binding::InputActionId first_runtime_binding_winner(const input_binding::DispatchPlan& plan,
+input_binding::InputActionId first_runtime_binding_winner(const input_binding::DispatchPlan&                  plan,
                                                           const std::span<const input_binding::InputActionId> actions)
 {
   const auto found = std::ranges::find_if(plan.winners, [&actions](const auto& winner) {
     return std::ranges::find(actions, winner.action) != actions.end();
   });
   return found == plan.winners.end() ? input_binding::InputActionId::Max : found->action;
+}
+
+int ship_select_request_from_runtime_bindings(const input_binding::DispatchPlan& plan)
+{
+  return hotkey_router_ship_select_request(std::array<bool, 8>{
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip1, input_binding::InputLayer::Fleet),
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip2, input_binding::InputLayer::Fleet),
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip3, input_binding::InputLayer::Fleet),
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip4, input_binding::InputLayer::Fleet),
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip5, input_binding::InputLayer::Fleet),
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip6, input_binding::InputLayer::Fleet),
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip7, input_binding::InputLayer::Fleet),
+      runtime_binding_winner_present(plan, input_binding::InputActionId::SelectShip8, input_binding::InputLayer::Fleet),
+  });
 }
 
 GameFunction dispatcher_owned_game_function(const input_binding::InputActionId action)
@@ -370,8 +389,7 @@ HotkeyRouterDispatchAction dispatch_runtime_bound_table_action(const input_bindi
     }
 
     const auto decision = entry.handler();
-    return hotkey_router_dispatch_action(true,
-                                         decision == DispatchDecision::HandledStop,
+    return hotkey_router_dispatch_action(true, decision == DispatchDecision::HandledStop,
                                          decision == DispatchDecision::HandledAllowOriginal);
   }
 
@@ -394,19 +412,16 @@ void dispatch_runtime_bound_simple_fleet_action(const input_binding::InputAction
 }
 
 HotkeyRouterStartupAction startup_action_from_runtime_bindings(const input_binding::DispatchPlan& plan,
-                                                               ScopelyShortcutPolicy scopely_shortcuts,
-                                                               bool hotkeys_enabled)
+                                                               ScopelyShortcutPolicy              scopely_shortcuts,
+                                                               bool                               hotkeys_enabled)
 {
-  return hotkey_router_startup_action(runtime_binding_winner_present(plan,
-                                                                     input_binding::InputActionId::HotkeysDisable,
+  return hotkey_router_startup_action(runtime_binding_winner_present(plan, input_binding::InputActionId::HotkeysDisable,
                                                                      input_binding::InputLayer::Global),
-                                      runtime_binding_winner_present(plan,
-                                                                     input_binding::InputActionId::HotkeysEnable,
+                                      runtime_binding_winner_present(plan, input_binding::InputActionId::HotkeysEnable,
                                                                      input_binding::InputLayer::Global),
-                                      scopely_shortcuts,
-                                      hotkeys_enabled);
+                                      scopely_shortcuts, hotkeys_enabled);
 }
-}
+} // namespace
 
 // ─── Main Per-Frame Hotkey Router ─────────────────────────────────────────────────────
 
@@ -417,8 +432,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
 
   const auto runtime_dispatch_plan = frame_runtime_dispatch_plan();
 
-  switch (startup_action_from_runtime_bindings(runtime_dispatch_plan,
-                                               ScopelyShortcutsPolicy(),
+  switch (startup_action_from_runtime_bindings(runtime_dispatch_plan, ScopelyShortcutsPolicy(),
                                                Config::Get().hotkeys_enabled)) {
     case HotkeyRouterStartupAction::DisableHotkeys:
       Config::Get().hotkeys_enabled = false;
@@ -440,24 +454,14 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   const auto config     = &Config::Get();
 
 #ifdef _WIN32
-  if (first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyQuitActions)
-      == input_binding::InputActionId::Quit) {
+  if (first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyQuitActions) == input_binding::InputActionId::Quit) {
     TerminateProcess(GetCurrentProcess(), 1);
     return false;
   }
 #endif
 
   // ─── Ship selection (1-8 keys) ───────────────────────────────────────────────────────
-  const auto ship_select_request = hotkey_router_ship_select_request(std::array<bool, 8>{
-      MapKey::IsDown(GameFunction::SelectShip1),
-      MapKey::IsDown(GameFunction::SelectShip2),
-      MapKey::IsDown(GameFunction::SelectShip3),
-      MapKey::IsDown(GameFunction::SelectShip4),
-      MapKey::IsDown(GameFunction::SelectShip5),
-      MapKey::IsDown(GameFunction::SelectShip6),
-      MapKey::IsDown(GameFunction::SelectShip7),
-      MapKey::IsDown(GameFunction::SelectShip8),
-  });
+  const auto ship_select_request = ship_select_request_from_runtime_bindings(runtime_dispatch_plan);
 
   if (HandleShipSelection(ship_select_request)) {
     return true;
@@ -472,7 +476,8 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   if (!is_in_chat) {
     if (!Key::IsInputFocused()) {
       // SelectCurrent — locate active fleet
-      if (MapKey::IsDown(GameFunction::SelectCurrent)) {
+      if (first_runtime_binding_winner(runtime_dispatch_plan, kHotkeySelectCurrentActions)
+          == input_binding::InputActionId::SelectCurrent) {
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
         if (fleet_bar) {
           auto fleet = fleet_bar->_fleetPanelController->fleet;
@@ -544,9 +549,8 @@ bool hotkey_router_screen_update(ScreenManager* _this)
                                                                : MapKey::IsDown(entry.game_function);
         if (active) {
           auto decision = entry.handler();
-          auto action = hotkey_router_dispatch_action(true,
-                                                      decision == DispatchDecision::HandledStop,
-                                                      decision == DispatchDecision::HandledAllowOriginal);
+          auto action   = hotkey_router_dispatch_action(true, decision == DispatchDecision::HandledStop,
+                                                        decision == DispatchDecision::HandledAllowOriginal);
           if (action == HotkeyRouterDispatchAction::SuppressOriginal) {
             return false;
           }
@@ -574,14 +578,11 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   if (!Key::IsInputFocused()) {
     const auto simple_fleet_action = first_runtime_binding_winner(runtime_dispatch_plan, kHotkeySimpleFleetActions);
     const auto space_action_inputs = hotkey_router_runtime_space_action_inputs(
-        runtime_binding_winner_present(runtime_dispatch_plan,
-                                       input_binding::InputActionId::FleetPrimary,
+        runtime_binding_winner_present(runtime_dispatch_plan, input_binding::InputActionId::FleetPrimary,
                                        input_binding::InputLayer::Fleet),
-        runtime_binding_winner_present(runtime_dispatch_plan,
-                                       input_binding::InputActionId::FleetSecondary,
+        runtime_binding_winner_present(runtime_dispatch_plan, input_binding::InputActionId::FleetSecondary,
                                        input_binding::InputLayer::Fleet),
-        runtime_binding_winner_present(runtime_dispatch_plan,
-                                       input_binding::InputActionId::FleetService,
+        runtime_binding_winner_present(runtime_dispatch_plan, input_binding::InputActionId::FleetService,
                                        input_binding::InputLayer::Fleet));
 
     // Escape to hide object viewers
@@ -590,8 +591,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
     }
 
     // Dismiss golden rewards screen
-    if (Key::Pressed(KeyCode::Escape)
-        || space_action_inputs.primary) {
+    if (Key::Pressed(KeyCode::Escape) || space_action_inputs.primary) {
       if (TryDismissRewardsScreen()) {
         return false;
       }
@@ -606,7 +606,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
       if (Hub::IsInSystemOrGalaxyOrStarbase() && !Hub::IsInChat() && !Key::IsInputFocused()) {
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
         if (fleet_bar) {
-          bool was_forced = force_space_action_next_frame;
+          bool was_forced          = force_space_action_next_frame;
           auto deferred_generation = DeferredSpaceActionGeneration();
           ExecuteSpaceAction(fleet_bar, space_action_inputs);
           if (was_forced && DeferredSpaceActionGeneration() == deferred_generation) {
@@ -631,21 +631,13 @@ bool hotkey_router_screen_update(ScreenManager* _this)
 // ─── Hook Delegate Functions ─────────────────────────────────────────────────────────
 
 bool hotkey_router_should_call_original_initialize_actions()
-{
-  return should_call_original_initialize_actions(ScopelyShortcutsPolicy());
-}
+{ return should_call_original_initialize_actions(ScopelyShortcutsPolicy()); }
 
 bool hotkey_router_should_call_original_screen_update(bool routerAllowsOriginal)
-{
-  return should_call_original_screen_update(routerAllowsOriginal, OriginalFramePolicySetting());
-}
+{ return should_call_original_screen_update(routerAllowsOriginal, OriginalFramePolicySetting()); }
 
 void hotkey_router_bind_context(RewardsButtonWidget* _this)
-{
-  HandleCargoBindContext(_this);
-}
+{ HandleCargoBindContext(_this); }
 
 void hotkey_router_show_fleet(PreScanTargetWidget* _this)
-{
-  HandleCargoShowFleet(_this);
-}
+{ HandleCargoShowFleet(_this); }

--- a/mods/src/patches/input_binding/input_binding.cc
+++ b/mods/src/patches/input_binding/input_binding.cc
@@ -7,267 +7,284 @@
 
 namespace input_binding
 {
-namespace {
-constexpr std::array<InputActionSpec, 54> kActionSpecs{{
-    {InputActionId::FleetPrimary, "fleet_primary", "SPACE|MOUSE1", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Fleet, ConflictGroup::FleetAction, 100},
-    {InputActionId::FleetSecondary, "fleet_secondary", "TAB|MOUSE4", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Fleet, ConflictGroup::FleetAction, 90},
-    {InputActionId::FleetService, "fleet_service", "R|MOUSE3", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Fleet, ConflictGroup::FleetAction, 80},
-    {InputActionId::FleetViewInfo, "fleet_view_info", "V|MOUSE2", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Fleet, ConflictGroup::FleetAction, 70},
-    {InputActionId::FleetQueueClear, "fleet_queue_clear", "CTRL-C", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Fleet, ConflictGroup::FleetAction, 110},
-    {InputActionId::FleetQueueToggle, "fleet_queue_toggle", "CTRL-Q", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Global, ConflictGroup::FrameDispatch, 800},
-    {InputActionId::HotkeysDisable, "hotkeys_disable", "CTRL-ALT-MINUS", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::GlobalControl, 1000},
-    {InputActionId::HotkeysEnable, "hotkeys_enable", "CTRL-ALT-=", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::GlobalControl, 1000},
-    {InputActionId::Quit, "quit", "F10", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Global, ConflictGroup::GlobalControl, 900},
-    {InputActionId::UiScaleUp, "ui_scale_up", "PGUP", TriggerMode::Pressed, InputPhase::Frame,
-  InputLayer::Global, ConflictGroup::FrameDispatch, 340},
-    {InputActionId::UiScaleDown, "ui_scale_down", "PGDOWN", TriggerMode::Pressed, InputPhase::Frame,
-  InputLayer::Global, ConflictGroup::FrameDispatch, 330},
-    {InputActionId::UiViewerScaleUp, "ui_viewer_scale_up", "SHIFT-PGUP", TriggerMode::Pressed,
-  InputPhase::Frame, InputLayer::Global, ConflictGroup::FrameDispatch, 320},
-    {InputActionId::UiViewerScaleDown, "ui_viewer_scale_down", "SHIFT-PGDOWN", TriggerMode::Pressed,
-  InputPhase::Frame, InputLayer::Global, ConflictGroup::FrameDispatch, 310},
-    {InputActionId::LogOff, "log_off", "CTRL-SHIFT-F12", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 230},
-    {InputActionId::LogError, "log_error", "CTRL-SHIFT-F11", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 220},
-    {InputActionId::LogWarn, "log_warn", "CTRL-SHIFT-F10", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 210},
-    {InputActionId::LogInfo, "log_info", "CTRL-SHIFT-F8", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 200},
-    {InputActionId::LogDebug, "log_debug", "CTRL-SHIFT-F9", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 190},
-    {InputActionId::LogTrace, "log_trace", "CTRL-SHIFT-F7", TriggerMode::Down, InputPhase::Frame,
-  InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 180},
-    {InputActionId::ShowQTrials, "show_qtrials", "SHIFT-Q", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 590},
-    {InputActionId::ShowBookmarks, "show_bookmarks", "B", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 580},
-    {InputActionId::ShowLookup, "show_lookup", "L", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 570},
-    {InputActionId::ShowRefinery, "show_refinery", "SHIFT-F", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 560},
-    {InputActionId::ShowFactions, "show_factions", "F", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 550},
-    {InputActionId::ShowStationExterior, "show_stationexterior", "SHIFT-G", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 540},
-    {InputActionId::ShowGalaxy, "show_galaxy", "G", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 530},
-    {InputActionId::ShowStationInterior, "show_stationinterior", "SHIFT-H", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 520},
-    {InputActionId::ShowSystem, "show_system", "H", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 510},
-    {InputActionId::ShowArtifacts, "show_artifacts", "SHIFT-I", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 500},
-    {InputActionId::ShowInventory, "show_inventory", "I", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 490},
-    {InputActionId::ShowMissions, "show_missions", "M", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 480},
-    {InputActionId::ShowResearch, "show_research", "U", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 470},
-    {InputActionId::ShowScrapYard, "show_scrapyard", "Y", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 460},
-    {InputActionId::ShowOfficers, "show_officers", "SHIFT-O", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 450},
-    {InputActionId::ShowCommander, "show_commander", "O", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 440},
-    {InputActionId::ShowAwayTeam, "show_awayteam", "T", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 430},
-    {InputActionId::ShowEvents, "show_events", "SHIFT-E", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 420},
-    {InputActionId::ShowExoComp, "show_exocomp", "X", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 410},
-    {InputActionId::ShowDaily, "show_daily", "Z", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 400},
-    {InputActionId::ShowGifts, "show_gifts", "/", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 390},
-    {InputActionId::ShowAlliance, "show_alliance", "ALT-'", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 380},
-    {InputActionId::ShowAllianceHelp, "show_alliance_help", "SHIFT-'", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 370},
-    {InputActionId::ShowAllianceArmada, "show_alliance_armada", "CTRL-'", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 360},
-    {InputActionId::ShowSettings, "show_settings", "SHIFT-S", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 350},
-    {InputActionId::TogglePreviewLocate, "toggle_preview_locate", "CTRL-R", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 300},
-    {InputActionId::TogglePreviewRecall, "toggle_preview_recall", "CTRL-T", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 290},
-    {InputActionId::ToggleCargoDefault, "toggle_cargo_default", "ALT-1", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 280},
-    {InputActionId::ToggleCargoPlayer, "toggle_cargo_player", "ALT-2", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 270},
-    {InputActionId::ToggleCargoStation, "toggle_cargo_station", "ALT-3", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 260},
-    {InputActionId::ToggleCargoHostile, "toggle_cargo_hostile", "ALT-4", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 250},
-    {InputActionId::ToggleCargoArmada, "toggle_cargo_armada", "ALT-5", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 240},
-    {InputActionId::ShowShips, "show_ships", "N", TriggerMode::Down, InputPhase::Frame,
-     InputLayer::Global, ConflictGroup::FrameDispatch, 170},
-    {InputActionId::ZoomIn, "zoom_in", "Q", TriggerMode::Pressed, InputPhase::NavigationZoomUpdate, InputLayer::Zoom,
-     ConflictGroup::Zoom, 100},
-    {InputActionId::ZoomOut, "zoom_out", "E", TriggerMode::Pressed, InputPhase::NavigationZoomUpdate,
-     InputLayer::Zoom, ConflictGroup::Zoom, 100},
-}};
+namespace
+{
+  constexpr std::array<InputActionSpec, 63> kActionSpecs{{
+      {InputActionId::FleetPrimary, "fleet_primary", "SPACE|MOUSE1", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Fleet, ConflictGroup::FleetAction, 100},
+      {InputActionId::FleetSecondary, "fleet_secondary", "TAB|MOUSE4", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Fleet, ConflictGroup::FleetAction, 90},
+      {InputActionId::FleetService, "fleet_service", "R|MOUSE3", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Fleet, ConflictGroup::FleetAction, 80},
+      {InputActionId::FleetViewInfo, "fleet_view_info", "V|MOUSE2", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Fleet, ConflictGroup::FleetAction, 70},
+      {InputActionId::FleetQueueClear, "fleet_queue_clear", "CTRL-C", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Fleet, ConflictGroup::FleetAction, 110},
+      {InputActionId::FleetQueueToggle, "fleet_queue_toggle", "CTRL-Q", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 800},
+      {InputActionId::SelectShip1, "select_ship1", "1", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 160},
+      {InputActionId::SelectShip2, "select_ship2", "2", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 159},
+      {InputActionId::SelectShip3, "select_ship3", "3", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 158},
+      {InputActionId::SelectShip4, "select_ship4", "4", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 157},
+      {InputActionId::SelectShip5, "select_ship5", "5", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 156},
+      {InputActionId::SelectShip6, "select_ship6", "6", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 155},
+      {InputActionId::SelectShip7, "select_ship7", "7", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 154},
+      {InputActionId::SelectShip8, "select_ship8", "8", TriggerMode::Down, InputPhase::Frame, InputLayer::Fleet,
+       ConflictGroup::FleetAction, 153},
+      {InputActionId::SelectCurrent, "select_current", "CTRL-SPACE", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Fleet, ConflictGroup::FleetAction, 152},
+      {InputActionId::HotkeysDisable, "hotkeys_disable", "CTRL-ALT-MINUS", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::GlobalControl, 1000},
+      {InputActionId::HotkeysEnable, "hotkeys_enable", "CTRL-ALT-=", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::GlobalControl, 1000},
+      {InputActionId::Quit, "quit", "F10", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::GlobalControl, 900},
+      {InputActionId::UiScaleUp, "ui_scale_up", "PGUP", TriggerMode::Pressed, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 340},
+      {InputActionId::UiScaleDown, "ui_scale_down", "PGDOWN", TriggerMode::Pressed, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 330},
+      {InputActionId::UiViewerScaleUp, "ui_viewer_scale_up", "SHIFT-PGUP", TriggerMode::Pressed, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 320},
+      {InputActionId::UiViewerScaleDown, "ui_viewer_scale_down", "SHIFT-PGDOWN", TriggerMode::Pressed,
+       InputPhase::Frame, InputLayer::Global, ConflictGroup::FrameDispatch, 310},
+      {InputActionId::LogOff, "log_off", "CTRL-SHIFT-F12", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 230},
+      {InputActionId::LogError, "log_error", "CTRL-SHIFT-F11", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 220},
+      {InputActionId::LogWarn, "log_warn", "CTRL-SHIFT-F10", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 210},
+      {InputActionId::LogInfo, "log_info", "CTRL-SHIFT-F8", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 200},
+      {InputActionId::LogDebug, "log_debug", "CTRL-SHIFT-F9", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 190},
+      {InputActionId::LogTrace, "log_trace", "CTRL-SHIFT-F7", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Diagnostics, ConflictGroup::FrameDispatch, 180},
+      {InputActionId::ShowQTrials, "show_qtrials", "SHIFT-Q", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 590},
+      {InputActionId::ShowBookmarks, "show_bookmarks", "B", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 580},
+      {InputActionId::ShowLookup, "show_lookup", "L", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 570},
+      {InputActionId::ShowRefinery, "show_refinery", "SHIFT-F", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 560},
+      {InputActionId::ShowFactions, "show_factions", "F", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 550},
+      {InputActionId::ShowStationExterior, "show_stationexterior", "SHIFT-G", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 540},
+      {InputActionId::ShowGalaxy, "show_galaxy", "G", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 530},
+      {InputActionId::ShowStationInterior, "show_stationinterior", "SHIFT-H", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 520},
+      {InputActionId::ShowSystem, "show_system", "H", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 510},
+      {InputActionId::ShowArtifacts, "show_artifacts", "SHIFT-I", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 500},
+      {InputActionId::ShowInventory, "show_inventory", "I", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 490},
+      {InputActionId::ShowMissions, "show_missions", "M", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 480},
+      {InputActionId::ShowResearch, "show_research", "U", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 470},
+      {InputActionId::ShowScrapYard, "show_scrapyard", "Y", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 460},
+      {InputActionId::ShowOfficers, "show_officers", "SHIFT-O", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 450},
+      {InputActionId::ShowCommander, "show_commander", "O", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 440},
+      {InputActionId::ShowAwayTeam, "show_awayteam", "T", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 430},
+      {InputActionId::ShowEvents, "show_events", "SHIFT-E", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 420},
+      {InputActionId::ShowExoComp, "show_exocomp", "X", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 410},
+      {InputActionId::ShowDaily, "show_daily", "Z", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 400},
+      {InputActionId::ShowGifts, "show_gifts", "/", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 390},
+      {InputActionId::ShowAlliance, "show_alliance", "ALT-'", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 380},
+      {InputActionId::ShowAllianceHelp, "show_alliance_help", "SHIFT-'", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 370},
+      {InputActionId::ShowAllianceArmada, "show_alliance_armada", "CTRL-'", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 360},
+      {InputActionId::ShowSettings, "show_settings", "SHIFT-S", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 350},
+      {InputActionId::TogglePreviewLocate, "toggle_preview_locate", "CTRL-R", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 300},
+      {InputActionId::TogglePreviewRecall, "toggle_preview_recall", "CTRL-T", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 290},
+      {InputActionId::ToggleCargoDefault, "toggle_cargo_default", "ALT-1", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 280},
+      {InputActionId::ToggleCargoPlayer, "toggle_cargo_player", "ALT-2", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 270},
+      {InputActionId::ToggleCargoStation, "toggle_cargo_station", "ALT-3", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 260},
+      {InputActionId::ToggleCargoHostile, "toggle_cargo_hostile", "ALT-4", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 250},
+      {InputActionId::ToggleCargoArmada, "toggle_cargo_armada", "ALT-5", TriggerMode::Down, InputPhase::Frame,
+       InputLayer::Global, ConflictGroup::FrameDispatch, 240},
+      {InputActionId::ShowShips, "show_ships", "N", TriggerMode::Down, InputPhase::Frame, InputLayer::Global,
+       ConflictGroup::FrameDispatch, 170},
+      {InputActionId::ZoomIn, "zoom_in", "Q", TriggerMode::Pressed, InputPhase::NavigationZoomUpdate, InputLayer::Zoom,
+       ConflictGroup::Zoom, 100},
+      {InputActionId::ZoomOut, "zoom_out", "E", TriggerMode::Pressed, InputPhase::NavigationZoomUpdate,
+       InputLayer::Zoom, ConflictGroup::Zoom, 100},
+  }};
 
-struct KeyName {
-  std::string_view name;
-  KeyCode          key;
-};
+  struct KeyName {
+    std::string_view name;
+    KeyCode          key;
+  };
 
-constexpr auto kKeyNames = std::to_array<KeyName>({
-    {"LALT", KeyCode::LeftAlt},
-    {"LAPPLE", KeyCode::LeftApple},
-    {"LCOM", KeyCode::LeftCommand},
-    {"LCMD", KeyCode::LeftCommand},
-    {"LCTRL", KeyCode::LeftControl},
-    {"ALTGR", KeyCode::AltGr},
-    {"END", KeyCode::End},
-    {"HOME", KeyCode::Home},
-    {"PGDOWN", KeyCode::PageDown},
-    {"PGUP", KeyCode::PageUp},
-    {"DOWN", KeyCode::DownArrow},
-    {"LEFT", KeyCode::LeftArrow},
-    {"RIGHT", KeyCode::RightArrow},
-    {"UP", KeyCode::UpArrow},
-    {"BACKSPACE", KeyCode::Backspace},
-    {"BREAK", KeyCode::Break},
-    {"CAPS", KeyCode::CapsLock},
-    {"CLEAR", KeyCode::Clear},
-    {"DELETE", KeyCode::Delete},
-    {"ESCAPE", KeyCode::Escape},
-    {"HELP", KeyCode::Help},
-    {"INSERT", KeyCode::Insert},
-    {"LSHIFT", KeyCode::LeftShift},
-    {"LWIN", KeyCode::LeftWindows},
-    {"MENU", KeyCode::Menu},
-    {"PAUSE", KeyCode::Pause},
-    {"PRINT", KeyCode::Print},
-    {"RALT", KeyCode::RightAlt},
-    {"RAPPLE", KeyCode::RightApple},
-    {"RCOM", KeyCode::RightCommand},
-    {"RCMD", KeyCode::RightCommand},
-    {"RCTRL", KeyCode::RightControl},
-    {"RETURN", KeyCode::Return},
-    {"RSHIFT", KeyCode::RightShift},
-    {"RWIN", KeyCode::RightWindows},
-    {"SCROLL", KeyCode::ScrollLock},
-    {"SYSREQ", KeyCode::SysReq},
-    {"TAB", KeyCode::Tab},
-    {"MOUSE0", KeyCode::Mouse0},
-    {"MOUSE1", KeyCode::Mouse1},
-    {"MOUSE2", KeyCode::Mouse2},
-    {"MOUSE3", KeyCode::Mouse3},
-    {"MOUSE4", KeyCode::Mouse4},
-    {"MOUSE5", KeyCode::Mouse5},
-    {"MOUSE6", KeyCode::Mouse6},
-    {"SPACE", KeyCode::Space},
-    {"MINUS", KeyCode::Minus},
-    {"-", KeyCode::Minus},
-    {"_", KeyCode::Underscore},
-    {",", KeyCode::Comma},
-    {";", KeyCode::Semicolon},
-    {":", KeyCode::Colon},
-    {"!", KeyCode::Exclaim},
-    {"?", KeyCode::Question},
-    {".", KeyCode::Period},
-    {"'", KeyCode::Quote},
-    {"/", KeyCode::Slash},
-    {"\\", KeyCode::Backslash},
-    {"`", KeyCode::BackQuote},
-    {"+", KeyCode::Plus},
-    {"PLUS", KeyCode::Plus},
-    {"=", KeyCode::Equals},
-    {"0", KeyCode::Alpha0},
-    {"1", KeyCode::Alpha1},
-    {"2", KeyCode::Alpha2},
-    {"3", KeyCode::Alpha3},
-    {"4", KeyCode::Alpha4},
-    {"5", KeyCode::Alpha5},
-    {"6", KeyCode::Alpha6},
-    {"7", KeyCode::Alpha7},
-    {"8", KeyCode::Alpha8},
-    {"9", KeyCode::Alpha9},
-    {"A", KeyCode::A},
-    {"B", KeyCode::B},
-    {"C", KeyCode::C},
-    {"D", KeyCode::D},
-    {"E", KeyCode::E},
-    {"F", KeyCode::F},
-    {"G", KeyCode::G},
-    {"H", KeyCode::H},
-    {"I", KeyCode::I},
-    {"J", KeyCode::J},
-    {"K", KeyCode::K},
-    {"L", KeyCode::L},
-    {"M", KeyCode::M},
-    {"N", KeyCode::N},
-    {"O", KeyCode::O},
-    {"P", KeyCode::P},
-    {"Q", KeyCode::Q},
-    {"R", KeyCode::R},
-    {"S", KeyCode::S},
-    {"T", KeyCode::T},
-    {"U", KeyCode::U},
-    {"V", KeyCode::V},
-    {"W", KeyCode::W},
-    {"X", KeyCode::X},
-    {"Y", KeyCode::Y},
-    {"Z", KeyCode::Z},
+  constexpr auto kKeyNames = std::to_array<KeyName>({
+      {"LALT", KeyCode::LeftAlt},
+      {"LAPPLE", KeyCode::LeftApple},
+      {"LCOM", KeyCode::LeftCommand},
+      {"LCMD", KeyCode::LeftCommand},
+      {"LCTRL", KeyCode::LeftControl},
+      {"ALTGR", KeyCode::AltGr},
+      {"END", KeyCode::End},
+      {"HOME", KeyCode::Home},
+      {"PGDOWN", KeyCode::PageDown},
+      {"PGUP", KeyCode::PageUp},
+      {"DOWN", KeyCode::DownArrow},
+      {"LEFT", KeyCode::LeftArrow},
+      {"RIGHT", KeyCode::RightArrow},
+      {"UP", KeyCode::UpArrow},
+      {"BACKSPACE", KeyCode::Backspace},
+      {"BREAK", KeyCode::Break},
+      {"CAPS", KeyCode::CapsLock},
+      {"CLEAR", KeyCode::Clear},
+      {"DELETE", KeyCode::Delete},
+      {"ESCAPE", KeyCode::Escape},
+      {"HELP", KeyCode::Help},
+      {"INSERT", KeyCode::Insert},
+      {"LSHIFT", KeyCode::LeftShift},
+      {"LWIN", KeyCode::LeftWindows},
+      {"MENU", KeyCode::Menu},
+      {"PAUSE", KeyCode::Pause},
+      {"PRINT", KeyCode::Print},
+      {"RALT", KeyCode::RightAlt},
+      {"RAPPLE", KeyCode::RightApple},
+      {"RCOM", KeyCode::RightCommand},
+      {"RCMD", KeyCode::RightCommand},
+      {"RCTRL", KeyCode::RightControl},
+      {"RETURN", KeyCode::Return},
+      {"RSHIFT", KeyCode::RightShift},
+      {"RWIN", KeyCode::RightWindows},
+      {"SCROLL", KeyCode::ScrollLock},
+      {"SYSREQ", KeyCode::SysReq},
+      {"TAB", KeyCode::Tab},
+      {"MOUSE0", KeyCode::Mouse0},
+      {"MOUSE1", KeyCode::Mouse1},
+      {"MOUSE2", KeyCode::Mouse2},
+      {"MOUSE3", KeyCode::Mouse3},
+      {"MOUSE4", KeyCode::Mouse4},
+      {"MOUSE5", KeyCode::Mouse5},
+      {"MOUSE6", KeyCode::Mouse6},
+      {"SPACE", KeyCode::Space},
+      {"MINUS", KeyCode::Minus},
+      {"-", KeyCode::Minus},
+      {"_", KeyCode::Underscore},
+      {",", KeyCode::Comma},
+      {";", KeyCode::Semicolon},
+      {":", KeyCode::Colon},
+      {"!", KeyCode::Exclaim},
+      {"?", KeyCode::Question},
+      {".", KeyCode::Period},
+      {"'", KeyCode::Quote},
+      {"/", KeyCode::Slash},
+      {"\\", KeyCode::Backslash},
+      {"`", KeyCode::BackQuote},
+      {"+", KeyCode::Plus},
+      {"PLUS", KeyCode::Plus},
+      {"=", KeyCode::Equals},
+      {"0", KeyCode::Alpha0},
+      {"1", KeyCode::Alpha1},
+      {"2", KeyCode::Alpha2},
+      {"3", KeyCode::Alpha3},
+      {"4", KeyCode::Alpha4},
+      {"5", KeyCode::Alpha5},
+      {"6", KeyCode::Alpha6},
+      {"7", KeyCode::Alpha7},
+      {"8", KeyCode::Alpha8},
+      {"9", KeyCode::Alpha9},
+      {"A", KeyCode::A},
+      {"B", KeyCode::B},
+      {"C", KeyCode::C},
+      {"D", KeyCode::D},
+      {"E", KeyCode::E},
+      {"F", KeyCode::F},
+      {"G", KeyCode::G},
+      {"H", KeyCode::H},
+      {"I", KeyCode::I},
+      {"J", KeyCode::J},
+      {"K", KeyCode::K},
+      {"L", KeyCode::L},
+      {"M", KeyCode::M},
+      {"N", KeyCode::N},
+      {"O", KeyCode::O},
+      {"P", KeyCode::P},
+      {"Q", KeyCode::Q},
+      {"R", KeyCode::R},
+      {"S", KeyCode::S},
+      {"T", KeyCode::T},
+      {"U", KeyCode::U},
+      {"V", KeyCode::V},
+      {"W", KeyCode::W},
+      {"X", KeyCode::X},
+      {"Y", KeyCode::Y},
+      {"Z", KeyCode::Z},
   });
 
-std::optional<ModifierMask> lookup_modifier(std::string_view token)
-{
-  if (token == "SHIFT") {
-    return ModifierMask::Logical(ModifierGroup::Shift);
-  }
-  if (token == "CTRL") {
-    return ModifierMask::Logical(ModifierGroup::Ctrl);
-  }
-  if (token == "ALT") {
-    return ModifierMask::Logical(ModifierGroup::Alt);
-  }
-  if (token == "WIN") {
-    return ModifierMask::Logical(ModifierGroup::Win);
-  }
-  if (token == "CMD") {
-    return ModifierMask::Logical(ModifierGroup::Command);
-  }
-  if (token == "APPLE") {
-    return ModifierMask::Logical(ModifierGroup::Command);
-  }
-  if (auto key = LookupKey(token); key && IsModifierKey(*key)) {
-    return ModifierMask::FromPressedKey(*key);
-  }
-  return std::nullopt;
-}
-
-bool modifiers_can_match_same_input(const ParsedChord& lhs, const ParsedChord& rhs)
-{
-  return lhs.modifiers.effective_logical_bits() == rhs.modifiers.effective_logical_bits();
-}
-
-bool conflicts_with(const ConflictGroup lhs, const ConflictGroup rhs)
-{ return lhs != ConflictGroup::None && lhs == rhs; }
-
-std::optional<std::string_view> find_override(const std::span<const BindingOverride> overrides,
-                                              const InputActionId action)
-{
-  const auto found = std::ranges::find_if(overrides, [action](const auto& entry) { return entry.action == action; });
-  if (found == overrides.end()) {
+  std::optional<ModifierMask> lookup_modifier(std::string_view token)
+  {
+    if (token == "SHIFT") {
+      return ModifierMask::Logical(ModifierGroup::Shift);
+    }
+    if (token == "CTRL") {
+      return ModifierMask::Logical(ModifierGroup::Ctrl);
+    }
+    if (token == "ALT") {
+      return ModifierMask::Logical(ModifierGroup::Alt);
+    }
+    if (token == "WIN") {
+      return ModifierMask::Logical(ModifierGroup::Win);
+    }
+    if (token == "CMD") {
+      return ModifierMask::Logical(ModifierGroup::Command);
+    }
+    if (token == "APPLE") {
+      return ModifierMask::Logical(ModifierGroup::Command);
+    }
+    if (auto key = LookupKey(token); key && IsModifierKey(*key)) {
+      return ModifierMask::FromPressedKey(*key);
+    }
     return std::nullopt;
   }
-  return found->binding;
-}
+
+  bool modifiers_can_match_same_input(const ParsedChord& lhs, const ParsedChord& rhs)
+  { return lhs.modifiers.effective_logical_bits() == rhs.modifiers.effective_logical_bits(); }
+
+  bool conflicts_with(const ConflictGroup lhs, const ConflictGroup rhs)
+  { return lhs != ConflictGroup::None && lhs == rhs; }
+
+  std::optional<std::string_view> find_override(const std::span<const BindingOverride> overrides,
+                                                const InputActionId                    action)
+  {
+    const auto found = std::ranges::find_if(overrides, [action](const auto& entry) { return entry.action == action; });
+    if (found == overrides.end()) {
+      return std::nullopt;
+    }
+    return found->binding;
+  }
 } // namespace
 
 bool ParsedChord::Matches(const KeyCode pressed_key, const ModifierMask held_modifiers,
@@ -280,13 +297,14 @@ bool ParsedChord::Matches(const KeyCode pressed_key, const ModifierMask held_mod
 }
 
 bool ParsedBinding::has_valid_chord() const
-{ return std::ranges::any_of(chords, [](const auto& chord) { return chord.valid; }); }
+{
+  return std::ranges::any_of(chords, [](const auto& chord) { return chord.valid; });
+}
 
 bool ParsedBinding::has_warnings() const
 {
-  return std::ranges::any_of(diagnostics, [](const auto& diagnostic) {
-    return diagnostic.severity == DiagnosticSeverity::Warning;
-  });
+  return std::ranges::any_of(diagnostics,
+                             [](const auto& diagnostic) { return diagnostic.severity == DiagnosticSeverity::Warning; });
 }
 
 bool ParsedBinding::has_errors() const
@@ -316,9 +334,8 @@ std::string ParsedBinding::DisplayString() const
 
 bool CompileResult::has_warnings() const
 {
-  return std::ranges::any_of(diagnostics, [](const auto& diagnostic) {
-    return diagnostic.severity == DiagnosticSeverity::Warning;
-  });
+  return std::ranges::any_of(diagnostics,
+                             [](const auto& diagnostic) { return diagnostic.severity == DiagnosticSeverity::Warning; });
 }
 
 bool CompileResult::has_errors() const
@@ -338,18 +355,17 @@ void BindingIndex::Register(const InputActionId action, ParsedChord chord, const
   }
   auto& bucket = trigger_mode == TriggerMode::Pressed ? pressed_ : down_;
   bucket[static_cast<size_t>(chord.key)].push_back({action, std::move(chord), trigger_mode, priority});
-  std::ranges::sort(bucket[static_cast<size_t>(chord.key)], [](const auto& lhs, const auto& rhs) {
-    return lhs.priority > rhs.priority;
-  });
+  std::ranges::sort(bucket[static_cast<size_t>(chord.key)],
+                    [](const auto& lhs, const auto& rhs) { return lhs.priority > rhs.priority; });
   ++size_;
 }
 
 std::vector<InputActionId> BindingIndex::Match(const TriggerMode trigger_mode, const KeyCode key,
                                                const ModifierMask held_modifiers,
-                                               const bool allow_extra_modifiers) const
+                                               const bool         allow_extra_modifiers) const
 {
   std::vector<InputActionId> matches;
-  const auto& bucket = buckets_for(trigger_mode)[static_cast<size_t>(key)];
+  const auto&                bucket = buckets_for(trigger_mode)[static_cast<size_t>(key)];
   for (const auto& binding : bucket) {
     if (binding.chord.Matches(key, held_modifiers, allow_extra_modifiers)) {
       matches.push_back(binding.action);
@@ -377,16 +393,16 @@ const InputActionSpec* FindActionSpec(const InputActionId id)
 const InputActionSpec* FindActionSpec(const std::string_view canonical_key)
 {
   const auto specs = ActionSpecs();
-  const auto found = std::ranges::find_if(specs, [canonical_key](const auto& spec) {
-    return spec.canonical_key == canonical_key;
-  });
+  const auto found =
+      std::ranges::find_if(specs, [canonical_key](const auto& spec) { return spec.canonical_key == canonical_key; });
   return found == specs.end() ? nullptr : &*found;
 }
 
 std::optional<KeyCode> LookupKey(const std::string_view key_name)
 {
   const auto normalized = AsciiStrToUpper(StripAsciiWhitespace(key_name));
-  const auto found = std::ranges::find_if(kKeyNames, [&normalized](const auto& item) { return item.name == normalized; });
+  const auto found =
+      std::ranges::find_if(kKeyNames, [&normalized](const auto& item) { return item.name == normalized; });
   if (found != kKeyNames.end()) {
     return found->key;
   }
@@ -457,15 +473,15 @@ bool IsModifierKey(const KeyCode key)
 ParsedChord ParseChord(const std::string_view chord_text)
 {
   ParsedChord chord;
-  const auto normalized = AsciiStrToUpper(StripAsciiWhitespace(chord_text));
-  chord.display = normalized;
+  const auto  normalized = AsciiStrToUpper(StripAsciiWhitespace(chord_text));
+  chord.display          = normalized;
 
   if (normalized.empty()) {
     return chord;
   }
 
   if (auto key = LookupKey(normalized); key && !IsModifierKey(*key)) {
-    chord.key = *key;
+    chord.key   = *key;
     chord.valid = true;
     return chord;
   }
@@ -493,7 +509,7 @@ ParsedChord ParseChord(const std::string_view chord_text)
 ParsedBinding ParseBinding(const std::string_view binding_text)
 {
   ParsedBinding binding;
-  const auto normalized = AsciiStrToUpper(StripAsciiWhitespace(binding_text));
+  const auto    normalized = AsciiStrToUpper(StripAsciiWhitespace(binding_text));
   if (normalized == "NONE") {
     binding.unbound = true;
     return binding;
@@ -524,7 +540,7 @@ CompileResult CompileBindingSet(const std::span<const BindingOverride> overrides
   struct RegisteredChord {
     InputActionId action = InputActionId::Max;
     ParsedChord   chord;
-    TriggerMode   trigger_mode = TriggerMode::Down;
+    TriggerMode   trigger_mode   = TriggerMode::Down;
     ConflictGroup conflict_group = ConflictGroup::None;
   };
 
@@ -534,7 +550,7 @@ CompileResult CompileBindingSet(const std::span<const BindingOverride> overrides
 
   for (const auto& spec : ActionSpecs()) {
     const auto binding_text = find_override(overrides, spec.id).value_or(spec.default_bind);
-    auto       parsed = ParseBinding(binding_text);
+    auto       parsed       = ParseBinding(binding_text);
 
     for (auto diagnostic : parsed.diagnostics) {
       diagnostic.action = spec.id;
@@ -552,13 +568,14 @@ CompileResult CompileBindingSet(const std::span<const BindingOverride> overrides
 
       for (const auto& registered : registered_chords) {
         if (registered.trigger_mode != spec.trigger_mode || registered.chord.key != chord.key
-          || !modifiers_can_match_same_input(registered.chord, chord)
+            || !modifiers_can_match_same_input(registered.chord, chord)
             || !conflicts_with(registered.conflict_group, spec.conflict_group)) {
           continue;
         }
 
         result.conflicts.push_back({registered.action, spec.id, chord, spec.trigger_mode, spec.conflict_group});
-        result.diagnostics.push_back({DiagnosticSeverity::Error, "Binding conflict", result.bound_chord_count, spec.id});
+        result.diagnostics.push_back(
+            {DiagnosticSeverity::Error, "Binding conflict", result.bound_chord_count, spec.id});
       }
 
       result.bindings.push_back({spec.id, chord, spec.trigger_mode, spec.priority});

--- a/mods/src/patches/input_binding/input_binding.h
+++ b/mods/src/patches/input_binding/input_binding.h
@@ -19,6 +19,15 @@ enum class InputActionId : uint16_t {
   FleetViewInfo,
   FleetQueueClear,
   FleetQueueToggle,
+  SelectShip1,
+  SelectShip2,
+  SelectShip3,
+  SelectShip4,
+  SelectShip5,
+  SelectShip6,
+  SelectShip7,
+  SelectShip8,
+  SelectCurrent,
   HotkeysDisable,
   HotkeysEnable,
   LogDebug,
@@ -143,15 +152,15 @@ public:
   constexpr void AddPhysical(PhysicalModifier modifier);
   constexpr void Merge(ModifierMask other);
 
-  [[nodiscard]] constexpr bool empty() const;
-  [[nodiscard]] constexpr bool IsSatisfiedBy(ModifierMask held) const;
-  [[nodiscard]] constexpr bool IsExactMatch(ModifierMask held) const;
+  [[nodiscard]] constexpr bool     empty() const;
+  [[nodiscard]] constexpr bool     IsSatisfiedBy(ModifierMask held) const;
+  [[nodiscard]] constexpr bool     IsExactMatch(ModifierMask held) const;
   [[nodiscard]] constexpr uint32_t logical_bits() const;
   [[nodiscard]] constexpr uint32_t physical_bits() const;
   [[nodiscard]] constexpr uint32_t effective_logical_bits() const;
 
 private:
-  uint32_t logical_bits_ = 0;
+  uint32_t logical_bits_  = 0;
   uint32_t physical_bits_ = 0;
 };
 
@@ -165,28 +174,28 @@ struct BindingDiagnostic {
   DiagnosticSeverity severity = DiagnosticSeverity::Info;
   std::string        message;
   size_t             token_index = 0;
-  InputActionId      action = InputActionId::Max;
+  InputActionId      action      = InputActionId::Max;
 };
 
 struct ParsedChord {
-  KeyCode      key = KeyCode::None;
-  ModifierMask modifiers;
-  std::string  display;
+  KeyCode                        key = KeyCode::None;
+  ModifierMask                   modifiers;
+  std::string                    display;
   std::vector<BindingDiagnostic> diagnostics;
-  bool         valid = false;
+  bool                           valid = false;
 
   [[nodiscard]] bool Matches(KeyCode pressed_key, ModifierMask held_modifiers,
                              bool allow_extra_modifiers = false) const;
 };
 
 struct ParsedBinding {
-  std::vector<ParsedChord>      chords;
+  std::vector<ParsedChord>       chords;
   std::vector<BindingDiagnostic> diagnostics;
-  bool                          unbound = false;
+  bool                           unbound = false;
 
-  [[nodiscard]] bool has_valid_chord() const;
-  [[nodiscard]] bool has_warnings() const;
-  [[nodiscard]] bool has_errors() const;
+  [[nodiscard]] bool        has_valid_chord() const;
+  [[nodiscard]] bool        has_warnings() const;
+  [[nodiscard]] bool        has_errors() const;
   [[nodiscard]] std::string DisplayString() const;
 };
 
@@ -194,7 +203,7 @@ struct CompiledBinding {
   InputActionId action = InputActionId::Max;
   ParsedChord   chord;
   TriggerMode   trigger_mode = TriggerMode::Down;
-  uint16_t      priority = 0;
+  uint16_t      priority     = 0;
 };
 
 class BindingIndex
@@ -204,11 +213,11 @@ public:
 
   [[nodiscard]] std::vector<InputActionId> Match(TriggerMode trigger_mode, KeyCode key, ModifierMask held_modifiers,
                                                  bool allow_extra_modifiers = false) const;
-  [[nodiscard]] size_t size() const;
+  [[nodiscard]] size_t                     size() const;
 
 private:
   static constexpr size_t kKeyCodeCount = static_cast<size_t>(KeyCode::Max) + 1;
-  using BindingBuckets = std::array<std::vector<CompiledBinding>, kKeyCodeCount>;
+  using BindingBuckets                  = std::array<std::vector<CompiledBinding>, kKeyCodeCount>;
 
   [[nodiscard]] const BindingBuckets& buckets_for(TriggerMode trigger_mode) const;
 
@@ -218,15 +227,15 @@ private:
 };
 
 struct BindingOverride {
-  InputActionId    action = InputActionId::Max;
-  std::string      binding;
+  InputActionId action = InputActionId::Max;
+  std::string   binding;
 };
 
 struct BindingConflict {
   InputActionId action_a = InputActionId::Max;
   InputActionId action_b = InputActionId::Max;
   ParsedChord   chord;
-  TriggerMode   trigger_mode = TriggerMode::Down;
+  TriggerMode   trigger_mode   = TriggerMode::Down;
   ConflictGroup conflict_group = ConflictGroup::None;
 };
 
@@ -243,13 +252,13 @@ struct CompileResult {
 };
 
 [[nodiscard]] std::span<const InputActionSpec> ActionSpecs();
-[[nodiscard]] const InputActionSpec* FindActionSpec(InputActionId id);
-[[nodiscard]] const InputActionSpec* FindActionSpec(std::string_view canonical_key);
-[[nodiscard]] std::optional<KeyCode> LookupKey(std::string_view key_name);
-[[nodiscard]] bool IsModifierKey(KeyCode key);
-[[nodiscard]] ParsedChord ParseChord(std::string_view chord_text);
-[[nodiscard]] ParsedBinding ParseBinding(std::string_view binding_text);
-[[nodiscard]] CompileResult CompileBindingSet(std::span<const BindingOverride> overrides = {});
+[[nodiscard]] const InputActionSpec*           FindActionSpec(InputActionId id);
+[[nodiscard]] const InputActionSpec*           FindActionSpec(std::string_view canonical_key);
+[[nodiscard]] std::optional<KeyCode>           LookupKey(std::string_view key_name);
+[[nodiscard]] bool                             IsModifierKey(KeyCode key);
+[[nodiscard]] ParsedChord                      ParseChord(std::string_view chord_text);
+[[nodiscard]] ParsedBinding                    ParseBinding(std::string_view binding_text);
+[[nodiscard]] CompileResult                    CompileBindingSet(std::span<const BindingOverride> overrides = {});
 
 } // namespace input_binding
 
@@ -330,24 +339,29 @@ constexpr uint32_t input_binding::ModifierMask::physical_bits() const
 constexpr uint32_t input_binding::ModifierMask::effective_logical_bits() const
 {
   auto bits = logical_bits_;
-  if (physical_bits_ & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftShift))
-                        | (1u << static_cast<uint8_t>(PhysicalModifier::RightShift)))) {
+  if (physical_bits_
+      & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftShift))
+         | (1u << static_cast<uint8_t>(PhysicalModifier::RightShift)))) {
     bits |= (1u << static_cast<uint8_t>(ModifierGroup::Shift));
   }
-  if (physical_bits_ & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftControl))
-                        | (1u << static_cast<uint8_t>(PhysicalModifier::RightControl)))) {
+  if (physical_bits_
+      & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftControl))
+         | (1u << static_cast<uint8_t>(PhysicalModifier::RightControl)))) {
     bits |= (1u << static_cast<uint8_t>(ModifierGroup::Ctrl));
   }
-  if (physical_bits_ & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftAlt))
-                        | (1u << static_cast<uint8_t>(PhysicalModifier::RightAlt)))) {
+  if (physical_bits_
+      & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftAlt))
+         | (1u << static_cast<uint8_t>(PhysicalModifier::RightAlt)))) {
     bits |= (1u << static_cast<uint8_t>(ModifierGroup::Alt));
   }
-  if (physical_bits_ & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftWindows))
-                        | (1u << static_cast<uint8_t>(PhysicalModifier::RightWindows)))) {
+  if (physical_bits_
+      & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftWindows))
+         | (1u << static_cast<uint8_t>(PhysicalModifier::RightWindows)))) {
     bits |= (1u << static_cast<uint8_t>(ModifierGroup::Win));
   }
-  if (physical_bits_ & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftCommand))
-                        | (1u << static_cast<uint8_t>(PhysicalModifier::RightCommand)))) {
+  if (physical_bits_
+      & ((1u << static_cast<uint8_t>(PhysicalModifier::LeftCommand))
+         | (1u << static_cast<uint8_t>(PhysicalModifier::RightCommand)))) {
     bits |= (1u << static_cast<uint8_t>(ModifierGroup::Command));
   }
   if (physical_bits_ & (1u << static_cast<uint8_t>(PhysicalModifier::AltGr))) {

--- a/mods/src/patches/input_binding/input_config_bridge.cc
+++ b/mods/src/patches/input_binding/input_config_bridge.cc
@@ -8,227 +8,223 @@
 
 namespace input_binding
 {
-namespace {
-struct BindingCandidate {
-  std::string             binding;
-  std::string             source_key;
-  BindingConfigSourceKind source_kind = BindingConfigSourceKind::Default;
-};
-
-void add_warning(ConfigBridgeResult& result, std::string message)
-{ result.compatibility_warnings.push_back(std::move(message)); }
-
-std::optional<std::string> normalize_binding_string(const std::string_view value)
+namespace
 {
-  const auto trimmed = StripAsciiWhitespace(value);
-  if (trimmed.empty()) {
+  struct BindingCandidate {
+    std::string             binding;
+    std::string             source_key;
+    BindingConfigSourceKind source_kind = BindingConfigSourceKind::Default;
+  };
+
+  void add_warning(ConfigBridgeResult& result, std::string message)
+  { result.compatibility_warnings.push_back(std::move(message)); }
+
+  std::optional<std::string> normalize_binding_string(const std::string_view value)
+  {
+    const auto trimmed = StripAsciiWhitespace(value);
+    if (trimmed.empty()) {
+      return std::nullopt;
+    }
+    return AsciiStrToUpper(trimmed);
+  }
+
+  const toml::table* input_bindings_table(const toml::table& config)
+  {
+    const auto* input = config["input"].as_table();
+    return input ? (*input)["bindings"].as_table() : nullptr;
+  }
+
+  const toml::table* shortcuts_table(const toml::table& config)
+  { return config["shortcuts"].as_table(); }
+
+  std::optional<std::string> read_binding_value(const toml::node_view<const toml::node> node,
+                                                const std::string& source_key, ConfigBridgeResult& result)
+  {
+    if (const auto value = node.value<std::string>()) {
+      auto normalized = normalize_binding_string(*value);
+      if (!normalized) {
+        add_warning(result, source_key + " is empty after trimming; ignoring configured value.");
+      }
+      return normalized;
+    }
+
+    if (const auto* array = node.as_array()) {
+      std::string joined;
+      for (size_t index = 0; index < array->size(); ++index) {
+        const auto item = (*array)[index].value<std::string>();
+        if (!item) {
+          add_warning(result, source_key + "[" + std::to_string(index) + "] must be a string; ignoring item.");
+          continue;
+        }
+
+        auto normalized = normalize_binding_string(*item);
+        if (!normalized) {
+          add_warning(result, source_key + "[" + std::to_string(index) + "] is empty after trimming; ignoring item.");
+          continue;
+        }
+
+        if (!joined.empty()) {
+          joined.append("|");
+        }
+        joined.append(*normalized);
+      }
+
+      if (joined.empty()) {
+        add_warning(result, source_key + " has no valid string items; ignoring configured value.");
+        return std::nullopt;
+      }
+
+      return joined;
+    }
+
+    add_warning(result, source_key + " must be a string or array of strings; ignoring configured value.");
     return std::nullopt;
   }
-  return AsciiStrToUpper(trimmed);
-}
 
-const toml::table* input_bindings_table(const toml::table& config)
-{
-  const auto* input = config["input"].as_table();
-  return input ? (*input)["bindings"].as_table() : nullptr;
-}
-
-const toml::table* shortcuts_table(const toml::table& config)
-{ return config["shortcuts"].as_table(); }
-
-std::optional<std::string> read_binding_value(const toml::node_view<const toml::node> node, const std::string& source_key,
-                                              ConfigBridgeResult& result)
-{
-  if (const auto value = node.value<std::string>()) {
-    auto normalized = normalize_binding_string(*value);
-    if (!normalized) {
-      add_warning(result, source_key + " is empty after trimming; ignoring configured value.");
-    }
-    return normalized;
-  }
-
-  if (const auto* array = node.as_array()) {
-    std::string joined;
-    for (size_t index = 0; index < array->size(); ++index) {
-      const auto item = (*array)[index].value<std::string>();
-      if (!item) {
-        add_warning(result, source_key + "[" + std::to_string(index) + "] must be a string; ignoring item.");
-        continue;
-      }
-
-      auto normalized = normalize_binding_string(*item);
-      if (!normalized) {
-        add_warning(result, source_key + "[" + std::to_string(index) + "] is empty after trimming; ignoring item.");
-        continue;
-      }
-
-      if (!joined.empty()) {
-        joined.append("|");
-      }
-      joined.append(*normalized);
-    }
-
-    if (joined.empty()) {
-      add_warning(result, source_key + " has no valid string items; ignoring configured value.");
+  std::optional<BindingCandidate> read_candidate(const toml::table* table, const std::string_view key,
+                                                 const std::string_view        source_prefix,
+                                                 const BindingConfigSourceKind source_kind, ConfigBridgeResult& result,
+                                                 const std::string_view deprecation_warning = {})
+  {
+    if (!table || !table->contains(key)) {
       return std::nullopt;
     }
 
-    return joined;
-  }
-
-  add_warning(result, source_key + " must be a string or array of strings; ignoring configured value.");
-  return std::nullopt;
-}
-
-std::optional<BindingCandidate> read_candidate(const toml::table* table,
-                                               const std::string_view key,
-                                               const std::string_view source_prefix,
-                                               const BindingConfigSourceKind source_kind,
-                                               ConfigBridgeResult& result,
-                                               const std::string_view deprecation_warning = {})
-{
-  if (!table || !table->contains(key)) {
-    return std::nullopt;
-  }
-
-  const std::string source_key = std::string(source_prefix) + std::string(key);
-  auto              binding    = read_binding_value((*table)[key], source_key, result);
-  if (!binding) {
-    return std::nullopt;
-  }
-
-  if (!deprecation_warning.empty()) {
-    add_warning(result, std::string(deprecation_warning));
-  }
-
-  return BindingCandidate{std::move(*binding), source_key, source_kind};
-}
-
-BindingCandidate default_candidate(const InputActionSpec& spec)
-{
-  return BindingCandidate{std::string(spec.default_bind), "default", BindingConfigSourceKind::Default};
-}
-
-void warn_conflict(const InputActionSpec& spec,
-                   const BindingCandidate& chosen,
-                   const BindingCandidate& ignored,
-                   ConfigBridgeResult& result)
-{
-  std::ostringstream message;
-  message << "Conflicting bindings for [input.bindings]." << spec.canonical_key << ": using " << chosen.source_key
-          << "='" << chosen.binding << "', ignoring " << ignored.source_key << "='" << ignored.binding << "'.";
-  add_warning(result, message.str());
-}
-
-ResolvedBinding resolve_binding(const InputActionSpec& spec,
-                                const std::vector<std::optional<BindingCandidate>>& candidates,
-                                ConfigBridgeResult& result)
-{
-  auto chosen        = default_candidate(spec);
-  bool saw_explicit  = false;
-
-  for (const auto& candidate : candidates) {
-    if (!candidate) {
-      continue;
+    const std::string source_key = std::string(source_prefix) + std::string(key);
+    auto              binding    = read_binding_value((*table)[key], source_key, result);
+    if (!binding) {
+      return std::nullopt;
     }
 
-    if (!saw_explicit) {
-      chosen = *candidate;
-      saw_explicit = true;
-      continue;
+    if (!deprecation_warning.empty()) {
+      add_warning(result, std::string(deprecation_warning));
     }
 
-    if (candidate->binding != chosen.binding) {
-      warn_conflict(spec, chosen, *candidate, result);
+    return BindingCandidate{std::move(*binding), source_key, source_kind};
+  }
+
+  BindingCandidate default_candidate(const InputActionSpec& spec)
+  { return BindingCandidate{std::string(spec.default_bind), "default", BindingConfigSourceKind::Default}; }
+
+  void warn_conflict(const InputActionSpec& spec, const BindingCandidate& chosen, const BindingCandidate& ignored,
+                     ConfigBridgeResult& result)
+  {
+    std::ostringstream message;
+    message << "Conflicting bindings for [input.bindings]." << spec.canonical_key << ": using " << chosen.source_key
+            << "='" << chosen.binding << "', ignoring " << ignored.source_key << "='" << ignored.binding << "'.";
+    add_warning(result, message.str());
+  }
+
+  ResolvedBinding resolve_binding(const InputActionSpec&                              spec,
+                                  const std::vector<std::optional<BindingCandidate>>& candidates,
+                                  ConfigBridgeResult&                                 result)
+  {
+    auto chosen       = default_candidate(spec);
+    bool saw_explicit = false;
+
+    for (const auto& candidate : candidates) {
+      if (!candidate) {
+        continue;
+      }
+
+      if (!saw_explicit) {
+        chosen       = *candidate;
+        saw_explicit = true;
+        continue;
+      }
+
+      if (candidate->binding != chosen.binding) {
+        warn_conflict(spec, chosen, *candidate, result);
+      }
     }
+
+    return ResolvedBinding{spec.id, std::string(spec.canonical_key), std::move(chosen.binding),
+                           std::move(chosen.source_key), chosen.source_kind};
   }
 
-  return ResolvedBinding{spec.id, std::string(spec.canonical_key), std::move(chosen.binding),
-                         std::move(chosen.source_key), chosen.source_kind};
-}
+  std::optional<BindingCandidate> resolve_disable_hotkeys_shortcut(const toml::table&  config,
+                                                                   ConfigBridgeResult& result)
+  {
+    const auto* shortcuts = shortcuts_table(config);
+    auto        canonical =
+        read_candidate(shortcuts, "set_hotkeys_disable", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result);
+    auto typo = read_candidate(
+        shortcuts, "set_hotkeys_disble", "[shortcuts].", BindingConfigSourceKind::DeprecatedAlias, result,
+        "[shortcuts].set_hotkeys_disble is deprecated; prefer [input.bindings].hotkeys_disable or "
+        "[shortcuts].set_hotkeys_disable.");
+    auto legacy = read_candidate(
+        shortcuts, "set_hotkeys_disabled", "[shortcuts].", BindingConfigSourceKind::DeprecatedAlias, result,
+        "[shortcuts].set_hotkeys_disabled is deprecated; prefer [input.bindings].hotkeys_disable or "
+        "[shortcuts].set_hotkeys_disable.");
 
-std::optional<BindingCandidate> resolve_disable_hotkeys_shortcut(const toml::table& config, ConfigBridgeResult& result)
-{
-  const auto* shortcuts = shortcuts_table(config);
-  auto canonical = read_candidate(shortcuts, "set_hotkeys_disable", "[shortcuts].", BindingConfigSourceKind::LegacyAlias,
-                                  result);
-  auto typo = read_candidate(shortcuts, "set_hotkeys_disble", "[shortcuts].",
-                             BindingConfigSourceKind::DeprecatedAlias, result,
-                             "[shortcuts].set_hotkeys_disble is deprecated; prefer [input.bindings].hotkeys_disable or "
-                             "[shortcuts].set_hotkeys_disable.");
-  auto legacy = read_candidate(shortcuts, "set_hotkeys_disabled", "[shortcuts].",
-                               BindingConfigSourceKind::DeprecatedAlias, result,
-                               "[shortcuts].set_hotkeys_disabled is deprecated; prefer [input.bindings].hotkeys_disable or "
-                               "[shortcuts].set_hotkeys_disable.");
-
-  const auto* spec = FindActionSpec(InputActionId::HotkeysDisable);
-  if (!spec) {
-    return std::nullopt;
-  }
-
-  if (canonical) {
-    if (typo && typo->binding != canonical->binding) {
-      warn_conflict(*spec, *canonical, *typo, result);
+    const auto* spec = FindActionSpec(InputActionId::HotkeysDisable);
+    if (!spec) {
+      return std::nullopt;
     }
-    if (legacy && legacy->binding != canonical->binding) {
-      warn_conflict(*spec, *canonical, *legacy, result);
+
+    if (canonical) {
+      if (typo && typo->binding != canonical->binding) {
+        warn_conflict(*spec, *canonical, *typo, result);
+      }
+      if (legacy && legacy->binding != canonical->binding) {
+        warn_conflict(*spec, *canonical, *legacy, result);
+      }
+      return canonical;
     }
-    return canonical;
-  }
 
-  if (typo) {
-    if (legacy && legacy->binding != typo->binding) {
-      warn_conflict(*spec, *typo, *legacy, result);
+    if (typo) {
+      if (legacy && legacy->binding != typo->binding) {
+        warn_conflict(*spec, *typo, *legacy, result);
+      }
+      return typo;
     }
-    return typo;
+
+    return legacy;
   }
 
-  return legacy;
-}
+  std::optional<BindingCandidate> resolve_enable_hotkeys_shortcut(const toml::table& config, ConfigBridgeResult& result)
+  {
+    const auto* shortcuts = shortcuts_table(config);
+    auto        canonical =
+        read_candidate(shortcuts, "set_hotkeys_enable", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result);
+    auto legacy = read_candidate(shortcuts, "set_hotkeys_enabled", "[shortcuts].",
+                                 BindingConfigSourceKind::DeprecatedAlias, result,
+                                 "[shortcuts].set_hotkeys_enabled is accepted for compatibility; prefer "
+                                 "[input.bindings].hotkeys_enable or [shortcuts].set_hotkeys_enable.");
 
-std::optional<BindingCandidate> resolve_enable_hotkeys_shortcut(const toml::table& config, ConfigBridgeResult& result)
-{
-  const auto* shortcuts = shortcuts_table(config);
-  auto canonical = read_candidate(shortcuts, "set_hotkeys_enable", "[shortcuts].", BindingConfigSourceKind::LegacyAlias,
-                                  result);
-  auto legacy = read_candidate(shortcuts, "set_hotkeys_enabled", "[shortcuts].",
-                               BindingConfigSourceKind::DeprecatedAlias, result,
-                               "[shortcuts].set_hotkeys_enabled is accepted for compatibility; prefer "
-                               "[input.bindings].hotkeys_enable or [shortcuts].set_hotkeys_enable.");
-
-  const auto* spec = FindActionSpec(InputActionId::HotkeysEnable);
-  if (!spec) {
-    return std::nullopt;
-  }
-
-  if (canonical) {
-    if (legacy && legacy->binding != canonical->binding) {
-      warn_conflict(*spec, *canonical, *legacy, result);
+    const auto* spec = FindActionSpec(InputActionId::HotkeysEnable);
+    if (!spec) {
+      return std::nullopt;
     }
-    return canonical;
+
+    if (canonical) {
+      if (legacy && legacy->binding != canonical->binding) {
+        warn_conflict(*spec, *canonical, *legacy, result);
+      }
+      return canonical;
+    }
+
+    return legacy;
   }
 
-  return legacy;
-}
+  std::string format_binding_diagnostic(const BindingDiagnostic& diagnostic)
+  {
+    const auto*        spec = FindActionSpec(diagnostic.action);
+    std::ostringstream message;
+    message << (spec ? spec->canonical_key : "unknown") << ": " << diagnostic.message;
+    return message.str();
+  }
 
-std::string format_binding_diagnostic(const BindingDiagnostic& diagnostic)
-{
-  const auto* spec = FindActionSpec(diagnostic.action);
-  std::ostringstream message;
-  message << (spec ? spec->canonical_key : "unknown") << ": " << diagnostic.message;
-  return message.str();
-}
+  std::string format_binding_conflict(const BindingConflict& conflict)
+  {
+    const auto* action_a = FindActionSpec(conflict.action_a);
+    const auto* action_b = FindActionSpec(conflict.action_b);
 
-std::string format_binding_conflict(const BindingConflict& conflict)
-{
-  const auto* action_a = FindActionSpec(conflict.action_a);
-  const auto* action_b = FindActionSpec(conflict.action_b);
-
-  std::ostringstream message;
-  message << (action_a ? action_a->canonical_key : "unknown") << " conflicts with "
-          << (action_b ? action_b->canonical_key : "unknown") << " on '" << conflict.chord.display << "'.";
-  return message.str();
-}
+    std::ostringstream message;
+    message << (action_a ? action_a->canonical_key : "unknown") << " conflicts with "
+            << (action_b ? action_b->canonical_key : "unknown") << " on '" << conflict.chord.display << "'.";
+    return message.str();
+  }
 } // namespace
 
 std::vector<BindingOverride> ConfigBridgeResult::AsOverrides() const
@@ -257,10 +253,10 @@ ConfigBridgeResult ResolveInputBindingConfig(const toml::table& config)
 
     switch (spec.id) {
       case InputActionId::FleetPrimary:
-        candidates.push_back(read_candidate(shortcuts, "action_primary", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
-        candidates.push_back(read_candidate(shortcuts, "action_queue", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "action_primary", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "action_queue", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         candidates.push_back(read_candidate(shortcuts, "action_recall_cancel", "[shortcuts].",
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
@@ -269,22 +265,58 @@ ConfigBridgeResult ResolveInputBindingConfig(const toml::table& config)
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::FleetService:
-        candidates.push_back(read_candidate(shortcuts, "action_recall", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
-        candidates.push_back(read_candidate(shortcuts, "action_repair", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "action_recall", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "action_repair", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::FleetViewInfo:
-        candidates.push_back(read_candidate(shortcuts, "action_view", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "action_view", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::FleetQueueClear:
         candidates.push_back(read_candidate(shortcuts, "action_queue_clear", "[shortcuts].",
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::FleetQueueToggle:
-        candidates.push_back(read_candidate(shortcuts, "toggle_queue", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "toggle_queue", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip1:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship1", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip2:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship2", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip3:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship3", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip4:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship4", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip5:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship5", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip6:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship6", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip7:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship7", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectShip8:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_ship8", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
+        break;
+      case InputActionId::SelectCurrent:
+        candidates.push_back(
+            read_candidate(shortcuts, "select_current", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::HotkeysDisable:
         candidates.push_back(resolve_disable_hotkeys_shortcut(config, result));
@@ -293,16 +325,16 @@ ConfigBridgeResult ResolveInputBindingConfig(const toml::table& config)
         candidates.push_back(resolve_enable_hotkeys_shortcut(config, result));
         break;
       case InputActionId::Quit:
-        candidates.push_back(read_candidate(shortcuts, "quit", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "quit", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::UiScaleUp:
-        candidates.push_back(read_candidate(shortcuts, "ui_scaleup", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "ui_scaleup", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::UiScaleDown:
-        candidates.push_back(read_candidate(shortcuts, "ui_scaledown", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "ui_scaledown", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::UiViewerScaleUp:
         candidates.push_back(read_candidate(shortcuts, "ui_scaleviewerup", "[shortcuts].",
@@ -313,116 +345,116 @@ ConfigBridgeResult ResolveInputBindingConfig(const toml::table& config)
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::LogOff:
-        candidates.push_back(read_candidate(shortcuts, "log_off", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "log_off", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::LogError:
-        candidates.push_back(read_candidate(shortcuts, "log_error", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "log_error", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::LogWarn:
-        candidates.push_back(read_candidate(shortcuts, "log_warn", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "log_warn", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::LogInfo:
-        candidates.push_back(read_candidate(shortcuts, "log_info", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "log_info", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::LogDebug:
-        candidates.push_back(read_candidate(shortcuts, "log_debug", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "log_debug", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::LogTrace:
-        candidates.push_back(read_candidate(shortcuts, "log_trace", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "log_trace", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowQTrials:
-        candidates.push_back(read_candidate(shortcuts, "show_qtrials", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_qtrials", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowBookmarks:
-        candidates.push_back(read_candidate(shortcuts, "show_bookmarks", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_bookmarks", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowLookup:
-        candidates.push_back(read_candidate(shortcuts, "show_lookup", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_lookup", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowRefinery:
-        candidates.push_back(read_candidate(shortcuts, "show_refinery", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_refinery", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowFactions:
-        candidates.push_back(read_candidate(shortcuts, "show_factions", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_factions", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowStationExterior:
         candidates.push_back(read_candidate(shortcuts, "show_stationexterior", "[shortcuts].",
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowGalaxy:
-        candidates.push_back(read_candidate(shortcuts, "show_galaxy", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_galaxy", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowStationInterior:
         candidates.push_back(read_candidate(shortcuts, "show_stationinterior", "[shortcuts].",
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowSystem:
-        candidates.push_back(read_candidate(shortcuts, "show_system", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_system", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowArtifacts:
-        candidates.push_back(read_candidate(shortcuts, "show_artifacts", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_artifacts", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowInventory:
-        candidates.push_back(read_candidate(shortcuts, "show_inventory", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_inventory", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowMissions:
-        candidates.push_back(read_candidate(shortcuts, "show_missions", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_missions", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowResearch:
-        candidates.push_back(read_candidate(shortcuts, "show_research", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_research", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowScrapYard:
-        candidates.push_back(read_candidate(shortcuts, "show_scrapyard", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_scrapyard", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowOfficers:
-        candidates.push_back(read_candidate(shortcuts, "show_officers", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_officers", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowCommander:
-        candidates.push_back(read_candidate(shortcuts, "show_commander", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_commander", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowAwayTeam:
-        candidates.push_back(read_candidate(shortcuts, "show_awayteam", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_awayteam", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowEvents:
-        candidates.push_back(read_candidate(shortcuts, "show_events", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_events", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowExoComp:
-        candidates.push_back(read_candidate(shortcuts, "show_exocomp", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_exocomp", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowDaily:
-        candidates.push_back(read_candidate(shortcuts, "show_daily", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_daily", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowGifts:
-        candidates.push_back(read_candidate(shortcuts, "show_gifts", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_gifts", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowAlliance:
-        candidates.push_back(read_candidate(shortcuts, "show_alliance", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_alliance", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowAllianceHelp:
         candidates.push_back(read_candidate(shortcuts, "show_alliance_help", "[shortcuts].",
@@ -433,8 +465,8 @@ ConfigBridgeResult ResolveInputBindingConfig(const toml::table& config)
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowSettings:
-        candidates.push_back(read_candidate(shortcuts, "show_settings", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_settings", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::TogglePreviewLocate:
         candidates.push_back(read_candidate(shortcuts, "toggle_preview_locate", "[shortcuts].",
@@ -465,16 +497,16 @@ ConfigBridgeResult ResolveInputBindingConfig(const toml::table& config)
                                             BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ShowShips:
-        candidates.push_back(read_candidate(shortcuts, "show_ships", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "show_ships", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ZoomIn:
-        candidates.push_back(read_candidate(shortcuts, "zoom_in", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "zoom_in", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::ZoomOut:
-        candidates.push_back(read_candidate(shortcuts, "zoom_out", "[shortcuts].",
-                                            BindingConfigSourceKind::LegacyAlias, result));
+        candidates.push_back(
+            read_candidate(shortcuts, "zoom_out", "[shortcuts].", BindingConfigSourceKind::LegacyAlias, result));
         break;
       case InputActionId::Max:
         break;

--- a/tests/src/test_input_binding_core.cc
+++ b/tests/src/test_input_binding_core.cc
@@ -20,6 +20,11 @@ TEST_SUITE("input_binding")
     REQUIRE(hotkeys_enable != nullptr);
     CHECK(hotkeys_enable->default_bind == "CTRL-ALT-=");
 
+    const auto* select_ship1 = input_binding::FindActionSpec(input_binding::InputActionId::SelectShip1);
+    REQUIRE(select_ship1 != nullptr);
+    CHECK(select_ship1->canonical_key == "select_ship1");
+    CHECK(select_ship1->default_bind == "1");
+
     for (const auto& spec : specs) {
       const auto binding = input_binding::ParseBinding(spec.default_bind);
       INFO(spec.canonical_key);
@@ -40,8 +45,8 @@ TEST_SUITE("input_binding")
 
   TEST_CASE("modifier masks satisfy logical and physical requirements")
   {
-    const auto ctrl = input_binding::ModifierMask::Logical(input_binding::ModifierGroup::Ctrl);
-    auto held_left_ctrl = input_binding::ModifierMask::FromPressedKey(KeyCode::LeftControl);
+    const auto ctrl           = input_binding::ModifierMask::Logical(input_binding::ModifierGroup::Ctrl);
+    auto       held_left_ctrl = input_binding::ModifierMask::FromPressedKey(KeyCode::LeftControl);
     CHECK(ctrl.IsSatisfiedBy(held_left_ctrl));
     CHECK(ctrl.IsExactMatch(held_left_ctrl));
 
@@ -121,8 +126,8 @@ TEST_SUITE("input_binding")
 
     CHECK(index.size() == 3);
 
-    const auto held = input_binding::ModifierMask{};
-    auto matches = index.Match(input_binding::TriggerMode::Down, KeyCode::Space, held);
+    const auto held    = input_binding::ModifierMask{};
+    auto       matches = index.Match(input_binding::TriggerMode::Down, KeyCode::Space, held);
     REQUIRE(matches.size() == 2);
     CHECK(matches[0] == input_binding::InputActionId::FleetQueueClear);
     CHECK(matches[1] == input_binding::InputActionId::FleetPrimary);
@@ -136,14 +141,14 @@ TEST_SUITE("input_binding")
   {
     const auto compiled = input_binding::CompileBindingSet();
 
-    CHECK(compiled.bound_chord_count == 58);
-    CHECK(compiled.index.size() == 58);
+    CHECK(compiled.bound_chord_count == 67);
+    CHECK(compiled.index.size() == 67);
     CHECK_FALSE(compiled.has_warnings());
     CHECK_FALSE(compiled.has_errors());
     CHECK_FALSE(compiled.has_conflicts());
 
-    const auto held = input_binding::ModifierMask{};
-    auto matches = compiled.index.Match(input_binding::TriggerMode::Down, KeyCode::Space, held);
+    const auto held    = input_binding::ModifierMask{};
+    auto       matches = compiled.index.Match(input_binding::TriggerMode::Down, KeyCode::Space, held);
     REQUIRE(matches.size() == 1);
     CHECK(matches[0] == input_binding::InputActionId::FleetPrimary);
 
@@ -163,10 +168,10 @@ TEST_SUITE("input_binding")
 
     const auto compiled = input_binding::CompileBindingSet(overrides);
     CHECK_FALSE(compiled.has_errors());
-    CHECK(compiled.bound_chord_count == 56);
+    CHECK(compiled.bound_chord_count == 65);
 
-    const auto matches = compiled.index.Match(input_binding::TriggerMode::Down, KeyCode::Space,
-                                              input_binding::ModifierMask{});
+    const auto matches =
+        compiled.index.Match(input_binding::TriggerMode::Down, KeyCode::Space, input_binding::ModifierMask{});
     CHECK(matches.empty());
   }
 
@@ -196,8 +201,8 @@ TEST_SUITE("input_binding")
     CHECK(compiled.conflicts[0].action_a == input_binding::InputActionId::FleetPrimary);
     CHECK(compiled.conflicts[0].action_b == input_binding::InputActionId::FleetService);
 
-    const auto matches = compiled.index.Match(input_binding::TriggerMode::Down, KeyCode::Space,
-                                              input_binding::ModifierMask{});
+    const auto matches =
+        compiled.index.Match(input_binding::TriggerMode::Down, KeyCode::Space, input_binding::ModifierMask{});
     REQUIRE(matches.size() == 2);
     CHECK(matches[0] == input_binding::InputActionId::FleetPrimary);
     CHECK(matches[1] == input_binding::InputActionId::FleetService);
@@ -208,6 +213,7 @@ TEST_SUITE("input_binding")
     const std::array overrides{
         input_binding::BindingOverride{input_binding::InputActionId::FleetPrimary, "CTRL-SPACE"},
         input_binding::BindingOverride{input_binding::InputActionId::FleetService, "LCTRL-SPACE"},
+        input_binding::BindingOverride{input_binding::InputActionId::SelectCurrent, "NONE"},
     };
 
     const auto compiled = input_binding::CompileBindingSet(overrides);
@@ -215,7 +221,7 @@ TEST_SUITE("input_binding")
     CHECK(compiled.has_conflicts());
     REQUIRE(compiled.conflicts.size() == 1);
 
-    const auto held = input_binding::ModifierMask::FromPressedKey(KeyCode::LeftControl);
+    const auto held    = input_binding::ModifierMask::FromPressedKey(KeyCode::LeftControl);
     const auto matches = compiled.index.Match(input_binding::TriggerMode::Down, KeyCode::Space, held);
     REQUIRE(matches.size() == 2);
     CHECK(matches[0] == input_binding::InputActionId::FleetPrimary);
@@ -225,7 +231,7 @@ TEST_SUITE("input_binding")
   TEST_CASE("config bridge resolves defaults into canonical bindings")
   {
     const toml::table config;
-    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto        bridge = input_binding::ResolveInputBindingConfig(config);
 
     const auto fleet_primary = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
       return binding.action == input_binding::InputActionId::FleetPrimary;
@@ -234,6 +240,76 @@ TEST_SUITE("input_binding")
     CHECK(fleet_primary->binding == "SPACE|MOUSE1");
     CHECK(fleet_primary->source_key == "default");
     CHECK(bridge.compatibility_warnings.empty());
+  }
+
+  TEST_CASE("config bridge accepts migrated ship selection aliases")
+  {
+    const auto config = toml::parse(R"(
+[shortcuts]
+select_ship1 = "CTRL-1"
+select_current = "CTRL-SPACE"
+)");
+
+    const auto bridge  = input_binding::ResolveInputBindingConfig(config);
+    const auto ship1   = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
+      return binding.action == input_binding::InputActionId::SelectShip1;
+    });
+    const auto current = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
+      return binding.action == input_binding::InputActionId::SelectCurrent;
+    });
+
+    REQUIRE(ship1 != bridge.bindings.end());
+    REQUIRE(current != bridge.bindings.end());
+    CHECK(ship1->binding == "CTRL-1");
+    CHECK(ship1->source_key == "[shortcuts].select_ship1");
+    CHECK(current->binding == "CTRL-SPACE");
+    CHECK(current->source_key == "[shortcuts].select_current");
+  }
+
+  TEST_CASE("dispatcher snapshot generates candidates and respects layer filtering")
+  {
+    const auto       compiled = input_binding::CompileBindingSet();
+    const std::array key_states{
+        input_binding::DispatchKeyState{KeyCode::Alpha1, {}, true, false},
+    };
+
+    auto plan = input_binding::PlanDispatchSnapshot(compiled, input_binding::InputPhase::Frame,
+                                                    input_binding::ActiveLayers::All(), key_states);
+    REQUIRE(plan.candidates.size() == 1);
+    REQUIRE(plan.winners.size() == 1);
+    CHECK(plan.candidates[0].action == input_binding::InputActionId::SelectShip1);
+    CHECK(plan.winners[0].action == input_binding::InputActionId::SelectShip1);
+
+    plan = input_binding::PlanDispatchSnapshot(compiled, input_binding::InputPhase::Frame,
+                                               input_binding::ActiveLayers::Only(input_binding::InputLayer::Global),
+                                               key_states);
+    CHECK(plan.candidates.empty());
+    CHECK(plan.winners.empty());
+  }
+
+  TEST_CASE("dispatcher watched keys and conflict winners cover migrated ship selection")
+  {
+    const auto       compiled = input_binding::CompileBindingSet();
+    const std::array watched_actions{
+        input_binding::InputActionId::SelectShip1,
+        input_binding::InputActionId::SelectCurrent,
+    };
+
+    const auto watched_keys =
+        input_binding::WatchedKeysForActions(compiled, input_binding::InputPhase::Frame, watched_actions);
+    CHECK(std::ranges::find(watched_keys, KeyCode::Alpha1) != watched_keys.end());
+    CHECK(std::ranges::find(watched_keys, KeyCode::Space) != watched_keys.end());
+
+    const std::array key_states{
+        input_binding::DispatchKeyState{KeyCode::Alpha1, {}, true, false},
+        input_binding::DispatchKeyState{KeyCode::Space, {}, true, false},
+    };
+
+    const auto plan = input_binding::PlanDispatchSnapshot(compiled, input_binding::InputPhase::Frame,
+                                                          input_binding::ActiveLayers::All(), key_states);
+    REQUIRE(plan.candidates.size() == 2);
+    REQUIRE(plan.winners.size() == 1);
+    CHECK(plan.winners[0].action == input_binding::InputActionId::SelectShip1);
   }
 
   TEST_CASE("config bridge prefers canonical input bindings over legacy shortcuts")
@@ -246,7 +322,7 @@ fleet_primary = ["CTRL-A", "MOUSE4"]
 action_primary = "SPACE|MOUSE1"
 )");
 
-    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto bridge        = input_binding::ResolveInputBindingConfig(config);
     const auto fleet_primary = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
       return binding.action == input_binding::InputActionId::FleetPrimary;
     });
@@ -265,7 +341,7 @@ action_queue = "Q"
 action_recall_cancel = "SPACE|MOUSE1"
 )");
 
-    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto bridge        = input_binding::ResolveInputBindingConfig(config);
     const auto fleet_primary = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
       return binding.action == input_binding::InputActionId::FleetPrimary;
     });
@@ -282,7 +358,7 @@ action_recall_cancel = "SPACE|MOUSE1"
 set_hotkeys_enabled = "CTRL-ALT-F1"
 )");
 
-    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto bridge         = input_binding::ResolveInputBindingConfig(config);
     const auto hotkeys_enable = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
       return binding.action == input_binding::InputActionId::HotkeysEnable;
     });
@@ -299,7 +375,7 @@ set_hotkeys_enabled = "CTRL-ALT-F1"
 fleet_service = "CTRL-R"
 )");
 
-    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto bridge  = input_binding::ResolveInputBindingConfig(config);
     const auto compile = input_binding::CompileBindingSet(bridge.AsOverrides());
     const auto runtime = input_binding::BuildInputBindingRuntimeConfig(bridge, compile);
 

--- a/tests/src/test_pure_common.h
+++ b/tests/src/test_pure_common.h
@@ -10,6 +10,7 @@
 #include "patches/fleet_input_policy.h"
 #include "patches/input_binding/input_binding.h"
 #include "patches/input_binding/input_config_bridge.h"
+#include "patches/input_binding/input_dispatcher.h"
 #include "patches/live_debug_event_store.h"
 #include "patches/live_debug_fleet_serializers.h"
 #include "patches/live_debug_recent_event_requests.h"


### PR DESCRIPTION
Moves the next bounded #49 dispatcher slice onto the compiled input binding path.

Summary:
- adds canonical `select_ship1` through `select_ship8` and `select_current` actions to the unified input schema
- preserves legacy `[shortcuts].select_ship*` and `[shortcuts].select_current` compatibility through the config bridge
- includes those actions in the frame dispatch snapshot and routes ship selection / select-current off dispatcher winners instead of direct `MapKey` checks
- adds pure tests for migrated aliases, dispatcher candidate generation, layer filtering, watched keys, and fleet conflict winner behavior

Validation run:
- `xmake run -y stfc-mod-tests` passed: 155 test cases / 1062 assertions
- `xmake build -y stfc-community-mod` passed
- `git diff --check` passed
- `ax cycle` passed: deploy hash matched, boot `ok: true`, recent log scan `errorCount: 0`

Closes #49