### PR TITLE
Redact sync secrets in runtime vars

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -7,6 +7,7 @@
  * macOS config-path migration, and converts legacy sync options.
  */
 #include "config.h"
+#include "config_redaction.h"
 #include "config_schema.h"
 #include "file.h"
 #include "patches/input_binding/input_config_bridge.h"
@@ -498,59 +499,10 @@ void Config::AdjustUiViewerScale(bool scaleUp)
  * @return The token with interior characters replaced by '*' (preserving dashes).
  */
 inline std::string mask_token(const std::string& token)
-{
-  if (token.empty()) {
-    return "<empty>";
-  }
-
-  std::string masked = token;
-  if (token.size() > 21) {
-    for (size_t i = 9; i < token.size() - 12; ++i) {
-      if (masked[i] != '-') {
-        masked[i] = '*';
-      }
-    }
-    return masked;
-  }
-
-  if (token.size() > 8) {
-    for (size_t i = 4; i < token.size() - 4; ++i) {
-      if (masked[i] != '-') {
-        masked[i] = '*';
-      }
-    }
-    return masked;
-  }
-
-  for (auto& ch : masked) {
-    if (ch != '-') {
-      ch = '*';
-    }
-  }
-  return masked;
-}
+{ return config_redaction::mask_token_for_log(token); }
 
 inline std::string mask_proxy_for_log(const std::string& proxy)
-{
-  if (proxy.empty()) {
-    return {};
-  }
-
-  const auto scheme_pos = proxy.find("://");
-  const auto authority_start = scheme_pos == std::string::npos ? 0 : scheme_pos + 3;
-  const auto at_pos = proxy.find('@', authority_start);
-  if (at_pos == std::string::npos) {
-    return proxy;
-  }
-
-  auto masked = proxy;
-  for (auto index = authority_start; index < at_pos; ++index) {
-    if (masked[index] != ':' && masked[index] != '/') {
-      masked[index] = '*';
-    }
-  }
-  return masked;
-}
+{ return config_redaction::mask_proxy_userinfo(proxy); }
 
 /** @brief Convert a toml::node_type to a human-readable string for diagnostics. */
 std::string get_config_type_as_string(const toml::node_type type)
@@ -851,8 +803,8 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
               defaults.allow_unsafe_tls_without_certificate_validation);
 
       parsed_target.insert("url", target.url);
-      parsed_target.insert("token", target.token);
-      parsed_target.insert("proxy", target.proxy);
+      parsed_target.insert("token", config_redaction::redact_secret_for_runtime_snapshot(target.token));
+      parsed_target.insert("proxy", config_redaction::mask_proxy_userinfo(target.proxy));
       parsed_target.insert("verify_ssl", target.verify_ssl);
       parsed_target.insert("allow_unsafe_tls_without_certificate_validation",
                            target.allow_unsafe_tls_without_certificate_validation);
@@ -1306,7 +1258,11 @@ void Config::Load()
       get_config_or_default(config, parsed, "sync", "resolver_cache_ttl", DCS::resolver_cache_ttl, write_config);
 
   SyncConfig sync_defaults;
