### PR TITLE
fix: warn when macOS notifications are unsupported

### DIFF
--- a/mods/src/patches/notification_audio.cc
+++ b/mods/src/patches/notification_audio.cc
@@ -47,6 +47,13 @@ void notification_audio_init()
 
 #if _WIN32
   spdlog::debug("[NotifyAudio] Windows notification audio initialized");
+#elif defined(__APPLE__)
+  if (Config::Get().notifications.audio_enabled) {
+    spdlog::warn(
+        "[NotifyAudio] macOS does not support notification audio yet; [notifications].notifications_audio_enabled will be ignored");
+  } else {
+    spdlog::debug("[NotifyAudio] Notification audio: macOS does not support this feature yet (no-op)");
+  }
 #else
   spdlog::debug("[NotifyAudio] Notification audio: platform not supported (no-op)");
 #endif

--- a/mods/src/patches/notification_audio.cc
+++ b/mods/src/patches/notification_audio.cc
@@ -1,10 +1,11 @@
 #include "patches/notification_audio.h"
 
 #include "config.h"
+#include "platform_config.h"
 
 #include <spdlog/spdlog.h>
 
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #endif
@@ -47,7 +48,7 @@ void notification_audio_init()
 
 #if _WIN32
   spdlog::debug("[NotifyAudio] Windows notification audio initialized");
-#elif defined(__APPLE__)
+#elif STFCMOD_PLATFORM_MACOS
   if (Config::Get().notifications.audio_enabled) {
     spdlog::warn(
         "[NotifyAudio] macOS does not support notification audio yet; [notifications].notifications_audio_enabled will be ignored");
@@ -66,7 +67,7 @@ void notification_audio_play(NotificationAudioEvent event)
     return;
   }
 
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
   if (!MessageBeep(MB_ICONINFORMATION)) {
     spdlog::warn("[NotifyAudio] Failed to play notification sound event={}", notification_audio_event_name(event));
     return;

--- a/mods/src/patches/notification_platform.cc
+++ b/mods/src/patches/notification_platform.cc
@@ -5,12 +5,13 @@
 #include "patches/notification_platform.h"
 
 #include "patches/notification_text.h"
+#include "platform_config.h"
 
 #include <mutex>
 
 #include <spdlog/spdlog.h>
 
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
 #include <windows.h>
 #include <winrt/Windows.Data.Xml.Dom.h>
 #include <winrt/Windows.UI.Notifications.h>
@@ -35,7 +36,7 @@ void notification_platform_reset_delivery_override_for_testing()
 
 void notification_platform_init()
 {
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
   try { winrt::init_apartment(); } catch (...) {}
 #endif
 }
@@ -50,7 +51,7 @@ void notification_platform_show(const char* title, const char* body)
     }
   }
 
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
   try {
     using namespace winrt::Windows::UI::Notifications;
     using namespace winrt::Windows::Data::Xml::Dom;
@@ -79,6 +80,9 @@ void notification_platform_show(const char* title, const char* body)
   } catch (...) {
     spdlog::warn("[Notify] WinRT notification failed (unknown error)");
   }
+#elif STFCMOD_PLATFORM_MACOS
+  (void)title;
+  (void)body;
 #else
   (void)title;
   (void)body;

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -402,6 +402,13 @@ void notification_init()
     s_notification_worker_thread = std::thread(notification_worker_main);
   });
   spdlog::debug("[Notify] Windows notification service initialized");
+#elif defined(__APPLE__)
+  if (Config::Get().notifications.enabled) {
+    spdlog::warn(
+        "[Notify] macOS does not support OS notifications yet; [notifications].notifications_enabled will be ignored");
+  } else {
+    spdlog::debug("[Notify] Notification service: macOS does not support this feature yet (no-op)");
+  }
 #else
   spdlog::debug("[Notify] Notification service: platform not supported (no-op)");
 #endif
