### PR TITLE
[codex] Limit CI to main and ready PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,20 +1,23 @@
 # @file ci.yaml
 # @brief CI build workflow — compiles the community patch on Windows and macOS.
 #
-# Triggers on every push and on PRs targeting main/dev.  Builds release
+# Triggers automatically for main branch updates and for PRs only when they
+# are opened/reopened as reviewable or moved out of draft. Builds release
 # artifacts for both platforms using xmake, creates a universal macOS app
 # bundle (arm64 + x86_64 via lipo), ad-hoc signs it, and packages a .dmg
-# installer.  Uploads version.dll (Windows) and the .dmg (macOS) as
-# build artifacts.
+# installer. Uploads version.dll (Windows) and the .dmg (macOS) as build
+# artifacts.
 
 name: Build
 
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     branches: ["main", "dev"]
+    types: [opened, reopened, ready_for_review]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,6 +28,7 @@ env:
 
 jobs:
   build-win:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-2025-vs2026
     steps:
       - name: Checkout
@@ -74,6 +78,7 @@ jobs:
           if-no-files-found: error
 
   build-mac:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: macos-26
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Limit the Build workflow so it no longer runs on every branch push.

## Problem

The current workflow runs on both branch pushes and pull request events. For active feature branches this can produce duplicate CI runs for the same logical change, especially once a PR exists.

## Intended Behavior

- Pushes to `main` still run the full Windows/macOS Build workflow and upload artifacts.
- Pull requests into `main` or `dev` run Build when they are opened, reopened, or marked ready for review.
- Draft PRs do not consume full Build minutes.
- Manual `workflow_dispatch` remains available for explicit reruns.

## Acceptance Checks

- Branch pushes outside `main` should not start Build.
- A ready/non-draft PR should start Build.
- A draft PR should not run the build jobs.
- Merges to `main` should still produce the full artifact set.

## Validation

- `git diff --check`

`actionlint` is not installed locally, so dedicated workflow linting was not run.

## Rollback

Revert this commit to restore the previous push-on-every-branch behavior.