-  sync_defaults.proxy      = get_config_or_default<std::string>(config, parsed, "sync", "proxy", DCS::proxy, write_log);
+  sync_defaults.proxy      = get_config_or_default<std::string>(config, parsed, "sync", "proxy", DCS::proxy, false);
+  parsed["sync"].as_table()->insert_or_assign("proxy", config_redaction::mask_proxy_userinfo(sync_defaults.proxy));
+  if (write_log) {
+    spdlog::debug("config value sync.proxy value: {}", mask_proxy_for_log(sync_defaults.proxy));
+  }
   sync_defaults.verify_ssl = get_config_or_default(config, parsed, "sync", "verify_ssl", DCS::verify_ssl, write_config);
   sync_defaults.allow_unsafe_tls_without_certificate_validation = get_config_or_default(
       config, parsed, "sync", "allow_unsafe_tls_without_certificate_validation",
@@ -1336,8 +1292,8 @@ void Config::Load()
 
     if (this->sync_targets.emplace("default", converted_target).second) {
       toml::table default_target{{"url", sync_url.value()},
-                                 {"token", sync_token.value()},
-                                 {"proxy", converted_target.proxy},
+                                 {"token", config_redaction::redact_secret_for_runtime_snapshot(converted_target.token)},
+                                 {"proxy", config_redaction::mask_proxy_userinfo(converted_target.proxy)},
                                  {"verify_ssl", converted_target.verify_ssl},
                                  {"allow_unsafe_tls_without_certificate_validation",
                                   converted_target.allow_unsafe_tls_without_certificate_validation}};

--- a/mods/src/config_redaction.cc
+++ b/mods/src/config_redaction.cc
@@ -1,0 +1,65 @@
+#include "config_redaction.h"
+
+namespace config_redaction
+{
+std::string mask_token_for_log(const std::string& token)
+{
+  if (token.empty()) {
+    return "<empty>";
+  }
+
+  std::string masked{token};
+  if (token.size() > 21) {
+    for (size_t i = 9; i < token.size() - 12; ++i) {
+      if (masked[i] != '-') {
+        masked[i] = '*';
+      }
+    }
+    return masked;
+  }
+
+  if (token.size() > 8) {
+    for (size_t i = 4; i < token.size() - 4; ++i) {
+      if (masked[i] != '-') {
+        masked[i] = '*';
+      }
+    }
+    return masked;
+  }
+
+  for (auto& ch : masked) {
+    if (ch != '-') {
+      ch = '*';
+    }
+  }
+  return masked;
+}
+
+std::string redact_secret_for_runtime_snapshot(const std::string& secret)
+{ return secret.empty() ? std::string{"<empty>"} : std::string{"<redacted>"}; }
+
+std::string mask_proxy_userinfo(const std::string& proxy)
+{
+  if (proxy.empty()) {
+    return {};
+  }
+
+  std::string masked{proxy};
+  const auto  scheme_pos      = masked.find("://");
+  const auto  authority_start = scheme_pos == std::string::npos ? 0 : scheme_pos + 3;
+  const auto  authority_end   = masked.find_first_of("/?#", authority_start);
+  const auto  at_pos          = masked.find('@', authority_start);
+
+  if (at_pos == std::string::npos || (authority_end != std::string::npos && at_pos > authority_end)) {
+    return masked;
+  }
+
+  for (auto index = authority_start; index < at_pos; ++index) {
+    if (masked[index] != ':') {
+      masked[index] = '*';
+    }
+  }
+
+  return masked;
+}
+} // namespace config_redaction

--- a/mods/src/config_redaction.h
+++ b/mods/src/config_redaction.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace config_redaction
+{
+[[nodiscard]] std::string mask_token_for_log(const std::string& token);
+[[nodiscard]] std::string redact_secret_for_runtime_snapshot(const std::string& secret);
+[[nodiscard]] std::string mask_proxy_userinfo(const std::string& proxy);
+} // namespace config_redaction

--- a/tests/src/test_config_redaction.cc
+++ b/tests/src/test_config_redaction.cc
@@ -1,0 +1,33 @@
+#include "test_pure_common.h"
+
+TEST_SUITE("config_redaction")
+{
+  TEST_CASE("runtime secret redaction never preserves token material")
+  {
+    const auto redacted = config_redaction::redact_secret_for_runtime_snapshot("super-secret-sync-token");
+    CHECK(redacted == "<redacted>");
+    CHECK(redacted.find("super") == std::string::npos);
+    CHECK(redacted.find("token") == std::string::npos);
+  }
+
+  TEST_CASE("empty runtime secret remains diagnosable")
+  { CHECK(config_redaction::redact_secret_for_runtime_snapshot("") == "<empty>"); }
+
+  TEST_CASE("log token mask preserves shape without exposing full token")
+  {
+    const auto masked = config_redaction::mask_token_for_log("abcdefghi-sensitive-jklmnopqr");
+    CHECK(masked.starts_with("abcdefghi"));
+    CHECK(masked.ends_with("-jklmnopqr"));
+    CHECK(masked.find("sensitive") == std::string::npos);
+  }
+
+  TEST_CASE("proxy userinfo masking preserves endpoint")
+  {
+    CHECK(config_redaction::mask_proxy_userinfo("socks5://user:pass@example.test:1080")
+          == "socks5://****:****@example.test:1080");
+    CHECK(config_redaction::mask_proxy_userinfo("http://user%40domain:pass@example.test/proxy")
+          == "http://*************:****@example.test/proxy");
+    CHECK(config_redaction::mask_proxy_userinfo("https://example.test/path?email=a@b.test")
+          == "https://example.test/path?email=a@b.test");
+  }
+}

--- a/tests/src/test_pure_common.h
+++ b/tests/src/test_pure_common.h
@@ -3,6 +3,7 @@
 #include <doctest/doctest.h>
 
 #include "bounded_ttl_cache.h"
+#include "config_redaction.h"
 #include "config_schema.h"
 #include "patches/async_work_queue.h"
 #include "patches/battle_log_decoder.h"

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -10,6 +10,7 @@ do
 
     -- Testable source files from the mod (pure logic only)
     add_files("../mods/src/testable_functions.cc")
+    add_files("../mods/src/config_redaction.cc")
     add_files("../mods/src/config_schema.cc")
     add_files("../mods/src/patches/live_debug_event_store.cc")
     add_files("../mods/src/patches/live_debug_recent_event_requests.cc")


### PR DESCRIPTION
## Summary
- Adds a pure config redaction helper for sync tokens and proxy userinfo.
- Writes redacted sync target tokens to `community_patch_runtime.vars` while keeping in-memory target credentials unchanged for transport.
- Masks top-level `[sync].proxy`, named target proxy userinfo, and legacy converted default target credentials in runtime snapshots/log output.
- Adds doctest coverage for token redaction and proxy userinfo masking edge cases.

Closes #57.

## Validation
- `xmake run -y stfc-mod-tests` passed: 161 test cases / 1121 assertions.
- `xmake build -y stfc-community-mod` passed.
- `git diff --check` passed with no output.
- `ax cycle` passed: deploy hash matched, boot ok, recent `errorCount: 0`.
- Generated `community_patch_runtime.vars` count-only check passed: `RawTokenAssignments: 0`, `UnmaskedProxyAssignments: 0`.