### PR TITLE
Manage long-lived worker shutdown

### DIFF
--- a/mods/src/patches/async_work_queue.h
+++ b/mods/src/patches/async_work_queue.h
@@ -59,6 +59,21 @@ public:
     return true;
   }
 
+  bool wait_pop(WorkItem& item)
+  {
+    std::unique_lock lock(mutex_);
+    condition_.wait(lock, [this] { return shutdown_requested_ || !queue_.empty(); });
+
+    if (queue_.empty()) {
+      return false;
+    }
+
+    item = std::move(queue_.front());
+    queue_.pop_front();
+    ++dequeued_;
+    return true;
+  }
+
   std::vector<WorkItem> drain()
   {
     std::lock_guard lock(mutex_);

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -101,10 +101,12 @@ const char* notification_toast_title(int state)
 static AsyncWorkQueue<NotificationQueueRequest> s_notification_queue;
 static std::mutex              s_recent_toast_mutex;
 static std::once_flag          s_notification_worker_once;
+static std::thread             s_notification_worker_thread;
 static constexpr auto          kNotificationCoalesceWindow   = std::chrono::milliseconds(750);
 static constexpr auto          kRecentToastDedupWindow       = std::chrono::milliseconds(500);
 static constexpr size_t        kRecentToastDedupMaxEntries   = 256;
 static constexpr size_t        kNotificationSummaryLimit     = 4;
+static constexpr auto          kNotificationJoinWarnThreshold = std::chrono::seconds(5);
 static BoundedTtlDeduper<uintptr_t> s_recent_toasts(kRecentToastDedupMaxEntries);
 
 bool notification_should_process_toast(Toast* toast)
@@ -397,7 +399,7 @@ void notification_init()
 #if _WIN32
   notification_platform_init();
   std::call_once(s_notification_worker_once, []() {
-    std::thread(notification_worker_main).detach();
+    s_notification_worker_thread = std::thread(notification_worker_main);
   });
   spdlog::debug("[Notify] Windows notification service initialized");
 #else
@@ -405,6 +407,25 @@ void notification_init()
 #endif
 
   s_notification_initialized = true;
+}
+
+void notification_shutdown()
+{
+#if _WIN32
+  s_notification_queue.request_shutdown();
+
+  if (!s_notification_worker_thread.joinable()) {
+    return;
+  }
+
+  const auto join_started_at = std::chrono::steady_clock::now();
+  s_notification_worker_thread.join();
+  const auto join_elapsed = std::chrono::steady_clock::now() - join_started_at;
+  if (join_elapsed > kNotificationJoinWarnThreshold) {
+    spdlog::warn("[NotifyQueue] worker join waited {} ms during shutdown",
+                 std::chrono::duration_cast<std::chrono::milliseconds>(join_elapsed).count());
+  }
+#endif
 }
 
 void notification_show(const char* title, const char* body)

--- a/mods/src/patches/notification_service.h
+++ b/mods/src/patches/notification_service.h
@@ -26,6 +26,11 @@ struct Toast;
 void notification_init();
 
 /**
+ * @brief Request notification worker shutdown and join the background thread.
+ */
+void notification_shutdown();
+
+/**
  * @brief Return the notification title for a toast state.
  */
 const char* notification_toast_title(int state);

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -60,7 +60,6 @@
 #include <spdlog/spdlog.h>
 
 #include <string>
-#include <thread>
 
 // Sync payload builders and entity-group dispatch live in sync_payload_builders.cc.
 
@@ -364,6 +363,6 @@ void InstallSyncPatches()
     }
   }
 
-  std::thread(ship_sync_data).detach();
-  std::thread(ship_combat_log_data).detach();
+  StartSyncSchedulerWorker();
+  StartCombatLogWorker();
 }

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -12,7 +12,10 @@
  */
 #include "patches.h"
 #include "file.h"
+#include "patches/notification_service.h"
+#include "patches/sync_battle_logs.h"
 #include "patches/sync_payload_builders.h"
+#include "patches/sync_scheduler.h"
 #include "patches/sync_transport.h"
 #include "version.h"
 