@@ -441,8 +448,10 @@ void notification_show(const char* title, const char* body)
 
 void notification_handle_generic_toast(Toast* toast, int state, const char* title)
 {
-#if !_WIN32
-  return; // No notification delivery on non-Windows platforms yet
+#if defined(__APPLE__)
+  return; // No notification delivery on macOS yet
+#elif !defined(_WIN32)
+  return; // No notification delivery on unsupported non-Windows platforms yet
 #else
   const auto& notifications = Config::Get().notifications;
   if (!notifications.enabled) {

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -11,6 +11,7 @@
 
 #include "bounded_ttl_cache.h"
 #include "config.h"
+#include "platform_config.h"
 #include "patches/async_work_queue.h"
 #include "patches/notification_platform.h"
 #include "patches/notification_queue.h"
@@ -97,7 +98,7 @@ const char* notification_toast_title(int state)
 }
 
 // ─── Platform Notification Delivery ──────────────────────────────────────────────────
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
 static AsyncWorkQueue<NotificationQueueRequest> s_notification_queue;
 static std::mutex              s_recent_toast_mutex;
 static std::once_flag          s_notification_worker_once;
@@ -396,13 +397,13 @@ void notification_init()
     spdlog::warn("[Notify] Could not resolve LanguageManager::Localize — notifications will show titles only");
   }
 
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
   notification_platform_init();
   std::call_once(s_notification_worker_once, []() {
     s_notification_worker_thread = std::thread(notification_worker_main);
   });
   spdlog::debug("[Notify] Windows notification service initialized");
-#elif defined(__APPLE__)
+#elif STFCMOD_PLATFORM_MACOS
   if (Config::Get().notifications.enabled) {
     spdlog::warn(
         "[Notify] macOS does not support OS notifications yet; [notifications].notifications_enabled will be ignored");
@@ -418,7 +419,7 @@ void notification_init()
 
 void notification_shutdown()
 {
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
   s_notification_queue.request_shutdown();
 
   if (!s_notification_worker_thread.joinable()) {
@@ -437,7 +438,7 @@ void notification_shutdown()
 
 void notification_show(const char* title, const char* body)
 {
-#if _WIN32
+#if STFCMOD_PLATFORM_WINDOWS
   if (!Config::Get().notifications.enabled) {
     return;
   }
@@ -448,9 +449,9 @@ void notification_show(const char* title, const char* body)
 
 void notification_handle_generic_toast(Toast* toast, int state, const char* title)
 {
-#if defined(__APPLE__)
+#if STFCMOD_PLATFORM_MACOS
   return; // No notification delivery on macOS yet
-#elif !defined(_WIN32)
+#elif STFCMOD_PLATFORM_OTHER
   return; // No notification delivery on unsupported non-Windows platforms yet
 #else
   const auto& notifications = Config::Get().notifications;

--- a/mods/src/platform_config.h
+++ b/mods/src/platform_config.h
@@ -1,0 +1,23 @@
+/**
+ * @file platform_config.h
+ * @brief Shared compile-time platform selectors for targeted cross-platform guards.
+ */
+#pragma once
+
+#if defined(_WIN32)
+#define STFCMOD_PLATFORM_WINDOWS 1
+#else
+#define STFCMOD_PLATFORM_WINDOWS 0
+#endif
+
+#if defined(__APPLE__)
+#define STFCMOD_PLATFORM_MACOS 1
+#else
+#define STFCMOD_PLATFORM_MACOS 0
+#endif
+
+#if !STFCMOD_PLATFORM_WINDOWS && !STFCMOD_PLATFORM_MACOS
+#define STFCMOD_PLATFORM_OTHER 1
+#else
+#define STFCMOD_PLATFORM_OTHER 0
+#endif


### PR DESCRIPTION
## Summary
- add one-time macOS warnings when OS notifications or notification audio are enabled in config but unsupported on this platform
- make the touched notification service branches explicit for `__APPLE__` vs other non-Windows targets

## Scope
This is only the notification warning slice of `#61`.
The broader platform-guard audit, any additional null-hardening outside the touched notification code, and real macOS validation are still pending.

## Issue
- refs `#61`

## Validation
- `xmake build -y stfc-community-mod`