### PR TITLE
[codex] Guard live debug recent event store

### DIFF
--- a/mods/src/patches/live_debug_event_store.cc
+++ b/mods/src/patches/live_debug_event_store.cc
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,6 +20,8 @@ LiveDebugRecentEventStore::LiveDebugRecentEventStore(size_t capacity)
 
 void LiveDebugRecentEventStore::append(std::string_view kind, nlohmann::json details, int64_t timestamp_ms_utc)
 {
+  const std::lock_guard lock(mutex_);
+
   events_.push_back({nlohmann::json{{"seq", ++nextSequence_},
                                     {"timestampMsUtc", timestamp_ms_utc},
                                     {"kind", kind},
@@ -196,6 +199,8 @@ void LiveDebugRecentEventStore::rebuild_kind_index() const
 
 LiveDebugRecentEventStoreSnapshot LiveDebugRecentEventStore::snapshot(const LiveDebugRecentEventStoreQuery& query) const
 {
+  const std::lock_guard lock(mutex_);
+
   LiveDebugRecentEventStoreSnapshot result;
   result.count = events_.size();
   result.capacity = capacity_;
@@ -279,6 +284,8 @@ LiveDebugRecentEventStoreSnapshot LiveDebugRecentEventStore::snapshot(const Live
 
 size_t LiveDebugRecentEventStore::clear()
 {
+  const std::lock_guard lock(mutex_);
+
   const auto cleared = events_.size();
   events_.clear();
   ++clearCount_;

--- a/mods/src/patches/live_debug_event_store.h
+++ b/mods/src/patches/live_debug_event_store.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <deque>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -63,6 +64,7 @@ public:
 private:
   void rebuild_kind_index() const;
 
+  mutable std::mutex         mutex_;
   size_t                     capacity_ = 0;
   uint64_t                   nextSequence_ = 0;
   uint64_t                   evictedCount_ = 0;

--- a/tests/src/test_live_debug_pure.cc
+++ b/tests/src/test_live_debug_pure.cc
@@ -1,5 +1,8 @@
 #include "test_pure_common.h"
 
+#include <atomic>
+#include <thread>
+
 // ===========================================================================
 // live_debug_pure
 // ===========================================================================
@@ -126,6 +129,58 @@ TEST_SUITE("live_debug_recent_event_store")
     REQUIRE(exact_snapshot.events.size() == 2);
     CHECK(exact_snapshot.events[0]["seq"] == 1);
     CHECK(exact_snapshot.events[1]["seq"] == 4);
+  }
+
+  TEST_CASE("snapshot can run while append and clear mutate the store")
+  {
+    LiveDebugRecentEventStore store(64);
+    std::atomic_bool          writers_done     = false;
+    std::atomic_bool          invariant_failed = false;
+
+    std::thread writer_a([&store] {
+      for (int i = 0; i < 250; ++i) {
+        store.append("event-a", nlohmann::json{{"payload", i}}, i);
+      }
+    });
+
+    std::thread writer_b([&store] {
+      for (int i = 0; i < 250; ++i) {
+        store.append("event-b", nlohmann::json{{"payload", i}}, i);
+      }
+    });
+
+    std::thread clearer([&store] {
+      for (int i = 0; i < 8; ++i) {
+        std::this_thread::yield();
+        store.clear();
+      }
+    });
+
+    std::thread reader([&store, &writers_done, &invariant_failed] {
+      LiveDebugRecentEventStoreQuery query;
+      query.kinds          = {"event-a", "event-b"};
+      query.match          = "payload";
+      query.limit          = 16;
+      query.includeDetails = false;
+
+      while (!writers_done.load()) {
+        const auto snapshot = store.snapshot(query);
+        if (snapshot.count > snapshot.capacity || snapshot.returnedCount != snapshot.events.size()
+            || snapshot.returnedCount > query.limit) {
+          invariant_failed.store(true);
+        }
+      }
+    });
+
+    writer_a.join();
+    writer_b.join();
+    clearer.join();
+    writers_done.store(true);
+    reader.join();
+
+    const auto snapshot = store.snapshot();
+    CHECK(snapshot.count <= snapshot.capacity);
+    CHECK_FALSE(invariant_failed.load());
   }
 
   TEST_CASE("recent-events request parser merges filters and summary flags")


### PR DESCRIPTION
## Summary

Fixes #104 by serializing access to `LiveDebugRecentEventStore`.

## Problem

AX/debug polling can snapshot recent live-debug events while game-thread hooks append or clear events. The store also lazily mutates kind indexes, kind-count caches, and per-event search text from `snapshot()`, so the race is not limited to the public event deque.

## Changes

- Add a store-level mutex.
- Lock `append()`, `snapshot()`, and `clear()`.
- Cover lazy kind-index rebuilds and search-text cache mutation under the same lock.
- Add a pure concurrent append/snapshot/clear test for the recent-event store.

## Acceptance Checks

- Concurrent append/snapshot/clear does not observe impossible snapshot metadata.
- Existing recent-event query behavior remains unchanged.
- AX debug polling no longer races event recording on the store internals.

## Validation

- `xmake build stfc-mod-tests`
- `build/windows/x64/release/stfc-mod-tests.exe --test-suite=live_debug_recent_event_store`
- `build/windows/x64/release/stfc-mod-tests.exe`
- `git diff --check`
