### PR TITLE
ci: harden xmake package cache restore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  XMAKE_PACKAGE_CACHE_VERSION: v1
+
 jobs:
   build-win:
     runs-on: windows-2025-vs2026
@@ -33,8 +36,21 @@ jobs:
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: latest
-          package-cache: true
-          package-cache-key: ${{ hashFiles('**/xmake.lua', '!macos-*/xmake.lua') }}
+
+      - name: Resolve xmake package dir
+        id: xmake-package-dir
+        shell: pwsh
+        run: |
+          $dir = xmake l -c "import(""core.package.package""); print(package.installdir())"
+          "dir=$dir" >> $env:GITHUB_OUTPUT
+
+      - name: Restore xmake package cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.xmake-package-dir.outputs.dir }}
+          key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-win-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'win-proxy-dll/xmake.lua', 'xmake-packages/**/*.lua') }}
+          restore-keys: |
+            xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-win-${{ runner.arch }}-
 
       - name: Configure
         run: xmake f -m release -y
@@ -69,8 +85,21 @@ jobs:
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: latest
-          package-cache: true
-          package-cache-key: ${{ hashFiles('**/xmake.lua', '!win-*/xmake.lua') }}
+
+      - name: Resolve xmake package dir
+        id: xmake-package-dir
+        shell: bash
+        run: |
+          dir="$(xmake l -c 'import("core.package.package"); print(package.installdir())')"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - name: Restore xmake package cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.xmake-package-dir.outputs.dir }}
+          key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-mac-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'macos-dylib/xmake.lua', 'macos-loader/xmake.lua', 'macos-launcher/xmake.lua', 'xmake-packages/**/*.lua') }}
+          restore-keys: |
+            xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-mac-${{ runner.arch }}-
 
       - name: Configure (arm64)
         run: xmake f -p macosx -a "arm64" -m release -y --target_minver=13.5

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  XMAKE_PACKAGE_CACHE_VERSION: v1
+
 jobs:
   analyze-cpp:
     name: Analyze (C/C++)
@@ -28,8 +31,21 @@ jobs:
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: latest
-          package-cache: true
-          package-cache-key: ${{ hashFiles('**/xmake.lua', '!macos-*/xmake.lua') }}
+
+      - name: Resolve xmake package dir
+        id: xmake-package-dir
+        shell: pwsh
+        run: |
+          $dir = xmake l -c "import(""core.package.package""); print(package.installdir())"
+          "dir=$dir" >> $env:GITHUB_OUTPUT
+
+      - name: Restore xmake package cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.xmake-package-dir.outputs.dir }}
+          key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-win-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'win-proxy-dll/xmake.lua', 'xmake-packages/**/*.lua') }}
+          restore-keys: |
+            xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-win-${{ runner.arch }}-
 
       - name: Configure & download packages
         run: xmake f -m release -y
@@ -66,8 +82,21 @@ jobs:
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: latest
-          package-cache: true
-          package-cache-key: ${{ hashFiles('**/xmake.lua', '!win-*/xmake.lua') }}
+
+      - name: Resolve xmake package dir
+        id: xmake-package-dir
+        shell: bash
+        run: |
+          dir="$(xmake l -c 'import("core.package.package"); print(package.installdir())')"
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - name: Restore xmake package cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.xmake-package-dir.outputs.dir }}
+          key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-mac-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'macos-dylib/xmake.lua', 'macos-loader/xmake.lua', 'macos-launcher/xmake.lua', 'xmake-packages/**/*.lua') }}
+          restore-keys: |
+            xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-mac-${{ runner.arch }}-
 
       - name: Configure & download packages
         run: xmake f -p macosx -a "arm64" -m release -y --target_minver=13.5


### PR DESCRIPTION
## Summary

- replace the xmake action's built-in exact-key package cache with explicit `actions/cache` steps on the real XMake package install directory
- add restore-key fallback so workflows can reuse older compatible package caches instead of hard-missing on exact-key restore
- apply the same cache behavior to both the main Build workflow and CodeQL

## Why

Recent healthy Windows runs spent ~14 minutes in `Configure` because XMake reinstalled dependencies after cache restore missed. The current setup uses exact-key-only restore and depends on cache visibility from the default branch (`main`), while active development happens on `guffa-dev` and feature branches.

Observed evidence:

- runs `25561020007` and `25563191362` used the same Windows cache key
- both still logged `No cached files found` for the xmake package cache path
- the expensive cold path was mostly package install time, especially `protobuf 32.1`

## Validation

- VS Code diagnostics: no YAML errors in `.github/workflows/ci.yaml`
- VS Code diagnostics: no YAML errors in `.github/workflows/codeql.yaml`
- `git diff --check`

Related: #69
