### PR TITLE
perf: cache frame input dispatch lookups

### DIFF
--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -44,6 +44,13 @@
 
 namespace
 {
+struct FrameRuntimeDispatchCache {
+  uint64_t                                generation = 0;
+  std::vector<KeyCode>                    watched_keys;
+  std::vector<input_binding::DispatchKeyState> key_states;
+  input_binding::DispatchPlan             plan;
+};
+
 constexpr std::array kHotkeyStartupActions{
     input_binding::InputActionId::HotkeysDisable,
     input_binding::InputActionId::HotkeysEnable,
@@ -203,45 +210,59 @@ input_binding::ModifierMask held_modifier_mask()
   return modifiers;
 }
 
-std::vector<input_binding::DispatchKeyState> build_dispatch_key_snapshot(std::span<const KeyCode> watched_keys)
+FrameRuntimeDispatchCache& frame_runtime_dispatch_cache()
 {
-  auto key_states = std::vector<input_binding::DispatchKeyState>{};
+  static auto cache = FrameRuntimeDispatchCache{};
+  return cache;
+}
+
+void rebuild_frame_runtime_watched_keys(FrameRuntimeDispatchCache& cache,
+                                        const input_binding::CompileResult& runtime_bindings)
+{
+  const auto generation = input_binding::RuntimeBindingGeneration();
+  if (cache.generation == generation) {
+    return;
+  }
+
+  cache.watched_keys =
+      input_binding::WatchedKeysForActions(runtime_bindings, input_binding::InputPhase::Frame, kHotkeyFrameActions);
+  cache.generation = generation;
+}
+
+void build_dispatch_key_snapshot(std::span<const KeyCode> watched_keys,
+                                 std::vector<input_binding::DispatchKeyState>& key_states)
+{
+  key_states.clear();
   key_states.reserve(watched_keys.size());
 
   const auto modifiers = held_modifier_mask();
   for (const auto key : watched_keys) {
     key_states.push_back({key, modifiers, Key::Down(key), Key::Pressed(key)});
   }
-
-  return key_states;
 }
 
-input_binding::DispatchPlan frame_runtime_dispatch_plan()
+const input_binding::DispatchPlan& frame_runtime_dispatch_plan()
 {
+  auto&       cache            = frame_runtime_dispatch_cache();
   const auto& runtime_bindings = input_binding::RuntimeBindingModel();
-  const auto  watched_keys =
-      input_binding::WatchedKeysForActions(runtime_bindings, input_binding::InputPhase::Frame, kHotkeyFrameActions);
+  rebuild_frame_runtime_watched_keys(cache, runtime_bindings);
+  build_dispatch_key_snapshot(cache.watched_keys, cache.key_states);
+  input_binding::PlanDispatchSnapshot(runtime_bindings,
+                                      input_binding::InputPhase::Frame,
+                                      input_binding::ActiveLayers::All(),
+                                      cache.key_states,
+                                      cache.plan);
 
-  const auto key_states = build_dispatch_key_snapshot(watched_keys);
-  return input_binding::PlanDispatchSnapshot(runtime_bindings, input_binding::InputPhase::Frame,
-                                             input_binding::ActiveLayers::All(), key_states);
+  return cache.plan;
 }
 
 bool runtime_binding_winner_present(const input_binding::DispatchPlan& plan, const input_binding::InputActionId action,
                                     const input_binding::InputLayer layer)
-{
-  return std::ranges::any_of(
-      plan.winners, [action, layer](const auto& winner) { return winner.action == action && winner.layer == layer; });
-}
+{ return plan.winner_lookup.Contains(action, layer); }
 
 input_binding::InputActionId first_runtime_binding_winner(const input_binding::DispatchPlan&                  plan,
                                                           const std::span<const input_binding::InputActionId> actions)
-{
-  const auto found = std::ranges::find_if(plan.winners, [&actions](const auto& winner) {
-    return std::ranges::find(actions, winner.action) != actions.end();
-  });
-  return found == plan.winners.end() ? input_binding::InputActionId::Max : found->action;
-}
+{ return plan.winner_lookup.First(actions); }
 
 int ship_select_request_from_runtime_bindings(const input_binding::DispatchPlan& plan)
 {
@@ -405,7 +426,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
 {
   Key::ResetCache();
 
-  const auto runtime_dispatch_plan = frame_runtime_dispatch_plan();
+  const auto& runtime_dispatch_plan = frame_runtime_dispatch_plan();
 
   switch (startup_action_from_runtime_bindings(runtime_dispatch_plan, ScopelyShortcutsPolicy(),
                                                Config::Get().hotkeys_enabled)) {
@@ -560,9 +581,9 @@ bool hotkey_router_screen_update(ScreenManager* _this)
     }
   }
 
-  if (!Key::IsInputFocused()) {
-  const auto simple_fleet_action = hotkey_router_simple_fleet_action(
-    false, first_runtime_binding_winner(runtime_dispatch_plan, kHotkeySimpleFleetActions));
+  if (!input_focused) {
+    const auto simple_fleet_action = hotkey_router_simple_fleet_action(
+        input_focused, first_runtime_binding_winner(runtime_dispatch_plan, kHotkeySimpleFleetActions));
     const auto space_action_inputs = hotkey_router_runtime_space_action_inputs(
         runtime_binding_winner_present(runtime_dispatch_plan, input_binding::InputActionId::FleetPrimary,
                                        input_binding::InputLayer::Fleet),
@@ -589,7 +610,7 @@ bool hotkey_router_screen_update(ScreenManager* _this)
 
     // Space actions (engage, scan, recall, repair, queue, etc.)
     if (hotkey_router_should_execute_space_action(space_action_inputs, force_space_action_next_frame)) {
-      if (Hub::IsInSystemOrGalaxyOrStarbase() && !Hub::IsInChat() && !Key::IsInputFocused()) {
+      if (Hub::IsInSystemOrGalaxyOrStarbase() && !Hub::IsInChat() && !input_focused) {
         auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
         if (fleet_bar) {
           bool was_forced          = force_space_action_next_frame;

--- a/mods/src/patches/input_binding/input_dispatcher.cc
+++ b/mods/src/patches/input_binding/input_dispatcher.cc
@@ -26,6 +26,7 @@ void select_winners(DispatchPlan& plan)
   sort_by_priority(plan.candidates);
   plan.winners.clear();
   plan.winners.reserve(plan.candidates.size());
+  plan.winner_lookup.Reset();
 
   for (const auto& candidate : plan.candidates) {
     if (candidate.conflict_group != ConflictGroup::None) {
@@ -37,6 +38,7 @@ void select_winners(DispatchPlan& plan)
     }
 
     plan.winners.push_back(candidate);
+    plan.winner_lookup.Add(candidate, plan.winners.size() - 1);
   }
 }
 
@@ -60,6 +62,49 @@ void append_candidates(const CompileResult& compile, const DispatchRequest& requ
 bool DispatchPlan::empty() const
 { return winners.empty(); }
 
+void DispatchWinnerLookup::Reset()
+{
+  winner_order.fill(0);
+  for (auto& layers : action_layers) {
+    layers.fill(false);
+  }
+}
+
+void DispatchWinnerLookup::Add(const DispatchCandidate& candidate, const size_t winner_index)
+{
+  const auto action_index = static_cast<size_t>(candidate.action);
+  if (winner_order[action_index] == 0) {
+    winner_order[action_index] = static_cast<uint16_t>(winner_index + 1);
+  }
+
+  action_layers[action_index][static_cast<size_t>(candidate.layer)] = true;
+}
+
+bool DispatchWinnerLookup::Contains(const InputActionId action, const InputLayer layer) const
+{
+  return action_layers[static_cast<size_t>(action)][static_cast<size_t>(layer)];
+}
+
+InputActionId DispatchWinnerLookup::First(const std::span<const InputActionId> actions) const
+{
+  auto          best_order  = uint16_t{0};
+  auto          best_action = InputActionId::Max;
+
+  for (const auto action : actions) {
+    const auto order = winner_order[static_cast<size_t>(action)];
+    if (order == 0) {
+      continue;
+    }
+
+    if (best_order == 0 || order < best_order) {
+      best_order  = order;
+      best_action = action;
+    }
+  }
+
+  return best_action;
+}
+
 DispatchPlan PlanDispatch(const CompileResult& compile, const DispatchRequest& request)
 {
   DispatchPlan plan;
@@ -69,14 +114,16 @@ DispatchPlan PlanDispatch(const CompileResult& compile, const DispatchRequest& r
   return plan;
 }
 
-DispatchPlan PlanDispatchSnapshot(const CompileResult& compile,
-                                  const InputPhase phase,
-                                  const ActiveLayers active_layers,
-                                  const std::span<const DispatchKeyState> key_states,
-                                  const bool allow_extra_modifiers)
+void PlanDispatchSnapshot(const CompileResult& compile,
+                          const InputPhase phase,
+                          const ActiveLayers active_layers,
+                          const std::span<const DispatchKeyState> key_states,
+                          DispatchPlan& plan,
+                          const bool allow_extra_modifiers)
 {
-  DispatchPlan plan;
-
+  plan.candidates.clear();
+  plan.winners.clear();
+  plan.winner_lookup.Reset();
   plan.candidates.reserve(key_states.size());
   plan.winners.reserve(key_states.size());
 
@@ -101,6 +148,16 @@ DispatchPlan PlanDispatchSnapshot(const CompileResult& compile,
   }
 
   select_winners(plan);
+}
+
+DispatchPlan PlanDispatchSnapshot(const CompileResult& compile,
+                                  const InputPhase phase,
+                                  const ActiveLayers active_layers,
+                                  const std::span<const DispatchKeyState> key_states,
+                                  const bool allow_extra_modifiers)
+{
+  DispatchPlan plan;
+  PlanDispatchSnapshot(compile, phase, active_layers, key_states, plan, allow_extra_modifiers);
 
   return plan;
 }

--- a/mods/src/patches/input_binding/input_dispatcher.h
+++ b/mods/src/patches/input_binding/input_dispatcher.h
@@ -9,6 +9,7 @@
 namespace input_binding
 {
 inline constexpr size_t kInputLayerCount = static_cast<size_t>(InputLayer::Zoom) + 1;
+inline constexpr size_t kDispatchActionCount = static_cast<size_t>(InputActionId::Max) + 1;
 
 struct ActiveLayers {
   std::array<bool, kInputLayerCount> bits{true, true, true, true};
@@ -45,9 +46,21 @@ struct DispatchCandidate {
   InputLayer    layer = InputLayer::Global;
 };
 
+struct DispatchWinnerLookup {
+  std::array<uint16_t, kDispatchActionCount>                            winner_order{};
+  std::array<std::array<bool, kInputLayerCount>, kDispatchActionCount> action_layers{};
+
+  void Reset();
+  void Add(const DispatchCandidate& candidate, size_t winner_index);
+
+  [[nodiscard]] bool          Contains(InputActionId action, InputLayer layer) const;
+  [[nodiscard]] InputActionId First(std::span<const InputActionId> actions) const;
+};
+
 struct DispatchPlan {
   std::vector<DispatchCandidate> candidates;
   std::vector<DispatchCandidate> winners;
+  DispatchWinnerLookup           winner_lookup;
 
   [[nodiscard]] bool empty() const;
 };
@@ -59,6 +72,11 @@ enum class ExecutionDecision : uint8_t {
 };
 
 [[nodiscard]] DispatchPlan PlanDispatch(const CompileResult& compile, const DispatchRequest& request);
+void PlanDispatchSnapshot(const CompileResult& compile, InputPhase phase,
+                          ActiveLayers active_layers,
+                          std::span<const DispatchKeyState> key_states,
+                          DispatchPlan& plan,
+                          bool allow_extra_modifiers = false);
 [[nodiscard]] DispatchPlan PlanDispatchSnapshot(const CompileResult& compile, InputPhase phase,
                                                 ActiveLayers active_layers,
                                                 std::span<const DispatchKeyState> key_states,

--- a/mods/src/patches/input_binding/input_runtime_bindings.cc
+++ b/mods/src/patches/input_binding/input_runtime_bindings.cc
@@ -8,6 +8,12 @@ namespace {
 CompileResult build_default_runtime_binding_model()
 { return CompileBindingSet(); }
 
+uint64_t& mutable_runtime_binding_generation()
+{
+  static uint64_t generation = 1;
+  return generation;
+}
+
 CompileResult& mutable_runtime_binding_model()
 {
   static auto model = build_default_runtime_binding_model();
@@ -16,8 +22,14 @@ CompileResult& mutable_runtime_binding_model()
 }
 
 void SetRuntimeBindingModel(CompileResult compile)
-{ mutable_runtime_binding_model() = std::move(compile); }
+{
+  mutable_runtime_binding_model() = std::move(compile);
+  ++mutable_runtime_binding_generation();
+}
 
 const CompileResult& RuntimeBindingModel()
 { return mutable_runtime_binding_model(); }
+
+uint64_t RuntimeBindingGeneration()
+{ return mutable_runtime_binding_generation(); }
 } // namespace input_binding

--- a/mods/src/patches/input_binding/input_runtime_bindings.h
+++ b/mods/src/patches/input_binding/input_runtime_bindings.h
@@ -6,4 +6,5 @@ namespace input_binding
 {
 void SetRuntimeBindingModel(CompileResult compile);
 [[nodiscard]] const CompileResult& RuntimeBindingModel();
+[[nodiscard]] uint64_t RuntimeBindingGeneration();
 } // namespace input_binding

--- a/tests/src/test_input_dispatcher.cc
+++ b/tests/src/test_input_dispatcher.cc
@@ -101,6 +101,74 @@ TEST_SUITE("input_dispatcher")
     CHECK(plan.winners[0].action == input_binding::InputActionId::ZoomIn);
   }
 
+  TEST_CASE("snapshot dispatcher builds winner lookup once per plan")
+  {
+    const std::array overrides{
+        input_binding::BindingOverride{input_binding::InputActionId::FleetPrimary, "SPACE"},
+        input_binding::BindingOverride{input_binding::InputActionId::FleetService, "SPACE"},
+        input_binding::BindingOverride{input_binding::InputActionId::HotkeysDisable, "SPACE"},
+        input_binding::BindingOverride{input_binding::InputActionId::LogDebug, "SPACE"},
+    };
+    const auto compiled = input_binding::CompileBindingSet(overrides);
+
+    const std::array key_states{
+        input_binding::DispatchKeyState{KeyCode::Space, {}, true, true},
+    };
+
+    const auto plan = input_binding::PlanDispatchSnapshot(compiled,
+                                                          input_binding::InputPhase::Frame,
+                                                          input_binding::ActiveLayers::All(),
+                                                          key_states);
+
+    CHECK(plan.winner_lookup.Contains(input_binding::InputActionId::HotkeysDisable,
+                                      input_binding::InputLayer::Global));
+    CHECK(plan.winner_lookup.Contains(input_binding::InputActionId::FleetPrimary,
+                                      input_binding::InputLayer::Fleet));
+    CHECK_FALSE(plan.winner_lookup.Contains(input_binding::InputActionId::FleetService,
+                                            input_binding::InputLayer::Fleet));
+    CHECK(plan.winner_lookup.First(std::array{input_binding::InputActionId::FleetService,
+                                              input_binding::InputActionId::FleetPrimary})
+          == input_binding::InputActionId::FleetPrimary);
+  }
+
+  TEST_CASE("snapshot dispatcher reuse overload refreshes winners and lookup")
+  {
+    const std::array overrides{
+        input_binding::BindingOverride{input_binding::InputActionId::HotkeysDisable, "F1"},
+        input_binding::BindingOverride{input_binding::InputActionId::HotkeysEnable, "F2"},
+    };
+    const auto compiled = input_binding::CompileBindingSet(overrides);
+
+    input_binding::DispatchPlan plan;
+    const std::array disable_key_states{
+        input_binding::DispatchKeyState{KeyCode::F1, {}, true, true},
+    };
+
+    input_binding::PlanDispatchSnapshot(compiled,
+                                        input_binding::InputPhase::Frame,
+                                        input_binding::ActiveLayers::All(),
+                                        disable_key_states,
+                                        plan);
+    CHECK(plan.winner_lookup.First(std::array{input_binding::InputActionId::HotkeysDisable,
+                                              input_binding::InputActionId::HotkeysEnable})
+          == input_binding::InputActionId::HotkeysDisable);
+
+    const std::array enable_key_states{
+        input_binding::DispatchKeyState{KeyCode::F2, {}, true, true},
+    };
+
+    input_binding::PlanDispatchSnapshot(compiled,
+                                        input_binding::InputPhase::Frame,
+                                        input_binding::ActiveLayers::All(),
+                                        enable_key_states,
+                                        plan);
+    CHECK_FALSE(plan.winner_lookup.Contains(input_binding::InputActionId::HotkeysDisable,
+                                            input_binding::InputLayer::Global));
+    CHECK(plan.winner_lookup.First(std::array{input_binding::InputActionId::HotkeysDisable,
+                                              input_binding::InputActionId::HotkeysEnable})
+          == input_binding::InputActionId::HotkeysEnable);
+  }
+
   TEST_CASE("snapshot dispatcher applies conflict groups across simultaneous keys")
   {
     const std::array overrides{

--- a/tests/src/test_input_runtime_bindings.cc
+++ b/tests/src/test_input_runtime_bindings.cc
@@ -7,6 +7,25 @@
 
 TEST_SUITE("input_runtime_bindings")
 {
+  TEST_CASE("runtime binding generation increments when the model changes")
+  {
+    const auto before = input_binding::RuntimeBindingGeneration();
+
+    input_binding::SetRuntimeBindingModel(input_binding::CompileBindingSet());
+    const auto after_defaults = input_binding::RuntimeBindingGeneration();
+    CHECK(after_defaults == before + 1);
+
+    const std::array overrides{
+        input_binding::BindingOverride{input_binding::InputActionId::HotkeysDisable, "F1"},
+    };
+
+    input_binding::SetRuntimeBindingModel(input_binding::CompileBindingSet(overrides));
+    const auto after_override = input_binding::RuntimeBindingGeneration();
+    CHECK(after_override == after_defaults + 1);
+
+    input_binding::SetRuntimeBindingModel(input_binding::CompileBindingSet());
+  }
+
   TEST_CASE("runtime binding model defaults to compiled action defaults")
   {
     input_binding::SetRuntimeBindingModel(input_binding::CompileBindingSet());


### PR DESCRIPTION
## Summary
- cache the frame-phase watched key list behind a runtime binding generation so `WatchedKeysForActions()` is no longer called every frame
- add a reusable snapshot-dispatch overload and a per-plan winner lookup to avoid repeated linear scans of `plan.winners`
- cover winner lookup reuse and runtime binding generation changes with focused tests

Closes #59

## Validation
- `xmake run -y stfc-mod-tests`
- `xmake build -y stfc-community-mod`
- `git diff --check`
- `ax cycle`