@@ -256,5 +259,8 @@ void ApplyPatches()
 void ShutdownPatches()
 {
   ShutdownSyncPayloadWorkers();
+  ShutdownSyncSchedulerWorker();
+  ShutdownCombatLogWorker();
+  notification_shutdown();
   http::shutdown_workers();
 }

--- a/mods/src/patches/sync_battle_logs.cc
+++ b/mods/src/patches/sync_battle_logs.cc
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "errormsg.h"
 #include "file.h"
+#include "patches/async_work_queue.h"
 #include "patches/battle_log_decoder.h"
 #include "patches/sync_transport.h"
 #include "str_utils.h"
@@ -30,7 +31,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <condition_variable>
 #include <cstdint>
 #include <deque>
 #include <exception>
@@ -39,9 +39,10 @@
 #include <fstream>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <ranges>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -63,9 +64,21 @@ struct WinRtApartmentGuard {
 };
 #endif
 
-std::mutex              combat_log_data_mtx;
-std::condition_variable combat_log_data_cv;
-std::queue<uint64_t>    combat_log_data_queue;
+namespace
+{
+AsyncWorkQueue<uint64_t> s_combat_log_queue;
+std::once_flag           s_combat_log_worker_once;
+std::thread              s_combat_log_worker_thread;
+constexpr auto           kCombatLogWorkerSlowJoinThreshold = std::chrono::seconds(5);
+
+void log_worker_join_time(const std::string_view worker_name, const std::chrono::steady_clock::duration elapsed)
+{
+  if (elapsed > kCombatLogWorkerSlowJoinThreshold) {
+    spdlog::warn("[BattleSync] {} join waited {} ms during shutdown", worker_name,
+                 std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+  }
+}
+} // namespace
 
 struct CachedPlayerData {
   std::string                           name;
@@ -611,14 +624,11 @@ void process_battle_headers(const nlohmann::json& section)
     http::sync_log_trace("PROCESS", "battle headers",
                          STR_FORMAT("Queuing {} battles for background processing", to_enqueue.size()));
 
-    {
-      std::lock_guard lk(combat_log_data_mtx);
-      for (const auto id : to_enqueue) {
-        combat_log_data_queue.push(id);
+    for (const auto id : to_enqueue) {
+      if (!s_combat_log_queue.enqueue(id)) {
+        spdlog::warn("Battle {} dropped because combat log worker shutdown is in progress", id);
       }
     }
-
-    combat_log_data_cv.notify_all();
   }
 }
 
@@ -739,7 +749,7 @@ void resolve_alliance_names(const std::unordered_set<int64_t>& alliance_ids, nlo
   }
 }
 
-void ship_combat_log_data()
+static void ship_combat_log_data()
 {
   using json = nlohmann::json;
 
@@ -747,14 +757,8 @@ void ship_combat_log_data()
   WinRtApartmentGuard apartmentGuard;
 #endif
 
-  for (;;) {
-    uint64_t journal_id;
-    {
-      std::unique_lock lock(combat_log_data_mtx);
-      combat_log_data_cv.wait(lock, [] { return !combat_log_data_queue.empty(); });
-      journal_id = combat_log_data_queue.front();
-      combat_log_data_queue.pop();
-    }
+  uint64_t journal_id = 0;
+  while (s_combat_log_queue.wait_pop(journal_id)) {
 
     const bool send_battlelogs            = has_enabled_sync_target(SyncConfig::Type::Battles);
     const bool export_battlelogs_realtime = has_enabled_sync_target(SyncConfig::Type::BattlelogsRealtime);
@@ -867,6 +871,7 @@ void ship_combat_log_data()
             }
           }
         }
+
       }
 
       const auto captured_at_unix_ms = current_probe_unix_ms();
@@ -923,4 +928,26 @@ void ship_combat_log_data()
       spdlog::error("Unknown error during processing of combat log data");
     }
   }
