### PR TITLE
[codex] Support ALL in legacy notification allowlist

### DIFF
--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1311,13 +1311,21 @@ void Config::Load()
     this->notifications.ClearToastStates();
 
     std::vector<std::string> notify_types = StrSplit(legacy_notify_banner_types, ',');
-    for (const auto& [key, value] : bannerTypes) {
-      auto upper_key = AsciiStrToUpper(key);
-      for (const std::string_view raw_type : notify_types) {
-        auto stripped_type = StripLeadingAsciiWhitespace(raw_type);
-        auto upper_type    = AsciiStrToUpper(stripped_type);
-        if (upper_key == upper_type) {
-          this->notifications.SetToastStateEnabled(value, true);
+    const bool legacy_notify_all_requested =
+        std::ranges::any_of(notify_types, legacy_notification_allowlist_requests_all);
+    if (legacy_notify_all_requested) {
+      for (const auto& spec : notificationToggleSpecs) {
+        this->notifications.SetToastStateEnabled(spec.toast_state, true);
+      }
+    } else {
+      for (const auto& [key, value] : bannerTypes) {
+        auto upper_key = AsciiStrToUpper(key);
+        for (const std::string_view raw_type : notify_types) {
+          auto stripped_type = StripLeadingAsciiWhitespace(raw_type);
+          auto upper_type    = AsciiStrToUpper(stripped_type);
+          if (upper_key == upper_type) {
+            this->notifications.SetToastStateEnabled(value, true);
+          }
         }
       }
     }

--- a/mods/src/testable_functions.cc
+++ b/mods/src/testable_functions.cc
@@ -4,6 +4,8 @@
 
 #include "testable_functions.h"
 
+#include "str_utils_pure.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cmath>
@@ -217,6 +219,15 @@ HotkeyDisableShortcutAliasDecision resolve_hotkey_disable_shortcut_alias(const H
   }
 
   return decision;
+}
+
+bool legacy_notification_allowlist_requests_all(const std::string_view token)
+{
+  const auto trimmed = StripAsciiWhitespace(token);
+  std::string normalized{trimmed};
+  std::ranges::transform(normalized, normalized.begin(),
+                         [](const unsigned char c) { return static_cast<char>(std::toupper(c)); });
+  return normalized == "ALL";
 }
 
 HotkeyRouterStartupAction hotkey_router_startup_action(bool disable_hotkeys_pressed, bool enable_hotkeys_pressed,

--- a/mods/src/testable_functions.h
+++ b/mods/src/testable_functions.h
@@ -85,6 +85,9 @@ SpaceActionInputs hotkey_router_runtime_space_action_inputs(bool fleet_primary_p
 // Resolve the canonical disable-hotkeys shortcut while accepting deprecated keys.
 HotkeyDisableShortcutAliasDecision resolve_hotkey_disable_shortcut_alias(const HotkeyDisableShortcutAliasInput& input);
 
+// Legacy [ui].notify_on_banner_types / notify_banner_types compatibility.
+bool legacy_notification_allowlist_requests_all(std::string_view token);
+
 enum class HotkeyRouterStartupAction {
   Continue = 0,
   DisableHotkeys,

--- a/tests/src/test_config_schema.cc
+++ b/tests/src/test_config_schema.cc
@@ -141,6 +141,18 @@ repair_complete = { system = true, audio = true, sound = "repair" }
   }
 }
 
+TEST_SUITE("legacy_notification_allowlist")
+{
+  TEST_CASE("ALL token is accepted case-insensitively with surrounding whitespace")
+  {
+    CHECK(legacy_notification_allowlist_requests_all("ALL"));
+    CHECK(legacy_notification_allowlist_requests_all(" all "));
+    CHECK(legacy_notification_allowlist_requests_all("\tAll\r\n"));
+    CHECK_FALSE(legacy_notification_allowlist_requests_all("FleetBattle"));
+    CHECK_FALSE(legacy_notification_allowlist_requests_all("ALLIES"));
+  }
+}
+
 // ===========================================================================
 // battle_log_decoder
 // ===========================================================================


### PR DESCRIPTION
## Summary
- Treat deprecated `[ui].notify_on_banner_types` / `notify_banner_types` token `ALL` as every current toast-backed notification toggle.
- Keep explicit `[notifications]` keys authoritative over legacy migration.
- Add a pure regression test for case-insensitive, whitespace-padded `ALL` parsing.

## Validation
- `git diff --check`
- `pwsh -NoProfile -File .ax\ax.ps1 pure-tests`
- `xmake -y mods`