### PR TITLE
[codex] Bound async work queues

### DIFF
--- a/mods/src/patches/async_work_queue.h
+++ b/mods/src/patches/async_work_queue.h
@@ -23,10 +23,12 @@ public:
     bool     worker_active = false;
     uint64_t enqueued = 0;
     uint64_t dequeued = 0;
+    uint64_t dropped = 0;
     uint64_t worker_errors = 0;
+    size_t   max_depth = 0;
   };
 
-  AsyncWorkQueue() = default;
+  explicit AsyncWorkQueue(size_t max_depth = 0) : max_depth_(max_depth) {}
   AsyncWorkQueue(const AsyncWorkQueue&) = delete;
   AsyncWorkQueue& operator=(const AsyncWorkQueue&) = delete;
 
@@ -35,6 +37,11 @@ public:
     {
       std::lock_guard lock(mutex_);
       if (shutdown_requested_) {
+        return false;
+      }
+
+      if (max_depth_ > 0 && queue_.size() >= max_depth_) {
+        ++dropped_;
         return false;
       }
 
@@ -137,7 +144,9 @@ public:
       worker_active_,
       enqueued_,
       dequeued_,
+      dropped_,
       worker_errors_,
+      max_depth_,
     };
   }
 
@@ -159,9 +168,11 @@ private:
   mutable std::mutex      mutex_;
   std::condition_variable condition_;
   std::deque<WorkItem>    queue_;
+  size_t                  max_depth_ = 0;
   bool                    shutdown_requested_ = false;
   bool                    worker_active_ = false;
   uint64_t                enqueued_ = 0;
   uint64_t                dequeued_ = 0;
+  uint64_t                dropped_ = 0;
   uint64_t                worker_errors_ = 0;
 };

--- a/mods/src/patches/notification_audio.cc
+++ b/mods/src/patches/notification_audio.cc
@@ -56,7 +56,8 @@ struct AudioPlaybackRequest {
   std::string       event_name;
 };
 
-AsyncWorkQueue<AudioPlaybackRequest> s_audio_queue;
+constexpr size_t                     kAudioQueueMaxDepth = 64;
+AsyncWorkQueue<AudioPlaybackRequest> s_audio_queue(kAudioQueueMaxDepth);
 std::once_flag                       s_audio_worker_once;
 std::thread                          s_audio_worker_thread;
 constexpr auto                       kAudioJoinWarnThreshold = std::chrono::seconds(2);