+
+  spdlog::debug("[BattleSync] combat log worker stopped");
+}
+
+void StartCombatLogWorker()
+{
+  std::call_once(s_combat_log_worker_once, [] {
+    s_combat_log_worker_thread = std::thread(ship_combat_log_data);
+  });
+}
+
+void ShutdownCombatLogWorker()
+{
+  s_combat_log_queue.request_shutdown();
+
+  if (!s_combat_log_worker_thread.joinable()) {
+    return;
+  }
+
+  const auto join_started_at = std::chrono::steady_clock::now();
+  s_combat_log_worker_thread.join();
+  log_worker_join_time("combat log worker", std::chrono::steady_clock::now() - join_started_at);
 }

--- a/mods/src/patches/sync_battle_logs.h
+++ b/mods/src/patches/sync_battle_logs.h
@@ -13,4 +13,5 @@ void load_previously_sent_logs();
 void process_battle_headers(const nlohmann::json& section);
 void cache_player_names(std::unique_ptr<std::string>&& bytes);
 void cache_alliance_names(std::unique_ptr<std::string>&& bytes);
-void ship_combat_log_data();
+void StartCombatLogWorker();
+void ShutdownCombatLogWorker();

--- a/mods/src/patches/sync_scheduler.cc
+++ b/mods/src/patches/sync_scheduler.cc
@@ -5,6 +5,7 @@
 #include "patches/sync_scheduler.h"
 
 #include "errormsg.h"
+#include "patches/async_work_queue.h"
 #include "patches/sync_transport.h"
 
 #include <spdlog/spdlog.h>
@@ -13,11 +14,12 @@
 #include <winrt/Windows.Foundation.h>
 #endif
 
-#include <condition_variable>
+#include <chrono>
 #include <exception>
 #include <mutex>
-#include <queue>
 #include <string>
+#include <string_view>
+#include <thread>
 #include <tuple>
 
 #if _WIN32
@@ -27,47 +29,53 @@ struct WinRtApartmentGuard {
 };
 #endif
 
