### PR TITLE
test: cover sync transport policy seams

### DIFF
--- a/mods/src/patches/sync_scheduler.cc
+++ b/mods/src/patches/sync_scheduler.cc
@@ -54,7 +54,7 @@ void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sy
     return;
   }
 
-  http::sync_log_debug("QUEUE", to_string(type), "Added data to sync queue");
+  http::sync_log_trace("QUEUE", to_string(type), "Added data to sync queue");
 }
 
 void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync)
@@ -64,7 +64,7 @@ void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first
     return;
   }
 
-  http::sync_log_debug("QUEUE", to_string(type), "Added " + std::to_string(data.size()) + " entries to sync queue");
+  http::sync_log_trace("QUEUE", to_string(type), "Added " + std::to_string(data.size()) + " entries to sync queue");
 }
 
 static void ship_sync_data()

--- a/mods/src/patches/sync_transport.cc
+++ b/mods/src/patches/sync_transport.cc
@@ -4,6 +4,8 @@
  */
 #include "patches/sync_transport.h"
 
+#include "patches/sync_transport_policy.h"
+
 #include "errormsg.h"
 #include "str_utils.h"
 #include "version.h"
@@ -108,21 +110,21 @@ constexpr int kSyncRequestTimeoutMs = 10'000;
 
 bool should_disable_tls_verification(const SyncConfig& config, const std::string& target_identifier)
 {
-  if (config.verify_ssl) {
-    return false;
-  }
+  const auto decision = DecideSyncTlsVerification(config);
 
-  if (!config.allow_unsafe_tls_without_certificate_validation) {
+  if (decision.warn_verify_ssl_ignored) {
     spdlog::warn("[Sync] Ignoring verify_ssl=false for '{}' because allow_unsafe_tls_without_certificate_validation "
                  "is not true.",
                  target_identifier);
-    return false;
   }
 
-  spdlog::error("[Sync] UNSAFE TLS certificate verification disabled for '{}'. Traffic can be intercepted. Set "
-                "verify_ssl=true or remove allow_unsafe_tls_without_certificate_validation to restore safe transport.",
-                target_identifier);
-  return true;
+  if (decision.emit_unsafe_tls_error) {
+    spdlog::error("[Sync] UNSAFE TLS certificate verification disabled for '{}'. Traffic can be intercepted. Set "
+                  "verify_ssl=true or remove allow_unsafe_tls_without_certificate_validation to restore safe transport.",
+                  target_identifier);
+  }
+
+  return decision.disable_verification;
 }
 
 [[nodiscard]] static std::string newUUID()
@@ -472,6 +474,7 @@ static std::shared_ptr<cpr::Session> get_curl_client_scopely()
 
   std::call_once(init_flag, [] {
     const auto header_snapshot = headers::Snapshot();
+    const auto session_headers = BuildScopelySessionHeaders(header_snapshot, newUUID());
     session = std::make_shared<cpr::Session>();
     session->SetAcceptEncoding(cpr::AcceptEncoding{});
     session->SetHttpVersion(cpr::HttpVersion{cpr::HttpVersionCode::VERSION_1_1});
@@ -492,12 +495,12 @@ static std::shared_ptr<cpr::Session> get_curl_client_scopely()
     session->SetHeader({
         {"Accept", "application/json"},
         {"Content-Type", "application/json"},
-        {"X-TRANSACTION-ID", newUUID()},
-        {"X-AUTH-SESSION-ID", header_snapshot.instanceSessionId},
-        {"X-PRIME-VERSION", header_snapshot.primeVersion},
-        {"X-Instance-ID", STR_FORMAT("{:03}", header_snapshot.instanceId)},
+      {"X-TRANSACTION-ID", session_headers.transaction_id},
+      {"X-AUTH-SESSION-ID", session_headers.auth_session_id},
+      {"X-PRIME-VERSION", session_headers.prime_version},
+      {"X-Instance-ID", session_headers.instance_id},
         {"X-PRIME-SYNC", "0"},
-        {"X-Unity-Version", header_snapshot.unityVersion},
+      {"X-Unity-Version", session_headers.unity_version},
         {"X-Powered-By", headers::poweredBy},
     });
   });
@@ -530,12 +533,13 @@ std::string get_scopely_data(const std::string& path, const std::string& post_da
     std::lock_guard lk(client_mutex);
     httpClient->SetUrl(url.c_str());
 
+    const auto session_headers = BuildScopelySessionHeaders(header_snapshot, newUUID());
     auto& request_headers = httpClient->GetHeader();
-    request_headers.insert_or_assign("X-TRANSACTION-ID", newUUID());
-    request_headers.insert_or_assign("X-AUTH-SESSION-ID", header_snapshot.instanceSessionId);
-    request_headers.insert_or_assign("X-PRIME-VERSION", header_snapshot.primeVersion);
-    request_headers.insert_or_assign("X-Instance-ID", STR_FORMAT("{:03}", header_snapshot.instanceId));
-    request_headers.insert_or_assign("X-Unity-Version", header_snapshot.unityVersion);
+    request_headers.insert_or_assign("X-TRANSACTION-ID", session_headers.transaction_id);
+    request_headers.insert_or_assign("X-AUTH-SESSION-ID", session_headers.auth_session_id);
+    request_headers.insert_or_assign("X-PRIME-VERSION", session_headers.prime_version);
+    request_headers.insert_or_assign("X-Instance-ID", session_headers.instance_id);
+    request_headers.insert_or_assign("X-Unity-Version", session_headers.unity_version);
 
     httpClient->SetBody(post_data);
     const auto response = httpClient->Post();

--- a/mods/src/patches/sync_transport_policy.cc
+++ b/mods/src/patches/sync_transport_policy.cc
@@ -1,0 +1,44 @@
+#include "patches/sync_transport_policy.h"
+
+#include <utility>
+
+namespace
+{
+std::string format_instance_id(const int32_t instance_id)
+{
+  auto value = std::to_string(instance_id);
+  if (value.starts_with('-') || value.size() >= 3) {
+    return value;
+  }
+
+  return std::string(3 - value.size(), '0') + value;
+}
+} // namespace
+
+namespace http
+{
+SyncTlsVerificationDecision DecideSyncTlsVerification(const SyncConfig& config)
+{
+  if (config.verify_ssl) {
+    return {};
+  }
+
+  if (!config.allow_unsafe_tls_without_certificate_validation) {
+    return {.disable_verification = false, .warn_verify_ssl_ignored = true, .emit_unsafe_tls_error = false};
+  }
+
+  return {.disable_verification = true, .warn_verify_ssl_ignored = false, .emit_unsafe_tls_error = true};
+}
+
+ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSnapshot& snapshot,
+                                                 std::string transaction_id)
+{
+  return {
+      std::move(transaction_id),
+      snapshot.instanceSessionId,
+      snapshot.primeVersion,
+      format_instance_id(snapshot.instanceId),
+      snapshot.unityVersion,
+  };
+}
+} // namespace http

--- a/mods/src/patches/sync_transport_policy.h
+++ b/mods/src/patches/sync_transport_policy.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "patches/sync_transport.h"
+
+#include <string>
+
+namespace http
+{
+struct SyncTlsVerificationDecision {
+  bool disable_verification = false;
+  bool warn_verify_ssl_ignored = false;
+  bool emit_unsafe_tls_error = false;
+};
+
+struct ScopelySessionHeaders {
+  std::string transaction_id;
+  std::string auth_session_id;
+  std::string prime_version;
+  std::string instance_id;
+  std::string unity_version;
+};
+
+[[nodiscard]] SyncTlsVerificationDecision DecideSyncTlsVerification(const SyncConfig& config);
+[[nodiscard]] ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSnapshot& snapshot,
+                                                              std::string transaction_id);
+} // namespace http

