### PR TITLE
[codex] Harden hook crash guards

### DIFF
--- a/mods/src/patches/battle_log_decoder.cc
+++ b/mods/src/patches/battle_log_decoder.cc
@@ -30,6 +30,7 @@ constexpr int64_t kTriggeredEffectStartMarker = -93;
 constexpr int64_t kTriggeredEffectShipMarker = -91;
 constexpr int64_t kTriggeredEffectEndMarker = -92;
 constexpr int64_t kTriggeredEffectTerminator = -94;
+constexpr size_t  kLosslessIntegerJsonMaxDepth = 128;
 
 struct ParticipantInfo {
   std::string          side;
@@ -264,12 +265,16 @@ void append_unique(std::vector<int64_t>& values, int64_t value)
   return result;
 }
 
-[[nodiscard]] nlohmann::json lossless_integer_json(const nlohmann::json& value)
+[[nodiscard]] nlohmann::json lossless_integer_json(const nlohmann::json& value, size_t depth)
 {
+  if (depth >= kLosslessIntegerJsonMaxDepth) {
+    return nullptr;
+  }
+
   if (value.is_object()) {
     auto result = nlohmann::json::object();
     for (const auto& [key, entry] : value.items()) {
-      result[key] = lossless_integer_json(entry);
+      result[key] = lossless_integer_json(entry, depth + 1);
     }
     return result;
   }
@@ -277,7 +282,7 @@ void append_unique(std::vector<int64_t>& values, int64_t value)
   if (value.is_array()) {
     auto result = nlohmann::json::array();
     for (const auto& entry : value) {
-      result.push_back(lossless_integer_json(entry));
+      result.push_back(lossless_integer_json(entry, depth + 1));
     }
     return result;
   }
@@ -288,6 +293,9 @@ void append_unique(std::vector<int64_t>& values, int64_t value)
 
   return value;
 }
