### PR TITLE
Fix IL2CPP access safety guards

### DIFF
--- a/mods/src/il2cpp/il2cpp_helper.h
+++ b/mods/src/il2cpp/il2cpp_helper.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "il2cpp-functions.h"
+#include "patches/il2cpp_safety.h"
 #include "patches/object_tracker_core.h"
 
 #include <il2cpp-api-types.h>
@@ -504,8 +505,16 @@ inline IL2CppClassHelper il2cpp_get_class_helper_impl(const char* assembly, cons
  */
 template <typename T> inline T* il2cpp_get_array_element(Il2CppArray* array, size_t index)
 {
-  Il2CppArraySize* n = (Il2CppArraySize*)(array);
-  return (T*)n->vector[index];
+  if (!array) {
+    return nullptr;
+  }
+
+  auto* sized_array = reinterpret_cast<Il2CppArraySize*>(array);
+  if (!il2cpp_array_index_is_valid(static_cast<size_t>(sized_array->max_length), index)) {
+    return nullptr;
+  }
+
+  return reinterpret_cast<T*>(sized_array->vector[index]);
 }
 
 /** @brief Global tracked-object core, keyed by Il2CppClass*. */
@@ -537,6 +546,29 @@ public:
     for (const auto object : objects) {
       typed_objects.push_back(reinterpret_cast<T*>(object));
     }
+    return typed_objects;
+  }
+
+  /**
+   * @brief Return the tracked snapshot with null entries filtered out.
+   *
+   * The tracker stores raw pointer identities only; callers still own any
+   * nested field validation before dereference.
+   */
+  static std::vector<T*> GetAllNonNull()
+  {
+    auto objects = tracked_objects.objects_for_class(T::get_class_helper().get_cls());
+
+    std::vector<T*> typed_objects;
+    typed_objects.reserve(objects.size());
+    for (const auto object : objects) {
+      if (!object) {
+        continue;
+      }
+
+      typed_objects.push_back(reinterpret_cast<T*>(object));
+    }
+
     return typed_objects;
   }
 };

