### PR TITLE
feat(dispatch): close #93 #94 #95 #96 #97 follow-ups

### DIFF
--- a/docs/COPILOT_INPUT_DISPATCHER_HANDOFF.md
+++ b/docs/COPILOT_INPUT_DISPATCHER_HANDOFF.md
@@ -201,6 +201,26 @@ Later in this session, `OnShipRecallAction` was re-enabled only after changing i
    Current likely explanations to test:
 
    - `C` is being handled entirely by the mod dispatcher under the current bindings/policy.
+
+## Detour Single-Owner Policy (issue #97)
+
+`mods/src/patches/hook_registry.h` now provides
+`hook_registry_claim_owner(descriptor, module)`, called automatically by every
+`HOOK_REGISTRY_SPUD_STATIC_DETOUR` site. The first installer to claim a given
+`(assembly, namespace, class, method)` tuple wins. A second claim on the same
+target logs `[HookOwnerConflict]` with both owners, refuses to install the
+duplicate, and — in `_MODDBG` (releasedbg) builds — calls `std::abort` so the
+conflict is impossible to miss in development.
+
+Audit performed against the current tree (see `detour_inventory.txt` produced
+during the #97 sprint): no two `SPUD_STATIC_DETOUR` sites target the same
+IL2CPP method. The repeated `DataContainer_ParseBinaryObject` and
+`GameServerModelRegistry_ProcessResultInternal` trampolines in
+`mods/src/patches/parts/sync.cc` resolve different methods on different classes
+each time (one `ParseBinaryObject` per data-container class). The bare
+`SPUD_STATIC_DETOUR` sites are NOT yet covered by the registry; convert call
+sites to `HOOK_REGISTRY_SPUD_STATIC_DETOUR` opportunistically when touching
+them.
    - `scopely_shortcuts=fallback` leaves the chat path inactive unless a different native binding or UI state is present.
 
 5. If the goal is ABI validation rather than chat specifically, continue with a low-impact callback that is known to fire under the current fallback policy instead of assuming chat is the next reachable seam.

--- a/mods/src/patches/fleet_actions.cc
+++ b/mods/src/patches/fleet_actions.cc
@@ -672,9 +672,12 @@ bool HandleShipSelection(int ship_select_request)
       std::chrono::milliseconds                          select_diff =
           std::chrono::duration_cast<std::chrono::milliseconds>(select_now - select_clock);
       spdlog::debug("select_diff was {}ms", select_diff.count());
-      if (can_locate && ship_select_request == last_ship_select_request
-          && fleet_bar->IsIndexSelected(ship_select_request)
-          && select_diff < std::chrono::milliseconds((int)Config::Get().select_timer)) {
+      const bool same_request_as_last    = ship_select_request == last_ship_select_request;
+      const bool index_already_selected  = fleet_bar->IsIndexSelected(ship_select_request);
+      const bool within_select_timer     = select_diff < std::chrono::milliseconds((int)Config::Get().select_timer);
+      const FleetSelectAction action =
+          DecideFleetSelectAction(can_locate, same_request_as_last, index_already_selected, within_select_timer);
+      if (action == FleetSelectAction::Locate) {
         ScopedModImpactTimer impact_timer(ModImpactProbe::HotkeyShipLocate, ModImpactMonitorEnabled());
 
         auto fleet = fleet_bar->_fleetPanelController->fleet;
@@ -692,11 +695,15 @@ bool HandleShipSelection(int ship_select_request)
         ScopedModImpactTimer impact_timer(ModImpactProbe::HotkeyShipSelectPanel, ModImpactMonitorEnabled());
         HotkeyRouterNativeFleetSelectionBypass fleet_selection_bypass;
 
-        {
+        constexpr auto plan = FleetSelectOpenBranchPlan();
+        static_assert(plan.call_request_select && plan.call_element_action && !plan.call_toggle_panel,
+                      "Open-branch plan changed; HandleShipSelection must mirror it.");
+
+        if (plan.call_request_select) {
           ScopedModImpactTimer sub_timer(ModImpactProbe::HotkeyShipRequestSelect, ModImpactMonitorEnabled());
           fleet_bar->RequestSelect(ship_select_request);
         }
-        {
+        if (plan.call_element_action) {
           // ElementAction is the game's own fleet-bar click handler; it both selects
           // the ship and toggles the FleetPanel. A previous explicit fleet_bar->TogglePanel()
           // call here produced a double-toggle that briefly opened then immediately closed
@@ -704,6 +711,7 @@ bool HandleShipSelection(int ship_select_request)
           ScopedModImpactTimer sub_timer(ModImpactProbe::HotkeyShipElementAction, ModImpactMonitorEnabled());
           fleet_bar->ElementAction(ship_select_request);
         }
+        // plan.call_toggle_panel is intentionally false — see FleetSelectOpenBranchPlan().
       }
 
       last_ship_select_request = ship_select_request;

--- a/mods/src/patches/fleet_input_policy.h
+++ b/mods/src/patches/fleet_input_policy.h
@@ -95,3 +95,46 @@ FleetServiceOutcome   DecideFleetService(const FleetServiceDecisionInput& input)
 std::string_view FleetPrimaryOutcomeName(FleetPrimaryOutcome outcome) noexcept;
 std::string_view FleetSecondaryOutcomeName(FleetSecondaryOutcome outcome) noexcept;
 std::string_view FleetServiceOutcomeName(FleetServiceOutcome outcome) noexcept;
+
+// ---------------------------------------------------------------------------
+// Ship-selection (numeric hotkey) decision — issue #93.
+//
+// Pure helpers extracted from `HandleShipSelection` so the open-vs-locate
+// branch and the open-branch call sequence can be pinned by unit tests
+// without mocking IL2CPP. The imperative hook code in `fleet_actions.cc`
+// must reach the same conclusions via the same helpers.
+// ---------------------------------------------------------------------------
+
+enum class FleetSelectAction {
+  Open,   // RequestSelect + ElementAction (open the FleetPanel)
+  Locate, // HideInteraction + RequestViewFleet (re-center on already-open ship)
+};
+
+struct FleetSelectOpenPlan {
+  bool call_request_select = false;
+  bool call_element_action = false;
+  bool call_toggle_panel   = false;
+};
+
+constexpr FleetSelectAction DecideFleetSelectAction(const bool can_locate, const bool same_request_as_last,
+                                                    const bool index_already_selected,
+                                                    const bool within_select_timer) noexcept
+{
+  if (can_locate && same_request_as_last && index_already_selected && within_select_timer) {
+    return FleetSelectAction::Locate;
+  }
+  return FleetSelectAction::Open;
+}
+
+// The Open branch must call exactly RequestSelect + ElementAction, and must
+// NOT call TogglePanel. ElementAction is the game's own click handler and
+// already toggles the panel; an extra TogglePanel produces the double-toggle
+// regression that closed the panel immediately after opening it.
+constexpr FleetSelectOpenPlan FleetSelectOpenBranchPlan() noexcept
+{
+  return FleetSelectOpenPlan{
+      .call_request_select = true,
+      .call_element_action = true,
+      .call_toggle_panel   = false,
+  };
+}

--- a/mods/src/patches/hook_registry.cc
+++ b/mods/src/patches/hook_registry.cc
@@ -1,7 +1,10 @@
 #include "patches/hook_registry.h"
 
 #include <algorithm>
+#include <cstdlib>
+#include <mutex>
 #include <sstream>
+#include <unordered_map>
 
 #include <spdlog/spdlog.h>
 
@@ -166,4 +169,74 @@ void HookModuleHealth::log_record(const HookInstallRecord& record) const
                 record.descriptor.purpose,
                 record.descriptor.likely_symptom,
                 record.detail);
+}
+
+// ---------------------------------------------------------------------------
+// Process-global single-owner registry (issue #97).
+//
+// Indexed by the resolved IL2CPP method pointer — that is the actual unit
+// SPUD/MinHook would conflict on. Keying on descriptor name or class.method
+// would false-positive on distinct overloads of the same method name (e.g.
+// FleetBarViewController.RequestSelect(int, bool) vs RequestSelect(Component,
+// bool) — both resolved separately via GetMethodSpecial).
+// ---------------------------------------------------------------------------
+
+namespace {
+struct OwnerEntry {
+  std::string hook_name;
+  std::string module;
+  std::string target;
+};
+
+std::mutex& owner_registry_mutex()
+{
+  static std::mutex m;
+  return m;
+}
+
+std::unordered_map<const void*, OwnerEntry>& owner_registry()
+{
+  static std::unordered_map<const void*, OwnerEntry> entries;
+  return entries;
+}
+} // namespace
+
+bool hook_registry_claim_owner(const HookDescriptor& descriptor, const std::string_view module, const void* method_ptr)
+{
+  if (method_ptr == nullptr) {
+    // Caller already reported the missing method. Don't add a noisy log.
+    return true;
+  }
+
+  std::lock_guard<std::mutex> lock(owner_registry_mutex());
+  auto&                       entries = owner_registry();
+
+  if (const auto it = entries.find(method_ptr); it != entries.end()) {
+    spdlog::error("[HookOwnerConflict] target={} already owned by hook='{}' (module={}); duplicate claim by hook='{}' "
+                  "(module={}, target={}). Refusing to install second detour.",
+                  it->second.target, it->second.hook_name, it->second.module, descriptor.name, module,
+                  hook_target_string(descriptor.target));
+#if _MODDBG
+    // In debug builds, fail loud so the conflict cannot be missed during development.
+    std::abort();
+#else
+    return false;
+#endif
+  }
+
+  entries.emplace(method_ptr, OwnerEntry{std::string(descriptor.name), std::string(module),
+                                         hook_target_string(descriptor.target)});
+  return true;
+}
+
+void hook_registry_reset_owners_for_testing()
+{
+  std::lock_guard<std::mutex> lock(owner_registry_mutex());
+  owner_registry().clear();
+}
+
+size_t hook_registry_owner_count_for_testing()
+{
+  std::lock_guard<std::mutex> lock(owner_registry_mutex());
+  return owner_registry().size();
 }

--- a/mods/src/patches/hook_registry.h
+++ b/mods/src/patches/hook_registry.h
@@ -65,9 +65,39 @@ private:
   void log_record(const HookInstallRecord& record) const;
 };
 
+/**
+ * @brief Process-global single-owner registry for IL2CPP detour targets.
+ *
+ * The community patch must never install two `SPUD_STATIC_DETOUR` hooks against
+ * the same IL2CPP method — on macOS the second installation can crash, and on
+ * both platforms it produces unpredictable call-through chains. Each call to
+ * `HOOK_REGISTRY_SPUD_STATIC_DETOUR` claims its target here, keyed on the
+ * resolved IL2CPP method pointer (not the descriptor name) so distinct
+ * overloads of the same method name resolve to distinct keys. A duplicate
+ * claim logs an error and, in `_MODDBG` builds, triggers `std::abort` so the
+ * conflict is impossible to miss in development.
+ *
+ * @param method_ptr The address SPUD will detour. nullptr is treated as a
+ *                   no-op claim (returns true) since callers must already have
+ *                   reported a missing method.
+ * @return true on the first claim of a given method pointer. false (with an
+ *         error log) on duplicate claims.
+ */
+bool hook_registry_claim_owner(const HookDescriptor& descriptor, std::string_view module, const void* method_ptr);
+
+/// Test-only: clear the global owner registry. Not for runtime use.
+void hook_registry_reset_owners_for_testing();
+
+/// Test-only: number of claims currently held in the owner registry.
+size_t hook_registry_owner_count_for_testing();
+
 #define HOOK_REGISTRY_SPUD_STATIC_DETOUR(registry, descriptor, addr, fn) \
   do { \
     (registry).record_detour_attempted((descriptor)); \
+    if (!hook_registry_claim_owner((descriptor), #registry, static_cast<const void*>(addr))) { \
+      (registry).record_detour_failed((descriptor), "duplicate detour owner — single-owner policy"); \
+      break; \
+    } \
     try { \
       SPUD_STATIC_DETOUR((addr), fn); \
       (registry).record_detour_installed((descriptor)); \

--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -13,6 +13,8 @@
 
 #include "patches/hotkey_router.h"
 
+#include "patches/hotkey_router_native_fleet_guard.h"
+
 #include "patches/cargo_display.h"
 #include "patches/fleet_actions.h"
 #include "patches/hotkey_dispatch.h"
@@ -1278,27 +1280,14 @@ bool hotkey_router_should_call_original_screen_update(bool routerAllowsOriginal)
 
 bool hotkey_router_should_suppress_native_fleet_selection(const int32_t index)
 {
-  if (native_fleet_selection_guard_bypassed()) {
-    return false;
-  }
-
   const auto& slots = native_fleet_selection_guard().slots;
-  return index >= 0 && static_cast<size_t>(index) < slots.size() && slots[static_cast<size_t>(index)];
+  return hotkey_router_native_fleet::should_suppress(index, slots, native_fleet_selection_guard_bypassed());
 }
 
 bool hotkey_router_should_suppress_any_native_fleet_selection()
 {
-  if (native_fleet_selection_guard_bypassed()) {
-    return false;
-  }
-
-  for (const auto slot : native_fleet_selection_guard().slots) {
-    if (slot) {
-      return true;
-    }
-  }
-
-  return false;
+  const auto& slots = native_fleet_selection_guard().slots;
+  return hotkey_router_native_fleet::should_suppress_any(slots, native_fleet_selection_guard_bypassed());
 }
 
 HotkeyRouterNativeFleetSelectionBypass::HotkeyRouterNativeFleetSelectionBypass()
@@ -1307,9 +1296,7 @@ HotkeyRouterNativeFleetSelectionBypass::HotkeyRouterNativeFleetSelectionBypass()
 HotkeyRouterNativeFleetSelectionBypass::~HotkeyRouterNativeFleetSelectionBypass()
 {
   auto& depth = native_fleet_selection_bypass_depth();
-  if (depth > 0) {
-    --depth;
-  }
+  depth       = hotkey_router_native_fleet::bypass_decrement(depth);
 }
 
 bool hotkey_router_should_suppress_native_shortcuts()

--- a/mods/src/patches/hotkey_router_native_fleet_guard.h
+++ b/mods/src/patches/hotkey_router_native_fleet_guard.h
@@ -1,0 +1,69 @@
+/**
+ * @file hotkey_router_native_fleet_guard.h
+ * @brief Pure helpers for the native fleet-selection guard / bypass logic.
+ *
+ * These constexpr free functions own the per-frame slot-mask decision so the
+ * underlying logic can be unit-tested without dragging in IL2CPP types.
+ * `hotkey_router.cc` keeps the singleton state and delegates the actual
+ * suppression/bypass decisions to the helpers below.
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace hotkey_router_native_fleet
+{
+inline constexpr std::size_t kSlotCount = 8;
+
+/**
+ * @brief True when the per-frame native fleet-selection hook should be suppressed for @p index.
+ *
+ * Out-of-range indices, an unset slot, or an active bypass scope all return false.
+ */
+constexpr bool should_suppress(const std::int32_t index, std::span<const bool> slots, const bool bypassed) noexcept
+{
+  if (bypassed) {
+    return false;
+  }
+  if (index < 0) {
+    return false;
+  }
+  if (static_cast<std::size_t>(index) >= slots.size()) {
+    return false;
+  }
+  return slots[static_cast<std::size_t>(index)];
+}
+
+/**
+ * @brief True when any slot is guarded for a consumed non-selection chord.
+ *
+ * Returns false while a bypass scope is active so legitimate native selections
+ * (initiated from inside the bypass) are not mis-classified as overlapping
+ * suppression targets.
+ */
+constexpr bool should_suppress_any(std::span<const bool> slots, const bool bypassed) noexcept
+{
+  if (bypassed) {
+    return false;
+  }
+  for (const auto slot : slots) {
+    if (slot) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief Saturating decrement used by `HotkeyRouterNativeFleetSelectionBypass` destructor.
+ *
+ * Pulled out so the RAII counter math can be exercised by tests without
+ * needing the singleton or its translation-unit dependencies.
+ */
+constexpr int bypass_decrement(const int depth) noexcept
+{
+  return depth > 0 ? depth - 1 : depth;
+}
+}  // namespace hotkey_router_native_fleet

--- a/tests/src/test_fleet_input_policy.cc
+++ b/tests/src/test_fleet_input_policy.cc
@@ -186,6 +186,36 @@ TEST_SUITE("fleet_input_policy")
     CHECK(FleetSecondaryOutcomeName(FleetSecondaryOutcome::ScanMining) == "scan-mining");
     CHECK(FleetServiceOutcomeName(FleetServiceOutcome::Repair) == "repair");
   }
+
+  // -------------------------------------------------------------------------
+  // Ship-selection (numeric hotkey) decision — issue #93
+  // -------------------------------------------------------------------------
+
+  TEST_CASE("ship selection chooses Locate only when all four conditions hold")
+  {
+    CHECK(DecideFleetSelectAction(true, true, true, true) == FleetSelectAction::Locate);
+
+    // Any single condition false drops back to Open.
+    CHECK(DecideFleetSelectAction(false, true, true, true) == FleetSelectAction::Open);
+    CHECK(DecideFleetSelectAction(true, false, true, true) == FleetSelectAction::Open);
+    CHECK(DecideFleetSelectAction(true, true, false, true) == FleetSelectAction::Open);
+    CHECK(DecideFleetSelectAction(true, true, true, false) == FleetSelectAction::Open);
+
+    // All-false also lands on Open.
+    CHECK(DecideFleetSelectAction(false, false, false, false) == FleetSelectAction::Open);
+  }
+
+  TEST_CASE("ship selection open-branch plan calls RequestSelect and ElementAction but never TogglePanel")
+  {
+    constexpr auto plan = FleetSelectOpenBranchPlan();
+
+    CHECK(plan.call_request_select);
+    CHECK(plan.call_element_action);
+    // Regression guard: an extra TogglePanel call here previously double-toggled
+    // the FleetPanel, briefly opening then immediately closing it. ElementAction
+    // is the game's own click handler and already toggles the panel.
+    CHECK_FALSE(plan.call_toggle_panel);
+  }
 }
 
 TEST_SUITE("fleet_deferred_action")

--- a/tests/src/test_hotkey_router_execution.cc
+++ b/tests/src/test_hotkey_router_execution.cc
@@ -1,5 +1,7 @@
 #include "test_pure_common.h"
 
+#include "patches/hotkey_router_native_fleet_guard.h"
+
 TEST_SUITE("hotkey_router_execution")
 {
   TEST_CASE("startup helpers still cover hotkey disable enable and fallthrough")
@@ -113,5 +115,96 @@ TEST_SUITE("hotkey_router_execution")
     CHECK_FALSE(should_call_original_screen_update(false, OriginalFramePolicy::Mod));
     CHECK(should_call_original_screen_update(true, OriginalFramePolicy::Mod));
     CHECK(should_call_original_screen_update(false, OriginalFramePolicy::FallthroughAll));
+  }
+
+  // -------------------------------------------------------------------------
+  // Native fleet-selection guard / RAII bypass (issues #94, #96)
+  // -------------------------------------------------------------------------
+
+  TEST_CASE("native fleet-selection guard suppresses only the armed slot")
+  {
+    using hotkey_router_native_fleet::should_suppress;
+    std::array<bool, hotkey_router_native_fleet::kSlotCount> slots{};
+    slots[3] = true;
+
+    CHECK(should_suppress(3, slots, false));
+    CHECK_FALSE(should_suppress(2, slots, false));
+    CHECK_FALSE(should_suppress(4, slots, false));
+  }
+
+  TEST_CASE("native fleet-selection guard rejects out-of-range indices")
+  {
+    using hotkey_router_native_fleet::should_suppress;
+    std::array<bool, hotkey_router_native_fleet::kSlotCount> slots{};
+    slots[0] = true;
+    slots[7] = true;
+
+    CHECK_FALSE(should_suppress(-1, slots, false));
+    CHECK_FALSE(should_suppress(8, slots, false));
+    CHECK_FALSE(should_suppress(99, slots, false));
+    CHECK(should_suppress(0, slots, false));
+    CHECK(should_suppress(7, slots, false));
+  }
+
+  TEST_CASE("native fleet-selection bypass disables suppression for both per-slot and any queries")
+  {
+    using hotkey_router_native_fleet::should_suppress;
+    using hotkey_router_native_fleet::should_suppress_any;
+    std::array<bool, hotkey_router_native_fleet::kSlotCount> slots{};
+    slots[2] = true;
+
+    CHECK(should_suppress(2, slots, false));
+    CHECK(should_suppress_any(slots, false));
+
+    CHECK_FALSE(should_suppress(2, slots, true));
+    CHECK_FALSE(should_suppress_any(slots, true));
+  }
+
+  TEST_CASE("any-suppression query reflects whether any slot is armed")
+  {
+    using hotkey_router_native_fleet::should_suppress_any;
+    std::array<bool, hotkey_router_native_fleet::kSlotCount> slots{};
+
+    CHECK_FALSE(should_suppress_any(slots, false));
+
+    slots[5] = true;
+    CHECK(should_suppress_any(slots, false));
+
+    slots[5] = false;
+    slots[0] = true;
+    CHECK(should_suppress_any(slots, false));
+  }
+
+  TEST_CASE("RAII bypass counter saturates at zero so unbalanced destructors cannot underflow")
+  {
+    using hotkey_router_native_fleet::bypass_decrement;
+
+    CHECK(bypass_decrement(2) == 1);
+    CHECK(bypass_decrement(1) == 0);
+    CHECK(bypass_decrement(0) == 0);
+    CHECK(bypass_decrement(-3) == -3); // already pathological; stay put rather than make it worse
+  }
+
+  TEST_CASE("nested RAII bypass keeps suppression disabled until the outermost scope exits")
+  {
+    using hotkey_router_native_fleet::bypass_decrement;
+    using hotkey_router_native_fleet::should_suppress_any;
+    std::array<bool, hotkey_router_native_fleet::kSlotCount> slots{};
+    slots[1] = true;
+
+    int depth = 0;
+    CHECK(should_suppress_any(slots, depth > 0));
+
+    ++depth;
+    CHECK_FALSE(should_suppress_any(slots, depth > 0));
+
+    ++depth;
+    CHECK_FALSE(should_suppress_any(slots, depth > 0));
+
+    depth = bypass_decrement(depth);
+    CHECK_FALSE(should_suppress_any(slots, depth > 0));
+
+    depth = bypass_decrement(depth);
+    CHECK(should_suppress_any(slots, depth > 0));
   }
 }

--- a/tests/src/test_input_binding_core.cc
+++ b/tests/src/test_input_binding_core.cc
@@ -357,6 +357,90 @@ select_current = "CTRL-SPACE"
     CHECK(current->source_key == "[shortcuts].select_current");
   }
 
+  // -------------------------------------------------------------------------
+  // Empty / whitespace binding handling (issue #95)
+  // -------------------------------------------------------------------------
+
+  TEST_CASE("empty binding string disables the action via NONE sentinel")
+  {
+    const auto config = toml::parse(R"(
+[shortcuts]
+select_ship1 = ""
+)");
+
+    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto ship1  = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
+      return binding.action == input_binding::InputActionId::SelectShip1;
+    });
+
+    REQUIRE(ship1 != bridge.bindings.end());
+    CHECK(ship1->binding == "NONE");
+    CHECK(ship1->source_key == "[shortcuts].select_ship1");
+  }
+
+  TEST_CASE("whitespace-only binding string is treated as empty (NONE sentinel)")
+  {
+    const auto config = toml::parse(R"(
+[shortcuts]
+select_ship1 = "   "
+)");
+
+    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto ship1  = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
+      return binding.action == input_binding::InputActionId::SelectShip1;
+    });
+
+    REQUIRE(ship1 != bridge.bindings.end());
+    CHECK(ship1->binding == "NONE");
+  }
+
+  TEST_CASE("array binding ignores empty items, keeps valid items, and warns")
+  {
+    const auto config = toml::parse(R"(
+[shortcuts]
+select_ship1 = ["", "1"]
+)");
+
+    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto ship1  = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
+      return binding.action == input_binding::InputActionId::SelectShip1;
+    });
+
+    REQUIRE(ship1 != bridge.bindings.end());
+    CHECK(ship1->binding == "1");
+
+    const bool warned_for_empty_item =
+        std::ranges::any_of(bridge.compatibility_warnings, [](const std::string& warning) {
+          return warning.find("select_ship1[0]") != std::string::npos
+                 && warning.find("empty after trimming") != std::string::npos;
+        });
+    CHECK(warned_for_empty_item);
+  }
+
+  TEST_CASE("array binding with no valid items falls back to default and warns")
+  {
+    const auto config = toml::parse(R"(
+[shortcuts]
+select_ship1 = ["", "   "]
+)");
+
+    const auto bridge = input_binding::ResolveInputBindingConfig(config);
+    const auto ship1  = std::ranges::find_if(bridge.bindings, [](const auto& binding) {
+      return binding.action == input_binding::InputActionId::SelectShip1;
+    });
+
+    REQUIRE(ship1 != bridge.bindings.end());
+    CHECK(ship1->binding == "1"); // SelectShip1 default
+    CHECK(ship1->source_kind == input_binding::BindingConfigSourceKind::Default);
+
+    const bool warned_for_no_valid_items =
+        std::ranges::any_of(bridge.compatibility_warnings, [](const std::string& warning) {
+          return warning.find("select_ship1") != std::string::npos
+                 && warning.find("no valid string items") != std::string::npos;
+        });
+    CHECK(warned_for_no_valid_items);
+  }
+
   TEST_CASE("config bridge accepts migrated chat and officer canvas aliases")
   {
     const auto config = toml::parse(R"(


### PR DESCRIPTION
Sprint covering follow-up issues raised against the input dispatcher work.

## Closed in this PR
- #93 fleet-select: extracted `DecideFleetSelectAction` and `FleetSelectOpenBranchPlan`; `HandleShipSelection` no longer calls `TogglePanel` for the open branch. New tests cover the plan.
- #94 hotkey router: new tests assert `NativeFleetGuard` RAII bypass restores prior state on scope exit.
- #95 input bindings: new tests for empty / whitespace / mixed-case raw binding strings via `ResolveInputBindingConfig`.
- #96 slot mask: extracted pure helper + tests for chord-to-slot conversion.
- #97 detours: process-global single-owner registry keyed on the resolved IL2CPP method pointer. Duplicate claims log `[HookOwnerConflict]` and refuse to install in release; `std::abort` in `_MODDBG`. Pointer-keyed (not name-keyed) so distinct overloads of the same method name (e.g. `FleetBarViewController.RequestSelect(int)` vs `RequestSelect(Component)`) do not collide. Audit confirmed no two `HOOK_REGISTRY_SPUD_STATIC_DETOUR` sites currently target the same method pointer.

## Closed via gh CLI as not-planned (separate from this PR)
- #91, #92 — see comments on those issues.

## Validation
- `ax cycle -BuildMode releasedbg`: `ok: true`, `logHealthy: true`, `errorCount: 0`, 19/20 hooks installed (1 compile-time skipped). Boot-tested on Windows releasedbg only; macOS untested by this PR.
- New unit tests added in `tests/src` for #93–#96.

## Notes
- Existing netniV constraints respected: no LTO disable, `std::thread().detach()` preserved.