--- a/tests/src/test_sync_transport_policy.cc
+++ b/tests/src/test_sync_transport_policy.cc
@@ -1,0 +1,59 @@
+#include <doctest/doctest.h>
+
+#include "patches/sync_transport_policy.h"
+
+TEST_SUITE("sync_transport_policy")
+{
+  TEST_CASE("verify_ssl stays enabled unless the explicit unsafe override is also set")
+  {
+    SyncConfig config;
+
+    auto decision = http::DecideSyncTlsVerification(config);
+    CHECK_FALSE(decision.disable_verification);
+    CHECK_FALSE(decision.warn_verify_ssl_ignored);
+    CHECK_FALSE(decision.emit_unsafe_tls_error);
+
+    config.verify_ssl = false;
+    decision = http::DecideSyncTlsVerification(config);
+    CHECK_FALSE(decision.disable_verification);
+    CHECK(decision.warn_verify_ssl_ignored);
+    CHECK_FALSE(decision.emit_unsafe_tls_error);
+
+    config.allow_unsafe_tls_without_certificate_validation = true;
+    decision = http::DecideSyncTlsVerification(config);
+    CHECK(decision.disable_verification);
+    CHECK_FALSE(decision.warn_verify_ssl_ignored);
+    CHECK(decision.emit_unsafe_tls_error);
+  }
+
+  TEST_CASE("scopely session headers are rebuilt from the latest snapshot")
+  {
+    http::headers::SessionHeaderSnapshot first_snapshot{
+        .gameServerUrl = "https://example.invalid",
+        .instanceSessionId = "session-one",
+        .instanceId = 7,
+        .unityVersion = "6000.0.52f1",
+        .primeVersion = "1.000.1",
+    };
+
+    const auto first_headers = http::BuildScopelySessionHeaders(first_snapshot, "txn-1");
+    CHECK(first_headers.transaction_id == "txn-1");
+    CHECK(first_headers.auth_session_id == "session-one");
+    CHECK(first_headers.prime_version == "1.000.1");
+    CHECK(first_headers.instance_id == "007");
+    CHECK(first_headers.unity_version == "6000.0.52f1");
+
+    http::headers::SessionHeaderSnapshot second_snapshot = first_snapshot;
+    second_snapshot.instanceSessionId = "session-two";
+    second_snapshot.instanceId = 42;
+    second_snapshot.primeVersion = "1.000.2";
+    second_snapshot.unityVersion = "6000.0.60f1";
+
+    const auto second_headers = http::BuildScopelySessionHeaders(second_snapshot, "txn-2");
+    CHECK(second_headers.transaction_id == "txn-2");
+    CHECK(second_headers.auth_session_id == "session-two");
+    CHECK(second_headers.prime_version == "1.000.2");
+    CHECK(second_headers.instance_id == "042");
+    CHECK(second_headers.unity_version == "6000.0.60f1");
+  }
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -27,6 +27,7 @@ do
     add_files("../mods/src/patches/mod_impact_monitor.cc")
     add_files("../mods/src/patches/notification_queue.cc")
     add_files("../mods/src/patches/notification_text.cc")
+    add_files("../mods/src/patches/sync_transport_policy.cc")
 
     add_packages("doctest", "nlohmann_json", "toml++", "spdlog")
 


### PR DESCRIPTION
## Summary
- extract a pure sync transport policy seam for TLS verification decisions and Scopely session header refreshes
- add focused unit coverage for the safe TLS default and fresh request-time session header snapshots
- demote high-volume sync queue enqueue logs from debug to trace

Closes #60

## Validation
- `xmake run -y stfc-mod-tests`
- `xmake build -y stfc-community-mod`
- `git diff --check`
- `ax cycle`
