### PR TITLE
refactor: extract hotkey router execution decisions

### DIFF
--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -425,11 +425,14 @@ bool hotkey_router_screen_update(ScreenManager* _this)
       break;
   }
 
-  const auto is_in_chat = Hub::IsInChat();
-  const auto config     = &Config::Get();
+  const auto is_in_chat    = Hub::IsInChat();
+  const auto input_focused = Key::IsInputFocused();
+  const auto config        = &Config::Get();
 
 #ifdef _WIN32
-  if (first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyQuitActions) == input_binding::InputActionId::Quit) {
+  if (hotkey_router_quit_action(first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyQuitActions)
+                                == input_binding::InputActionId::Quit)
+      == HotkeyRouterQuitAction::QuitProcess) {
     TerminateProcess(GetCurrentProcess(), 1);
     return false;
   }
@@ -443,16 +446,20 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   }
 
   // ─── Escape in chat / input focus ───────────────────────────────────────────────────
-  if (hotkey_router_should_clear_input_focus(Key::Pressed(KeyCode::Escape), Key::IsInputFocused(), Hub::IsInChat())) {
+  if (hotkey_router_should_clear_input_focus(Key::Pressed(KeyCode::Escape), input_focused, is_in_chat)) {
     Key::ClearInputFocus();
     return false;
   }
 
   if (!is_in_chat) {
-    if (!Key::IsInputFocused()) {
+    if (!input_focused) {
       // SelectCurrent — locate active fleet
-      if (first_runtime_binding_winner(runtime_dispatch_plan, kHotkeySelectCurrentActions)
-          == input_binding::InputActionId::SelectCurrent) {
+      if (hotkey_router_select_current_action(is_in_chat,
+                                              input_focused,
+                                              first_runtime_binding_winner(runtime_dispatch_plan,
+                                                                           kHotkeySelectCurrentActions)
+                                                  == input_binding::InputActionId::SelectCurrent)
+          == HotkeyRouterSelectCurrentAction::ViewActiveFleet) {
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
         if (fleet_bar) {
           auto fleet = fleet_bar->_fleetPanelController->fleet;
@@ -468,7 +475,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
 
       // ToggleQueue
       const auto queue_toggle_action = first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyQueueActions);
-      if (hotkey_router_should_toggle_queue(is_in_chat, Key::IsInputFocused(),
+      if (hotkey_router_should_toggle_queue(is_in_chat, input_focused,
                                             queue_toggle_action == input_binding::InputActionId::FleetQueueToggle)) {
         config->queue_enabled = !config->queue_enabled;
         return false;
@@ -478,31 +485,42 @@ bool hotkey_router_screen_update(ScreenManager* _this)
       const auto chat_open_action = first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyChatOpenActions);
       if (chat_open_action != input_binding::InputActionId::Max) {
         if (auto chat_manager = ChatManager::Instance(); chat_manager) {
-          if (chat_manager->IsSideChatOpen) {
-            if (auto view_controller = ObjectFinder<FullScreenChatViewController>::Get(); view_controller) {
-              if (auto message_list = view_controller->_messageList; message_list) {
-                if (auto message_field = message_list->_inputField; message_field) {
-                  message_field->ActivateInputField();
+          switch (hotkey_router_chat_open_action(is_in_chat,
+                                                 input_focused,
+                                                 chat_manager->IsSideChatOpen,
+                                                 chat_open_action)) {
+            case HotkeyRouterChatOpenAction::ActivateExistingInput:
+              if (auto view_controller = ObjectFinder<FullScreenChatViewController>::Get(); view_controller) {
+                if (auto message_list = view_controller->_messageList; message_list) {
+                  if (auto message_field = message_list->_inputField; message_field) {
+                    message_field->ActivateInputField();
+                  }
                 }
               }
-            }
-          } else if (chat_open_action == input_binding::InputActionId::ShowChatSide1
-                     || chat_open_action == input_binding::InputActionId::ShowChatSide2) {
-            chat_manager->OpenChannel(ChatChannelCategory::Alliance, ChatViewMode::Side);
-          } else {
-            chat_manager->OpenChannel(ChatChannelCategory::Alliance, ChatViewMode::Fullscreen);
+              break;
+            case HotkeyRouterChatOpenAction::OpenAllianceSide:
+              chat_manager->OpenChannel(ChatChannelCategory::Alliance, ChatViewMode::Side);
+              break;
+            case HotkeyRouterChatOpenAction::OpenAllianceFullscreen:
+              chat_manager->OpenChannel(ChatChannelCategory::Alliance, ChatViewMode::Fullscreen);
+              break;
+            default:
+              break;
           }
         }
       }
 
       // MoveLeft / MoveRight (officer canvas)
-      switch (first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyOfficerCanvasActions)) {
-        case input_binding::InputActionId::MoveLeft:
+      switch (hotkey_router_officer_canvas_action(is_in_chat,
+                                                  input_focused,
+                                                  first_runtime_binding_winner(runtime_dispatch_plan,
+                                                                               kHotkeyOfficerCanvasActions))) {
+        case HotkeyRouterOfficerCanvasAction::MoveLeft:
           if (MoveOfficerCanvas(true)) {
             return false;
           }
           break;
-        case input_binding::InputActionId::MoveRight:
+        case HotkeyRouterOfficerCanvasAction::MoveRight:
           if (MoveOfficerCanvas(false)) {
             return false;
           }
@@ -511,7 +529,10 @@ bool hotkey_router_screen_update(ScreenManager* _this)
           break;
       }
 
-      if (const auto action = first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyTableDispatchActions);
+      if (const auto action = hotkey_router_table_dispatch_request(is_in_chat,
+                                                                   input_focused,
+                                                                   first_runtime_binding_winner(runtime_dispatch_plan,
+                                                                                                kHotkeyTableDispatchActions));
           action != input_binding::InputActionId::Max) {
         if (dispatch_runtime_bound_table_action(action) == HotkeyRouterDispatchAction::SuppressOriginal) {
           return false;
@@ -521,14 +542,16 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   } else {
     // ─── In-chat channel selection ─────────────────────────────────────────────────────
     if (auto chat_manager = ChatManager::Instance(); chat_manager) {
-      switch (first_runtime_binding_winner(runtime_dispatch_plan, kHotkeyChatChannelActions)) {
-        case input_binding::InputActionId::SelectChatGlobal:
+      switch (hotkey_router_chat_channel_action(is_in_chat,
+                                                first_runtime_binding_winner(runtime_dispatch_plan,
+                                                                             kHotkeyChatChannelActions))) {
+        case HotkeyRouterChatChannelAction::Global:
           chat_manager->OpenChannel(ChatChannelCategory::Global);
           return false;
-        case input_binding::InputActionId::SelectChatAlliance:
+        case HotkeyRouterChatChannelAction::Alliance:
           chat_manager->OpenChannel(ChatChannelCategory::Alliance);
           return false;
-        case input_binding::InputActionId::SelectChatPrivate:
+        case HotkeyRouterChatChannelAction::Private:
           chat_manager->OpenChannel(ChatChannelCategory::Private);
           return false;
         default:
@@ -538,7 +561,8 @@ bool hotkey_router_screen_update(ScreenManager* _this)
   }
 
   if (!Key::IsInputFocused()) {
-    const auto simple_fleet_action = first_runtime_binding_winner(runtime_dispatch_plan, kHotkeySimpleFleetActions);
+  const auto simple_fleet_action = hotkey_router_simple_fleet_action(
+    false, first_runtime_binding_winner(runtime_dispatch_plan, kHotkeySimpleFleetActions));
     const auto space_action_inputs = hotkey_router_runtime_space_action_inputs(
         runtime_binding_winner_present(runtime_dispatch_plan, input_binding::InputActionId::FleetPrimary,
                                        input_binding::InputLayer::Fleet),
@@ -559,8 +583,8 @@ bool hotkey_router_screen_update(ScreenManager* _this)
       }
     }
 
-    if (simple_fleet_action == input_binding::InputActionId::FleetQueueClear) {
-      dispatch_runtime_bound_simple_fleet_action(simple_fleet_action);
+    if (simple_fleet_action == HotkeyRouterSimpleFleetAction::QueueClear) {
+      dispatch_runtime_bound_simple_fleet_action(input_binding::InputActionId::FleetQueueClear);
     }
 
     // Space actions (engage, scan, recall, repair, queue, etc.)
@@ -579,7 +603,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
     }
 
     // ActionView — toggle cargo/rewards info panel
-    if (simple_fleet_action == input_binding::InputActionId::FleetViewInfo) {
+    if (simple_fleet_action == HotkeyRouterSimpleFleetAction::ViewInfo) {
       HandleActionView();
     }
 

--- a/mods/src/testable_functions.cc
+++ b/mods/src/testable_functions.cc
@@ -259,6 +259,109 @@ HotkeyRouterDispatchAction hotkey_router_dispatch_action(bool entry_active,
   return HotkeyRouterDispatchAction::Continue;
 }
 
+HotkeyRouterQuitAction hotkey_router_quit_action(const bool quit_pressed)
+{
+  return quit_pressed ? HotkeyRouterQuitAction::QuitProcess : HotkeyRouterQuitAction::None;
+}
+
+HotkeyRouterSelectCurrentAction hotkey_router_select_current_action(const bool is_in_chat,
+                                                                    const bool input_focused,
+                                                                    const bool select_current_pressed)
+{
+  if (!select_current_pressed || is_in_chat || input_focused) {
+    return HotkeyRouterSelectCurrentAction::None;
+  }
+
+  return HotkeyRouterSelectCurrentAction::ViewActiveFleet;
+}
+
+HotkeyRouterChatOpenAction hotkey_router_chat_open_action(const bool                         is_in_chat,
+                                                          const bool                         input_focused,
+                                                          const bool                         side_chat_open,
+                                                          const input_binding::InputActionId action)
+{
+  if (is_in_chat || input_focused) {
+    return HotkeyRouterChatOpenAction::None;
+  }
+
+  switch (action) {
+    case input_binding::InputActionId::ShowChat:
+      return side_chat_open ? HotkeyRouterChatOpenAction::ActivateExistingInput
+                            : HotkeyRouterChatOpenAction::OpenAllianceFullscreen;
+    case input_binding::InputActionId::ShowChatSide1:
+    case input_binding::InputActionId::ShowChatSide2:
+      return side_chat_open ? HotkeyRouterChatOpenAction::ActivateExistingInput
+                            : HotkeyRouterChatOpenAction::OpenAllianceSide;
+    default:
+      return HotkeyRouterChatOpenAction::None;
+  }
+}
+
+HotkeyRouterChatChannelAction hotkey_router_chat_channel_action(const bool                         is_in_chat,
+                                                                const input_binding::InputActionId action)
+{
+  if (!is_in_chat) {
+    return HotkeyRouterChatChannelAction::None;
+  }
+
+  switch (action) {
+    case input_binding::InputActionId::SelectChatGlobal:
+      return HotkeyRouterChatChannelAction::Global;
+    case input_binding::InputActionId::SelectChatAlliance:
+      return HotkeyRouterChatChannelAction::Alliance;
+    case input_binding::InputActionId::SelectChatPrivate:
+      return HotkeyRouterChatChannelAction::Private;
+    default:
+      return HotkeyRouterChatChannelAction::None;
+  }
+}
+
+HotkeyRouterOfficerCanvasAction hotkey_router_officer_canvas_action(const bool                         is_in_chat,
+                                                                    const bool                         input_focused,
+                                                                    const input_binding::InputActionId action)
+{
+  if (is_in_chat || input_focused) {
+    return HotkeyRouterOfficerCanvasAction::None;
+  }
+
+  switch (action) {
+    case input_binding::InputActionId::MoveLeft:
+      return HotkeyRouterOfficerCanvasAction::MoveLeft;
+    case input_binding::InputActionId::MoveRight:
+      return HotkeyRouterOfficerCanvasAction::MoveRight;
+    default:
+      return HotkeyRouterOfficerCanvasAction::None;
+  }
+}
+
+input_binding::InputActionId hotkey_router_table_dispatch_request(const bool                         is_in_chat,
+                                                                  const bool                         input_focused,
+                                                                  const input_binding::InputActionId action)
+{
+  if (is_in_chat || input_focused) {
+    return input_binding::InputActionId::Max;
+  }
+
+  return action;
+}
+
+HotkeyRouterSimpleFleetAction hotkey_router_simple_fleet_action(const bool                         input_focused,
+                                                                const input_binding::InputActionId action)
+{
+  if (input_focused) {
+    return HotkeyRouterSimpleFleetAction::None;
+  }
+
+  switch (action) {
+    case input_binding::InputActionId::FleetQueueClear:
+      return HotkeyRouterSimpleFleetAction::QueueClear;
+    case input_binding::InputActionId::FleetViewInfo:
+      return HotkeyRouterSimpleFleetAction::ViewInfo;
+    default:
+      return HotkeyRouterSimpleFleetAction::None;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Incoming attack policy
 // ---------------------------------------------------------------------------

--- a/mods/src/testable_functions.h
+++ b/mods/src/testable_functions.h
@@ -3,6 +3,7 @@
 // Testable pure functions extracted from notification_service.cc and
 // battle_notify_parser.cc.  No IL2CPP, no platform, no game memory.
 
+#include "patches/input_binding/input_binding.h"
 #include "patches/space_action_inputs.h"
 
 #include "patches/hotkey_policy.h"
@@ -104,6 +105,61 @@ bool hotkey_router_should_toggle_queue(bool is_in_chat, bool input_focused, bool
 HotkeyRouterDispatchAction hotkey_router_dispatch_action(bool entry_active,
                                                          bool handler_stops,
                                                          bool handler_allows_original);
+
+enum class HotkeyRouterQuitAction {
+  None = 0,
+  QuitProcess,
+};
+
+enum class HotkeyRouterSelectCurrentAction {
+  None = 0,
+  ViewActiveFleet,
+};
+
+enum class HotkeyRouterChatOpenAction {
+  None = 0,
+  ActivateExistingInput,
+  OpenAllianceSide,
+  OpenAllianceFullscreen,
+};
+
+enum class HotkeyRouterChatChannelAction {
+  None = 0,
+  Global,
+  Alliance,
+  Private,
+};
+
+enum class HotkeyRouterOfficerCanvasAction {
+  None = 0,
+  MoveLeft,
+  MoveRight,
+};
+
+enum class HotkeyRouterSimpleFleetAction {
+  None = 0,
+  QueueClear,
+  ViewInfo,
+};
+
+HotkeyRouterQuitAction hotkey_router_quit_action(bool quit_pressed);
+HotkeyRouterSelectCurrentAction hotkey_router_select_current_action(bool is_in_chat,
+                                                                    bool input_focused,
+                                                                    bool select_current_pressed);
+HotkeyRouterChatOpenAction hotkey_router_chat_open_action(bool is_in_chat,
+                                                          bool input_focused,
+                                                          bool side_chat_open,
+                                                          input_binding::InputActionId action);
+HotkeyRouterChatChannelAction hotkey_router_chat_channel_action(bool is_in_chat,
+                                                                input_binding::InputActionId action);
+HotkeyRouterOfficerCanvasAction hotkey_router_officer_canvas_action(bool is_in_chat,
+                                                                    bool input_focused,
+                                                                    input_binding::InputActionId action);
+input_binding::InputActionId hotkey_router_table_dispatch_request(bool is_in_chat,
+                                                                  bool input_focused,
+                                                                  input_binding::InputActionId action);
+HotkeyRouterSimpleFleetAction hotkey_router_simple_fleet_action(bool input_focused,
+                                                                input_binding::InputActionId action);
 
 enum class IncomingAttackPolicyAttackerKind {
   Unknown = 0,

--- a/tests/src/test_hotkey_router_execution.cc
+++ b/tests/src/test_hotkey_router_execution.cc
@@ -1,0 +1,143 @@
+#include "test_pure_common.h"
+
+TEST_SUITE("hotkey_router_execution")
+{
+  TEST_CASE("startup helpers still cover hotkey disable enable and fallthrough")
+  {
+    CHECK(hotkey_router_startup_action(true, false, false, true) == HotkeyRouterStartupAction::DisableHotkeys);
+    CHECK(hotkey_router_startup_action(false, true, false, false) == HotkeyRouterStartupAction::EnableHotkeys);
+    CHECK(hotkey_router_startup_action(false, false, ScopelyShortcutPolicy::Native, true)
+          == HotkeyRouterStartupAction::AllowOriginal);
+    CHECK(hotkey_router_startup_action(false, false, ScopelyShortcutPolicy::Fallback, false)
+          == HotkeyRouterStartupAction::SuppressOriginal);
+  }
+
+  TEST_CASE("quit action only routes when quit winner is present")
+  {
+    CHECK(hotkey_router_quit_action(false) == HotkeyRouterQuitAction::None);
+    CHECK(hotkey_router_quit_action(true) == HotkeyRouterQuitAction::QuitProcess);
+  }
+
+  TEST_CASE("ship selection keeps the first fleet winner")
+  {
+    CHECK(hotkey_router_ship_select_request(std::array<bool, 8>{false, false, true, false, false, false, false, false})
+          == 2);
+    CHECK(hotkey_router_ship_select_request(std::array<bool, 8>{true, false, true, false, false, false, false, false})
+          == 0);
+  }
+
+  TEST_CASE("escape focus clearing stays a pure routing decision")
+  {
+    CHECK(hotkey_router_should_clear_input_focus(true, true, false));
+    CHECK(hotkey_router_should_clear_input_focus(true, false, true));
+    CHECK_FALSE(hotkey_router_should_clear_input_focus(true, false, false));
+  }
+
+  TEST_CASE("select current only routes on the gameplay surface")
+  {
+    CHECK(hotkey_router_select_current_action(false, false, true) == HotkeyRouterSelectCurrentAction::ViewActiveFleet);
+    CHECK(hotkey_router_select_current_action(true, false, true) == HotkeyRouterSelectCurrentAction::None);
+    CHECK(hotkey_router_select_current_action(false, true, true) == HotkeyRouterSelectCurrentAction::None);
+  }
+
+  TEST_CASE("queue toggle remains blocked in chat and focused inputs")
+  {
+    CHECK(hotkey_router_should_toggle_queue(false, false, true));
+    CHECK_FALSE(hotkey_router_should_toggle_queue(true, false, true));
+    CHECK_FALSE(hotkey_router_should_toggle_queue(false, true, true));
+  }
+
+  TEST_CASE("chat open can activate the existing side-chat input field")
+  {
+    CHECK(hotkey_router_chat_open_action(false,
+                                         false,
+                                         true,
+                                         input_binding::InputActionId::ShowChat)
+          == HotkeyRouterChatOpenAction::ActivateExistingInput);
+    CHECK(hotkey_router_chat_open_action(false,
+                                         false,
+                                         true,
+                                         input_binding::InputActionId::ShowChatSide1)
+          == HotkeyRouterChatOpenAction::ActivateExistingInput);
+  }
+
+  TEST_CASE("chat open winners map to side or fullscreen channel opens")
+  {
+    CHECK(hotkey_router_chat_open_action(false,
+                                         false,
+                                         false,
+                                         input_binding::InputActionId::ShowChat)
+          == HotkeyRouterChatOpenAction::OpenAllianceFullscreen);
+    CHECK(hotkey_router_chat_open_action(false,
+                                         false,
+                                         false,
+                                         input_binding::InputActionId::ShowChatSide2)
+          == HotkeyRouterChatOpenAction::OpenAllianceSide);
+  }
+
+  TEST_CASE("chat channel winners only route while already in chat")
+  {
+    CHECK(hotkey_router_chat_channel_action(true, input_binding::InputActionId::SelectChatGlobal)
+          == HotkeyRouterChatChannelAction::Global);
+    CHECK(hotkey_router_chat_channel_action(true, input_binding::InputActionId::SelectChatAlliance)
+          == HotkeyRouterChatChannelAction::Alliance);
+    CHECK(hotkey_router_chat_channel_action(false, input_binding::InputActionId::SelectChatPrivate)
+          == HotkeyRouterChatChannelAction::None);
+  }
+
+  TEST_CASE("officer canvas movement only routes on the gameplay surface")
+  {
+    CHECK(hotkey_router_officer_canvas_action(false,
+                                              false,
+                                              input_binding::InputActionId::MoveLeft)
+          == HotkeyRouterOfficerCanvasAction::MoveLeft);
+    CHECK(hotkey_router_officer_canvas_action(false,
+                                              false,
+                                              input_binding::InputActionId::MoveRight)
+          == HotkeyRouterOfficerCanvasAction::MoveRight);
+    CHECK(hotkey_router_officer_canvas_action(true,
+                                              false,
+                                              input_binding::InputActionId::MoveLeft)
+          == HotkeyRouterOfficerCanvasAction::None);
+  }
+
+  TEST_CASE("table dispatch requests only surface on unfocused gameplay frames")
+  {
+    CHECK(hotkey_router_table_dispatch_request(false,
+                                               false,
+                                               input_binding::InputActionId::ShowBookmarks)
+          == input_binding::InputActionId::ShowBookmarks);
+    CHECK(hotkey_router_table_dispatch_request(true,
+                                               false,
+                                               input_binding::InputActionId::ShowBookmarks)
+          == input_binding::InputActionId::Max);
+    CHECK(hotkey_router_table_dispatch_request(false,
+                                               true,
+                                               input_binding::InputActionId::ShowBookmarks)
+          == input_binding::InputActionId::Max);
+  }
+
+  TEST_CASE("simple fleet winners map to queue clear and view info only when unfocused")
+  {
+    CHECK(hotkey_router_simple_fleet_action(false,
+                                            input_binding::InputActionId::FleetQueueClear)
+          == HotkeyRouterSimpleFleetAction::QueueClear);
+    CHECK(hotkey_router_simple_fleet_action(false,
+                                            input_binding::InputActionId::FleetViewInfo)
+          == HotkeyRouterSimpleFleetAction::ViewInfo);
+    CHECK(hotkey_router_simple_fleet_action(true,
+                                            input_binding::InputActionId::FleetViewInfo)
+          == HotkeyRouterSimpleFleetAction::None);
+  }
+
+  TEST_CASE("original call policy still distinguishes handled suppressed and allow-original paths")
+  {
+    CHECK(hotkey_router_dispatch_action(true, true, false) == HotkeyRouterDispatchAction::SuppressOriginal);
+    CHECK(hotkey_router_dispatch_action(true, false, true) == HotkeyRouterDispatchAction::AllowOriginal);
+    CHECK(hotkey_router_dispatch_action(true, false, false) == HotkeyRouterDispatchAction::Continue);
+
+    CHECK_FALSE(should_call_original_screen_update(false, OriginalFramePolicy::Mod));
+    CHECK(should_call_original_screen_update(true, OriginalFramePolicy::Mod));
+    CHECK(should_call_original_screen_update(false, OriginalFramePolicy::FallthroughAll));
+  }
+}


### PR DESCRIPTION
## Summary
- extract pure hotkey-router execution helpers for post-dispatch routing decisions
- keep `hotkey_router_screen_update()` focused on thin executor blocks and runtime object access
- add pure tests for startup, quit, ship selection, queue toggle, chat open/channel, table dispatch, simple fleet actions, and original-call policy

Closes #63

## Validation
- `xmake run -y stfc-mod-tests`
- `xmake build -y stfc-community-mod`
- `git diff --check`
- `ax cycle`