@@ -269,8 +270,11 @@ void notification_audio_play(NotificationSound sound, std::string_view event_nam
   request.sound      = sound;
   request.event_name = std::string(event_name);
   if (!s_audio_queue.enqueue(std::move(request))) {
-    spdlog::warn("[NotifyAudio] Dropped notification sound event={} sound={} reason=shutdown", event_name,
-                 notification_sound_name(sound));
+    const auto diagnostics = s_audio_queue.diagnostics();
+    spdlog::warn("[NotifyAudio] Dropped notification sound event={} sound={} reason={} queue_size={} dropped={}",
+                 event_name, notification_sound_name(sound),
+                 diagnostics.shutdown_requested ? "shutdown" : "full",
+                 diagnostics.depth, diagnostics.dropped);
     return;
   }
 #else

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -101,7 +101,8 @@ const char* notification_toast_title(int state)
 
 // ─── Platform Notification Delivery ──────────────────────────────────────────────────
 #if STFCMOD_PLATFORM_WINDOWS
-static AsyncWorkQueue<NotificationQueueRequest> s_notification_queue;
+static constexpr size_t        kNotificationQueueMaxDepth     = 256;
+static AsyncWorkQueue<NotificationQueueRequest> s_notification_queue(kNotificationQueueMaxDepth);
 static std::mutex              s_recent_toast_mutex;
 static std::once_flag          s_notification_worker_once;
 static std::thread             s_notification_worker_thread;
@@ -146,9 +147,13 @@ static void queue_system_notification(const char* title, const char* body, const
   request.queued_at = std::chrono::steady_clock::now();
 
   if (!s_notification_queue.enqueue(std::move(request))) {
-    spdlog::warn("[NotifyQueue] drop source={} title='{}' reason=shutdown",
+    const auto diagnostics = s_notification_queue.diagnostics();
+    spdlog::warn("[NotifyQueue] drop source={} title='{}' reason={} queue_size={} dropped={}",
                  source ? source : "unknown",
-                 title ? notification_flatten_text(title) : "");
+                 title ? notification_flatten_text(title) : "",
+                 diagnostics.shutdown_requested ? "shutdown" : "full",
+                 diagnostics.depth,
+                 diagnostics.dropped);
     return;
   }
 

--- a/mods/src/patches/sync_battle_logs.cc
+++ b/mods/src/patches/sync_battle_logs.cc
@@ -67,7 +67,8 @@ struct WinRtApartmentGuard {
 
 namespace
 {
-AsyncWorkQueue<uint64_t> s_combat_log_queue;
+constexpr size_t         kCombatLogQueueMaxDepth = 512;
+AsyncWorkQueue<uint64_t> s_combat_log_queue(kCombatLogQueueMaxDepth);
 std::once_flag           s_combat_log_worker_once;
 std::thread              s_combat_log_worker_thread;
 constexpr auto           kCombatLogWorkerSlowJoinThreshold = std::chrono::seconds(5);
@@ -704,7 +705,12 @@ void process_battle_headers(const nlohmann::json& section)
 
     for (const auto id : to_enqueue) {
       if (!s_combat_log_queue.enqueue(id)) {
-        spdlog::warn("Battle {} dropped because combat log worker shutdown is in progress", id);
+        const auto diagnostics = s_combat_log_queue.diagnostics();
+        spdlog::warn("Battle {} dropped because combat log queue is {} (queue_size={}, dropped={})",
+                     id,
+                     diagnostics.shutdown_requested ? "shutting down" : "full",
+                     diagnostics.depth,
+                     diagnostics.dropped);
       }
     }
   }

--- a/mods/src/patches/sync_scheduler.cc
+++ b/mods/src/patches/sync_scheduler.cc
@@ -33,7 +33,8 @@ namespace
 {
 using SyncQueueItem = std::tuple<SyncConfig::Type, std::string, bool>;
 
-AsyncWorkQueue<SyncQueueItem> s_sync_data_queue;
+constexpr size_t              kSyncDataQueueMaxDepth = 256;
+AsyncWorkQueue<SyncQueueItem> s_sync_data_queue(kSyncDataQueueMaxDepth);
 std::once_flag                s_sync_worker_once;
 std::thread                   s_sync_worker_thread;
 constexpr auto                kSyncWorkerSlowJoinThreshold = std::chrono::seconds(5);
@@ -50,7 +51,11 @@ void log_worker_join_time(const std::string_view worker_name, const std::chrono:
 void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync)
 {
   if (!s_sync_data_queue.enqueue({type, data, is_first_sync})) {
-    http::sync_log_warn("QUEUE", to_string(type), "Dropping data because sync scheduler shutdown is in progress");
+    const auto diagnostics = s_sync_data_queue.diagnostics();
+    http::sync_log_warn("QUEUE", to_string(type),
+                        diagnostics.shutdown_requested
+                            ? "Dropping data because sync scheduler shutdown is in progress"
+                            : "Dropping data because sync scheduler queue is full");
     return;
   }
 
@@ -60,7 +65,11 @@ void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sy
 void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync)
 {
   if (!s_sync_data_queue.enqueue({type, data.dump(), is_first_sync})) {
-    http::sync_log_warn("QUEUE", to_string(type), "Dropping data because sync scheduler shutdown is in progress");
+    const auto diagnostics = s_sync_data_queue.diagnostics();
+    http::sync_log_warn("QUEUE", to_string(type),
+                        diagnostics.shutdown_requested
+                            ? "Dropping data because sync scheduler shutdown is in progress"
+                            : "Dropping data because sync scheduler queue is full");
     return;
   }
 

--- a/tests/src/test_runtime_helpers.cc
+++ b/tests/src/test_runtime_helpers.cc
@@ -119,6 +119,26 @@ TEST_SUITE("async_work_queue")
     CHECK(diagnostics.dequeued == 2);
   }
 
+  TEST_CASE("bounded queue rejects new work at max depth")
+  {
+    AsyncWorkQueue<int> queue(2);
+
+    CHECK(queue.enqueue(10));
+    CHECK(queue.enqueue(20));
+    CHECK_FALSE(queue.enqueue(30));
+
+    auto diagnostics = queue.diagnostics();
+    CHECK(diagnostics.depth == 2);
+    CHECK(diagnostics.max_depth == 2);
+    CHECK(diagnostics.enqueued == 2);
+    CHECK(diagnostics.dropped == 1);
+
+    auto batch = queue.drain();
+    REQUIRE(batch.size() == 2);
+    CHECK(batch[0] == 10);
+    CHECK(batch[1] == 20);
+  }
+
   TEST_CASE("rejects new work after shutdown while preserving queued work")
   {
     AsyncWorkQueue<std::string> queue;


### PR DESCRIPTION
## Summary

Fixes #107 by adding depth caps and drop diagnostics to async work queues.

## Problem

`AsyncWorkQueue` had no depth cap, so bursty producers could enqueue work faster than background consumers drain it. Notification audio, system notifications, combat log fetches, and sync data could all grow without bound during long sessions or bursts.

## Changes

- Add optional `max_depth` support to `AsyncWorkQueue`.
- Track dropped enqueue attempts in queue diagnostics.
- Keep default construction unlimited for existing tests/helpers.
- Cap runtime queues:
  - notification audio: 64
  - system notifications: 256
  - combat log fetches: 512
  - sync data: 256
- Update drop logs to distinguish shutdown from full queues.
- Add a pure unit test for bounded enqueue behavior.

## Acceptance Checks

- Queues configured with a max depth reject new work once full.
- Drop counters increment when work is rejected due to capacity.
- Existing shutdown behavior still rejects new work while preserving queued items.
- Runtime producers emit useful diagnostics on full queues.

## Validation

- `xmake -y`
- `xmake build stfc-mod-tests`
- `build/windows/x64/release/stfc-mod-tests.exe --test-suite=async_work_queue`
- `build/windows/x64/release/stfc-mod-tests.exe`
- `git diff --check`