+
+[[nodiscard]] nlohmann::json lossless_integer_json(const nlohmann::json& value)
+{ return lossless_integer_json(value, 0); }
 
 [[nodiscard]] nlohmann::json json_slice(const nlohmann::json& values, size_t start, size_t count)
 {

--- a/mods/src/patches/fleet_actions.cc
+++ b/mods/src/patches/fleet_actions.cc
@@ -515,6 +515,11 @@ bool TryExecuteWarpCancel(FleetBarViewController* fleet_bar, FleetPlayerData* fl
                           bool has_queue, bool has_queue_clear, bool has_recall, bool has_repair,
                           bool has_recall_cancel, bool suppress_warp_cancel, SpaceActionDiagnostics& diagnostics)
 {
+  if (!fleet_bar || !fleet_bar->_fleetPanelController || !fleet) {
+    diagnostics.SetOutcome("warp-cancel-missing-fleet-context");
+    return false;
+  }
+
   if (suppress_warp_cancel) {
     live_debug_record_space_action_warp_cancel_suppressed(
         fleet_bar, fleet, has_primary, has_secondary, has_queue, has_queue_clear, has_recall, has_repair,
@@ -660,9 +665,15 @@ bool HandleShipSelection(int ship_select_request)
   if (Key::HasShift()) {
     ScopedModImpactTimer impact_timer(ModImpactProbe::HotkeyShipTow, ModImpactMonitorEnabled());
 
+    auto* fleets_manager     = FleetsManager::Instance();
+    auto* deployment_manager = DeploymentManger::Instance();
+    if (!fleets_manager || !deployment_manager) {
+      return false;
+    }
+
     FleetPlayerData* foundDisco = nullptr;
     for (int discoIdx = 0; discoIdx < 10; ++discoIdx) {
-      auto fleetPlayerData = FleetsManager::Instance()->GetFleetPlayerData(discoIdx);
+      auto fleetPlayerData = fleets_manager->GetFleetPlayerData(discoIdx);
       if (fleetPlayerData && fleetPlayerData->Hull && fleetPlayerData->Hull->Id == 1307832955) {
         foundDisco = fleetPlayerData;
         break;
@@ -670,14 +681,18 @@ bool HandleShipSelection(int ship_select_request)
     }
 
     if (foundDisco) {
-      auto towedFleetId = FleetsManager::Instance()->GetFleetPlayerData(ship_select_request)->Id;
+      auto* towed_fleet = fleets_manager->GetFleetPlayerData(ship_select_request);
+      if (!towed_fleet) {
+        return false;
+      }
+
+      auto towedFleetId = towed_fleet->Id;
       auto plannedCourse =
-          DeploymentManger::Instance()->PlanCourse(FleetsManager::Instance()->GetFleetPlayerData(ship_select_request),
-                                                   foundDisco->Address, Vector3::zero(), nullptr, nullptr, nullptr);
-      while (plannedCourse->MoveNext()) {
+          deployment_manager->PlanCourse(towed_fleet, foundDisco->Address, Vector3::zero(), nullptr, nullptr, nullptr);
+      while (plannedCourse && plannedCourse->MoveNext()) {
         ;
       }
-      DeploymentManger::Instance()->SetTowRequest(towedFleetId, foundDisco->Id);
+      deployment_manager->SetTowRequest(towedFleetId, foundDisco->Id);
     }
   } else {
     FleetBarViewController* fleet_bar  = nullptr;
@@ -700,16 +715,26 @@ bool HandleShipSelection(int ship_select_request)
       if (action == FleetSelectAction::Locate) {
         ScopedModImpactTimer impact_timer(ModImpactProbe::HotkeyShipLocate, ModImpactMonitorEnabled());
 
-        auto fleet = fleet_bar->_fleetPanelController->fleet;
+        auto fleet_controller = fleet_bar->_fleetPanelController;
+        auto fleet            = fleet_controller ? fleet_controller->fleet : nullptr;
+        if (!fleet) {
+          return false;
+        }
+
         {
           ScopedModImpactTimer sub_timer(ModImpactProbe::HotkeyShipLocateHideInteraction, ModImpactMonitorEnabled());
-          if (NavigationSectionManager::Instance() && NavigationSectionManager::Instance()->SNavigationManager) {
-            NavigationSectionManager::Instance()->SNavigationManager->HideInteraction();
+          if (auto* navigation_section_manager = NavigationSectionManager::Instance();
+              navigation_section_manager && navigation_section_manager->SNavigationManager) {
+            navigation_section_manager->SNavigationManager->HideInteraction();
           }
         }
         {
           ScopedModImpactTimer sub_timer(ModImpactProbe::HotkeyShipLocateRequestView, ModImpactMonitorEnabled());
-          FleetsManager::Instance()->RequestViewFleet(fleet, true);
+          if (auto* fleets_manager = FleetsManager::Instance()) {
+            fleets_manager->RequestViewFleet(fleet, true);
+          } else {
+            return false;
+          }
         }
       } else {
         ScopedModImpactTimer impact_timer(ModImpactProbe::HotkeyShipSelectPanel, ModImpactMonitorEnabled());
@@ -764,6 +789,10 @@ inline FleetActionExecutionResult
 DidExecuteFleetAction(std::string_view actionText, ActionType actionType, FleetBarViewController* fleet_bar,
                       const std::span<const FleetState> wantedStates, FleetState helpState = FleetState::Unknown)
 {
+  if (!fleet_bar || !fleet_bar->_fleetPanelController || !fleet_bar->_fleetPanelController->fleet) {
+    return {};
+  }
+
   auto fleet_controller = fleet_bar->_fleetPanelController;
   auto fleet            = fleet_bar->_fleetPanelController->fleet;
   auto fleet_state      = fleet->CurrentState;
@@ -787,8 +816,9 @@ DidExecuteFleetAction(std::string_view actionText, ActionType actionType, FleetB
   if (canAction) {
     switch (result.request_mode) {
       case FleetActionRequestMode::Default:
-        if (NavigationSectionManager::Instance() && NavigationSectionManager::Instance()->SNavigationManager) {
-          NavigationSectionManager::Instance()->SNavigationManager->HideInteraction();
+        if (auto* navigation_section_manager = NavigationSectionManager::Instance();
+            navigation_section_manager && navigation_section_manager->SNavigationManager) {
+          navigation_section_manager->SNavigationManager->HideInteraction();
         }
 
         result.did_action = fleet_controller->RequestAction(fleet, actionType, 0, ActionBehaviour::Default);
@@ -838,6 +868,10 @@ void ClearFleetActionQueue(FleetBarViewController* fleet_bar)
 
 bool ExecuteSpaceAction(FleetBarViewController* fleet_bar, const SpaceActionInputs& inputs)
 {
+  if (!fleet_bar || !fleet_bar->_fleetPanelController || !fleet_bar->_fleetPanelController->fleet) {
+    return false;
+  }
+
   auto fleet_controller = fleet_bar->_fleetPanelController;
   auto fleet            = fleet_controller->fleet;
 
@@ -864,9 +898,13 @@ bool ExecuteSpaceAction(FleetBarViewController* fleet_bar, const SpaceActionInpu
 
   if (has_queue_clear) {
     auto action_queue = ActionQueueManager::Instance();
-    action_queue->ClearQueue(fleet);
-    diagnostics.Complete("queue-clear");
-    return true;
+    if (action_queue) {
+      action_queue->ClearQueue(fleet);
+      diagnostics.Complete("queue-clear");
+      return true;
+    }
+    diagnostics.SetOutcome("queue-manager-missing");
+    return false;
   }
 
   const auto target_context_requested = has_primary || has_secondary || has_queue;
@@ -903,7 +941,7 @@ bool ExecuteSpaceAction(FleetBarViewController* fleet_bar, const SpaceActionInpu
   }
 
   auto action_queue   = ActionQueueManager::Instance();
-  auto queue_unlocked = has_queue && action_queue->IsQueueUnlocked();
+  auto queue_unlocked = has_queue && action_queue && action_queue->IsQueueUnlocked();
 
   for (const auto& pre_scan_target : runtime_context.visible_pre_scan_targets) {
     auto pre_scan_widget             = pre_scan_target.widget;

--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -151,14 +151,17 @@ bool hotkey_router_screen_update(ScreenManager* _this)
             spdlog::trace("[HotkeyDiag] action=select-current");
           }
           auto fleet_bar = ObjectFinder<FleetBarViewController>::Get();
-          if (fleet_bar) {
+          if (fleet_bar && fleet_bar->_fleetPanelController) {
             auto fleet = fleet_bar->_fleetPanelController->fleet;
             if (fleet) {
-              if (NavigationSectionManager::Instance() && NavigationSectionManager::Instance()->SNavigationManager) {
-                NavigationSectionManager::Instance()->SNavigationManager->HideInteraction();
+              if (auto* navigation_section_manager = NavigationSectionManager::Instance();
+                  navigation_section_manager && navigation_section_manager->SNavigationManager) {
+                navigation_section_manager->SNavigationManager->HideInteraction();
               }
-              FleetsManager::Instance()->RequestViewFleet(fleet, true);
-              return false;
+              if (auto* fleets_manager = FleetsManager::Instance()) {
+                fleets_manager->RequestViewFleet(fleet, true);
+                return false;
+              }
             }
           }
         }

--- a/mods/src/patches/navigation.cc
+++ b/mods/src/patches/navigation.cc
@@ -14,14 +14,26 @@
 #include "prime/NavigationSectionManager.h"
 #include "prime/ScreenManager.h"
 
+#include <cstring>
+
 void GotoSection(SectionID sectionID, void* section_data)
 {
-  Hub::get_SectionManager()->TriggerSectionChange(sectionID, section_data, false, false, true);
+  auto* section_manager = Hub::get_SectionManager();
+  if (!section_manager) {
+    NavigationSectionManager::ChangeNavigationSection(sectionID);
+    return;
+  }
+
+  section_manager->TriggerSectionChange(sectionID, section_data, false, false, true);
 }
 
 void ChangeNavigationSection(SectionID sectionID)
 {
-  const auto section_data = Hub::get_SectionManager()->_sectionStorage->GetState(sectionID);
+  void* section_data = nullptr;
+  if (auto* section_manager = Hub::get_SectionManager();
+      section_manager && section_manager->_sectionStorage) {
+    section_data = section_manager->_sectionStorage->GetState(sectionID);
+  }
 
   if (section_data) {
     GotoSection(sectionID, section_data);
@@ -37,7 +49,9 @@ bool MoveOfficerCanvas(bool goLeft)
   // ScreenManager/CanvasRoot/MainFrame/LeftArrow and RightArrow
 
   auto const canvas = ScreenManager::GetTopCanvas(true);
-  if (strcmp(((Il2CppObject*)(canvas))->klass->name, "OfficerShowcase_Canvas") == 0) {}
+  auto*      canvas_object = reinterpret_cast<Il2CppObject*>(canvas);
+  if (canvas_object && canvas_object->klass && canvas_object->klass->name
+      && strcmp(canvas_object->klass->name, "OfficerShowcase_Canvas") == 0) {}
 
   return false;
 }

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -29,6 +29,7 @@
 
 #include <cstring>
 #include <cstdlib>
+#include <exception>
 
 namespace
 {
@@ -252,10 +253,16 @@ void ApplyPatches()
       auto n = dlsym(assembly, "il2cpp_init");
 #endif
       printf("Got il2cpp_init %p\n", n);
+      if (!n) {
+        spdlog::error("Failed to resolve il2cpp_init; community patch hooks were not installed");
+        return;
+      }
 
       SPUD_STATIC_DETOUR(n, il2cpp_init_hook);
+    } catch (const std::exception& exception) {
+      spdlog::error("Failed to install il2cpp_init hook: {}", exception.what());
     } catch (...) {
-      // Failed to Apply at least some patches
+      spdlog::error("Failed to install il2cpp_init hook: unknown exception");
     }
   }
 }

--- a/mods/src/patches/sync_payload_builders.cc
+++ b/mods/src/patches/sync_payload_builders.cc
@@ -810,7 +810,14 @@ void process_entity_slots_rtc(std::unique_ptr<std::string>&& json_payload)
         if (const auto& params = data["fleet_preset_slot_params"]; !params.is_null()) {
           auto setup_json = json::array();
           for (const auto& setup : params["setups"]) {
-            setup_json.push_back({{"drydock_id", setup["d"]}, {"ship_id", setup["s"][0]}, {"officer_ids", setup["o"]}});
+            json ship_id = nullptr;
+            if (const auto& ships = setup["s"]; ships.is_array() && !ships.empty()) {
+              ship_id = ships[0];
+            }
+
+            setup_json.push_back({{"drydock_id", setup.value("d", json(nullptr))},
+                                  {"ship_id", ship_id},
+                                  {"officer_ids", setup.value("o", json::array())}});
           }
 
           slot_params = {{"name", params["name"]}, {"order", params["order"]}, {"setup", setup_json}};
@@ -1222,6 +1229,10 @@ void HandleEntityGroup(EntityGroup* entity_group)
 
 void HandleServiceResponseEntityGroups(ServiceResponse* service_response)
 {
+  if (!service_response || !service_response->EntityGroups) {
+    return;
+  }
+
   const auto entity_groups = service_response->EntityGroups;
   for (int i = 0; i < entity_groups->Count; ++i) {
     const auto entity_group = entity_groups->get_Item(i);
@@ -1241,7 +1252,15 @@ void HandleRealtimeDataPayload(RealtimeDataPayload* data)
   }
 
   const auto type_string = to_string(data->DataType);
-  if (std::stoi(type_string) != DataType::JSON) {
+  int        data_type   = 0;
+  try {
+    data_type = std::stoi(type_string);
+  } catch (const std::exception& exception) {
+    spdlog::warn("Failed to parse realtime data payload type '{}': {}", type_string, exception.what());
+    return;
+  }
+
+  if (data_type != DataType::JSON) {
     return;
   }
 

--- a/mods/src/patches/sync_transport.cc
+++ b/mods/src/patches/sync_transport.cc
@@ -130,11 +130,22 @@ bool should_disable_tls_verification(const SyncConfig& config, const std::string
 [[nodiscard]] static std::string newUUID()
 {
 #ifdef _WIN32
-  UUID uuid;
-  UuidCreate(&uuid);
+  UUID uuid{};
+  const auto create_status = UuidCreate(&uuid);
+  if (create_status != RPC_S_OK && create_status != RPC_S_UUID_LOCAL_ONLY) {
+    spdlog::warn("[Sync] Failed to create UUID for request headers: status={}", create_status);
+    return {};
+  }
 
-  unsigned char* str;
-  UuidToStringA(&uuid, &str);
+  unsigned char* str = nullptr;
+  const auto     stringify_status = UuidToStringA(&uuid, &str);
+  if (stringify_status != RPC_S_OK || !str) {
+    spdlog::warn("[Sync] Failed to stringify UUID for request headers: status={}", stringify_status);
+    if (str) {
+      RpcStringFreeA(&str);
+    }
+    return {};
+  }
 
   std::string result(reinterpret_cast<char*>(str));
 

--- a/tests/src/test_battle_log_decoder.cc
+++ b/tests/src/test_battle_log_decoder.cc
@@ -114,6 +114,22 @@ TEST_SUITE("battle_log_decoder")
     CHECK_FALSE(capture["capture"]["journal"]["data"].contains("battle_log"));
   }
 
+  TEST_CASE("build_sidecar_battle_capture_event caps lossless integer recursion")
+  {
+    auto nested = nlohmann::json{{"leaf", 42}};
+    for (int depth = 0; depth < 160; ++depth) {
+      nested = nlohmann::json{{"next", std::move(nested)}};
+    }
+
+    auto journal          = nlohmann::json::object();
+    journal["id"]         = 123;
+    journal["battle_log"] = nlohmann::json::array({-96, -97});
+    journal["nested"]     = std::move(nested);
+
+    CHECK_NOTHROW(
+        (void)battle_log_decoder::build_sidecar_battle_capture_event(journal, nlohmann::json::object(), 0, 0));
+  }
+
   TEST_CASE("hostile display names ignore retrieving placeholders and derive from reward keys")
   {
     const auto names   = nlohmann::json{{"mar_42", {{"name", "Retrieving..."}}}};


### PR DESCRIPTION
## Summary

Fixes #109 and #112 by adding defensive guards around crash-prone hook paths and startup/runtime utility failures.

## Problem

Several IL2CPP hook paths assumed singleton/controller pointers were always present. That is fragile during scene transitions, loading, shutdown, or partial UI state. Separately, root hook install failures were swallowed, Windows UUID conversion ignored API failures, and `lossless_integer_json` recursed without a depth budget.

## Changes

- Guard navigation section changes when `Hub::get_SectionManager()` or its storage is unavailable.
- Guard hotkey select-current and fleet action paths against missing fleet panels, fleet data, fleet managers, deployment managers, action queues, and navigation managers.
- Guard `HandleServiceResponseEntityGroups()` against null service responses / entity-group lists.
- Guard RTC slot payload parsing for malformed data types and fleet preset setup arrays.
- Log failed `il2cpp_init` resolution / hook installation instead of silently swallowing root hook failures.
- Check `UuidCreate()` / `UuidToStringA()` results before using UUID strings.
- Add a recursion cap to `lossless_integer_json()` and cover it with a pure test.

## Acceptance Checks

- Missing fleet/UI/runtime singleton pointers should fail closed instead of dereferencing null.
- Malformed RTC data type strings should be dropped with a warning instead of throwing out of the hook path.
- Failed root hook installation should be visible in logs.
- Deep JSON sidecar capture data should not recurse without bound.

## Validation

- `xmake -y`
- `xmake build stfc-mod-tests`
- `build/windows/x64/release/stfc-mod-tests.exe --test-suite=battle_log_decoder`
- `build/windows/x64/release/stfc-mod-tests.exe`
- `git diff --check`