--- a/mods/src/patches/fleet_actions.cc
+++ b/mods/src/patches/fleet_actions.cc
@@ -315,7 +315,7 @@ SpaceActionRuntimeContext GatherSpaceActionRuntimeContext(FleetPlayerData* fleet
 {
   SpaceActionRuntimeContext runtime_context;
 
-  const auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
+  const auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAllNonNull();
   runtime_context.visible_pre_scan_targets.reserve(all_pre_scan_widgets.size());
   for (auto pre_scan_widget : all_pre_scan_widgets) {
     if (!IsViewerVisible(pre_scan_widget)) {

--- a/mods/src/patches/fleet_deferred_action.h
+++ b/mods/src/patches/fleet_deferred_action.h
@@ -7,6 +7,8 @@ namespace fleet_deferred_action
 struct State {
   bool      pending = false;
   uint64_t  fleet_id = 0;
+  // Stored as raw pointer identities for short-lived same-process matching only.
+  // This state never owns or dereferences these addresses.
   uintptr_t widget_identity = 0;
   uintptr_t target_identity = 0;
   uint64_t  generation = 0;

--- a/mods/src/patches/il2cpp_safety.cc
+++ b/mods/src/patches/il2cpp_safety.cc
@@ -1,0 +1,6 @@
+#include "patches/il2cpp_safety.h"
+
+bool il2cpp_array_index_is_valid(const size_t array_length, const size_t index)
+{
+  return index < array_length;
+}

--- a/mods/src/patches/il2cpp_safety.h
+++ b/mods/src/patches/il2cpp_safety.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <cstddef>
+
+[[nodiscard]] bool il2cpp_array_index_is_valid(size_t array_length, size_t index);

--- a/mods/src/patches/viewer_mgmt.cc
+++ b/mods/src/patches/viewer_mgmt.cc
@@ -34,8 +34,8 @@ static int show_info_pending = 0;
 template <typename T>
 inline bool CanHideViewersOfType()
 {
-  for (auto widget : ObjectFinder<T>::GetAll()) {
-    const auto visible = widget && widget->_visibilityController != NULL
+  for (auto widget : ObjectFinder<T>::GetAllNonNull()) {
+    const auto visible = widget->_visibilityController != NULL
                          && (widget->_visibilityController->_state == VisibilityState::Visible
                              || widget->_visibilityController->_state == VisibilityState::Show);
     if (visible) {
@@ -59,12 +59,9 @@ bool CanHideViewers()
 template <typename T>
 inline bool DidHideViewersOfType()
 {
-  const auto objects = ObjectFinder<T>::GetAll();
+  const auto objects = ObjectFinder<T>::GetAllNonNull();
   auto       didHide = false;
   for (auto widget : objects) {
-    if (!widget) {
-      continue;
-    }
     auto visbility_controller = widget->_visibilityController;
     if (!visbility_controller) {
       continue;
@@ -106,19 +103,30 @@ bool TryDismissRewardsScreen()
 
 void HandleActionView()
 {
-  auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
+  auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAllNonNull();
 
   for (auto& pre_scan_widget : all_pre_scan_widgets) {
-    if (pre_scan_widget
-        && (pre_scan_widget->_visibilityController->_state == VisibilityState::Visible
-            || pre_scan_widget->_visibilityController->_state == VisibilityState::Show)) {
-      auto rewardsWidget = pre_scan_widget->_rewardsButtonWidget;
-      if (rewardsWidget->_rewardsController->_state != VisibilityState::Visible
-          && rewardsWidget->_rewardsController->_state != VisibilityState::Show) {
-        show_info_pending = 5;
-      } else {
-        rewardsWidget->_rewardsController->Hide();
-      }
+    const auto visibility_controller = pre_scan_widget->_visibilityController;
+    if (!visibility_controller) {
+      continue;
+    }
+
+    const auto visible = visibility_controller->_state == VisibilityState::Visible
+                         || visibility_controller->_state == VisibilityState::Show;
+    if (!visible) {
+      continue;
+    }
+
+    auto rewards_widget = pre_scan_widget->_rewardsButtonWidget;
+    if (!rewards_widget || !rewards_widget->_rewardsController) {
+      continue;
+    }
+
+    if (rewards_widget->_rewardsController->_state != VisibilityState::Visible
+        && rewards_widget->_rewardsController->_state != VisibilityState::Show) {
+      show_info_pending = 5;
+    } else {
+      rewards_widget->_rewardsController->Hide();
     }
   }
 }
@@ -129,19 +137,29 @@ void TickInfoPending()
     return;
   }
 
-  auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAll();
+  auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAllNonNull();
 
   for (auto& pre_scan_widget : all_pre_scan_widgets) {
-    const auto pre_scan_visible = pre_scan_widget
-                                  && (pre_scan_widget->_visibilityController->_state == VisibilityState::Visible
-                                      || pre_scan_widget->_visibilityController->_state == VisibilityState::Show);
-    if (pre_scan_visible) {
-      auto       rewardsWidget          = pre_scan_widget->_rewardsButtonWidget;
-      const auto rewards_widget_visible = rewardsWidget->_rewardsController->_state == VisibilityState::Visible
-                                          || rewardsWidget->_rewardsController->_state == VisibilityState::Show;
-      if (!rewards_widget_visible) {
-        rewardsWidget->_rewardsController->Show(true);
-      }
+    const auto visibility_controller = pre_scan_widget->_visibilityController;
+    if (!visibility_controller) {
+      continue;
+    }
+
+    const auto pre_scan_visible = visibility_controller->_state == VisibilityState::Visible
+                                  || visibility_controller->_state == VisibilityState::Show;
+    if (!pre_scan_visible) {
+      continue;
+    }
+
+    auto rewards_widget = pre_scan_widget->_rewardsButtonWidget;
+    if (!rewards_widget || !rewards_widget->_rewardsController) {
+      continue;
+    }
+
+    const auto rewards_widget_visible = rewards_widget->_rewardsController->_state == VisibilityState::Visible
+                                        || rewards_widget->_rewardsController->_state == VisibilityState::Show;
+    if (!rewards_widget_visible) {
+      rewards_widget->_rewardsController->Show(true);
     }
   }
   show_info_pending -= 1;

--- a/tests/src/test_il2cpp_safety.cc
+++ b/tests/src/test_il2cpp_safety.cc
@@ -1,0 +1,15 @@
+#include <doctest/doctest.h>
+
+#include "patches/il2cpp_safety.h"
+
+TEST_SUITE("il2cpp_safety")
+{
+  TEST_CASE("array index bounds helper only allows in-range access")
+  {
+    CHECK_FALSE(il2cpp_array_index_is_valid(0, 0));
+    CHECK(il2cpp_array_index_is_valid(1, 0));
+    CHECK(il2cpp_array_index_is_valid(3, 2));
+    CHECK_FALSE(il2cpp_array_index_is_valid(3, 3));
+    CHECK_FALSE(il2cpp_array_index_is_valid(3, 99));
+  }
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -20,6 +20,7 @@ do
     add_files("../mods/src/patches/battle_log_decoder.cc")
     add_files("../mods/src/patches/fleet_deferred_action.cc")
     add_files("../mods/src/patches/fleet_input_policy.cc")
+    add_files("../mods/src/patches/il2cpp_safety.cc")
     add_files("../mods/src/patches/input_binding/input_binding.cc")
     add_files("../mods/src/patches/input_binding/input_config_bridge.cc")
     add_files("../mods/src/patches/input_binding/input_dispatcher.cc")


### PR DESCRIPTION
Refs #55

## Summary
- return `nullptr` for null or out-of-range IL2CPP array access through a shared bounds helper with unit coverage
- add `ObjectFinder<T>::GetAllNonNull()` and use it in viewer and fleet pre-scan consumers before nested field checks
- guard nested rewards/visibility controller dereferences and document deferred pointer identity as match-only state

## Validation
- `xmake run -y stfc-mod-tests`
- `xmake build -y stfc-community-mod`
- `git diff --check`
- `ax cycle`