-std::mutex sync_data_mtx;
-std::condition_variable sync_data_cv;
-std::queue<std::tuple<SyncConfig::Type, std::string, bool>> sync_data_queue;
+namespace
+{
+using SyncQueueItem = std::tuple<SyncConfig::Type, std::string, bool>;
+
+AsyncWorkQueue<SyncQueueItem> s_sync_data_queue;
+std::once_flag                s_sync_worker_once;
+std::thread                   s_sync_worker_thread;
+constexpr auto                kSyncWorkerSlowJoinThreshold = std::chrono::seconds(5);
+
+void log_worker_join_time(const std::string_view worker_name, const std::chrono::steady_clock::duration elapsed)
+{
+  if (elapsed > kSyncWorkerSlowJoinThreshold) {
+    spdlog::warn("[SyncQueue] {} join waited {} ms during shutdown", worker_name,
+                 std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+  }
+}
+} // namespace
 
 void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync)
 {
-  {
-    std::lock_guard lk(sync_data_mtx);
-    sync_data_queue.emplace(type, data, is_first_sync);
-    http::sync_log_debug("QUEUE", to_string(type), "Added data to sync queue");
+  if (!s_sync_data_queue.enqueue({type, data, is_first_sync})) {
+    http::sync_log_warn("QUEUE", to_string(type), "Dropping data because sync scheduler shutdown is in progress");
+    return;
   }
 
-  sync_data_cv.notify_all();
+  http::sync_log_debug("QUEUE", to_string(type), "Added data to sync queue");
 }
 
 void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync)
 {
-  {
-    std::lock_guard lk(sync_data_mtx);
-    sync_data_queue.emplace(type, data.dump(), is_first_sync);
-    http::sync_log_debug("QUEUE", to_string(type), "Added " + std::to_string(data.size()) + " entries to sync queue");
+  if (!s_sync_data_queue.enqueue({type, data.dump(), is_first_sync})) {
+    http::sync_log_warn("QUEUE", to_string(type), "Dropping data because sync scheduler shutdown is in progress");
+    return;
   }
 
-  sync_data_cv.notify_all();
+  http::sync_log_debug("QUEUE", to_string(type), "Added " + std::to_string(data.size()) + " entries to sync queue");
 }
 
-void ship_sync_data()
+static void ship_sync_data()
 {
 #if _WIN32
   WinRtApartmentGuard apartmentGuard;
 #endif
 
   try {
-    for (;;) {
-      std::tuple<SyncConfig::Type, std::string, bool> sync_data;
-      {
-        std::unique_lock lock(sync_data_mtx);
-        sync_data_cv.wait(lock, [] { return !sync_data_queue.empty(); });
-        sync_data = std::move(sync_data_queue.front());
-        sync_data_queue.pop();
-      }
+    SyncQueueItem sync_data;
+    while (s_sync_data_queue.wait_pop(sync_data)) {
 
       try {
         auto& [type, data, is_first_sync] = sync_data;
@@ -91,4 +99,26 @@ void ship_sync_data()
   } catch (...) {
     spdlog::critical("ship_sync_data thread terminated: unknown exception");
   }
+
+  spdlog::debug("[SyncQueue] worker stopped");
+}
+
+void StartSyncSchedulerWorker()
+{
+  std::call_once(s_sync_worker_once, [] {
+    s_sync_worker_thread = std::thread(ship_sync_data);
+  });
+}
+
+void ShutdownSyncSchedulerWorker()
+{
+  s_sync_data_queue.request_shutdown();
+
+  if (!s_sync_worker_thread.joinable()) {
+    return;
+  }
+
+  const auto join_started_at = std::chrono::steady_clock::now();
+  s_sync_worker_thread.join();
+  log_worker_join_time("sync scheduler worker", std::chrono::steady_clock::now() - join_started_at);
 }

--- a/mods/src/patches/sync_scheduler.h
+++ b/mods/src/patches/sync_scheduler.h
@@ -12,4 +12,5 @@
 
 void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync = false);
 void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync = false);
-void ship_sync_data();
+void StartSyncSchedulerWorker();
+void ShutdownSyncSchedulerWorker();

--- a/tests/src/test_runtime_helpers.cc
+++ b/tests/src/test_runtime_helpers.cc
@@ -149,6 +149,32 @@ TEST_SUITE("async_work_queue")
     CHECK(diagnostics.dequeued == 1);
   }
 
+  TEST_CASE("wait_pop drains queued work after shutdown before stopping")
+  {
+    AsyncWorkQueue<int> queue;
+    int                 value = 0;
+
+    CHECK(queue.enqueue(42));
+    queue.request_shutdown();
+
+    CHECK(queue.wait_pop(value));
+    CHECK(value == 42);
+    CHECK_FALSE(queue.wait_pop(value));
+  }
+
+  TEST_CASE("wait_pop wakes and returns false when shutdown is requested empty")
+  {
+    AsyncWorkQueue<int> queue;
+    int                 value = 0;
+    bool                result = true;
+
+    std::thread waiter([&] { result = queue.wait_pop(value); });
+    queue.request_shutdown();
+    waiter.join();
+
+    CHECK_FALSE(result);
+  }
+
   TEST_CASE("tracks worker activity and errors")
   {
     AsyncWorkQueue<int> queue;


### PR DESCRIPTION
## Summary
- replaces the detached sync scheduler, combat-log, and notification workers with module-owned joinable threads
- reuses `AsyncWorkQueue` shutdown semantics for the sync and combat queues so idle workers wake and exit cleanly
- routes `ShutdownPatches()` through the new worker shutdown hooks before HTTP target worker teardown
- adds pure tests for queue shutdown wakeup and drain behavior used by the scheduler path

Closes #58.

## Validation
- `xmake run -y stfc-mod-tests` passed: 163 test cases / 1126 assertions.
- `xmake build -y stfc-community-mod` passed.
- `git diff --check` passed with no output.
- `ax cycle` passed: stop/deploy/relaunch/boot ok, deploy hash matched, recent `errorCount: 0`.
- Active repo grep for `.detach()` no longer finds any long-lived worker starts under `D:\dev\stfc-mod\mods\src`.

## Notes
- Worker stop messages are currently debug-level, so they are not visible in the normal info-level boot log used by `ax cycle`.
- The remaining detached-thread matches are only in the separate `D:\dev\netniv\stfc-mod` checkout, not in the active fork branch for this PR.