### PR TITLE
[codex] Bound sync queues and resolver caches

### DIFF
--- a/mods/src/patches/sync_battle_logs.cc
+++ b/mods/src/patches/sync_battle_logs.cc
@@ -97,6 +97,25 @@ struct CachedAllianceData {
 std::unordered_map<int64_t, CachedAllianceData> alliance_data_cache;
 std::mutex                                      alliance_data_cache_mtx;
 
+static constexpr size_t kPlayerDataCacheMaxEntries   = 4096;
+static constexpr size_t kAllianceDataCacheMaxEntries = 1024;
+
+template <typename Cache>
+void prune_resolver_cache_locked(Cache& cache, size_t max_entries, std::chrono::steady_clock::time_point now)
+{
+  for (auto it = cache.begin(); it != cache.end();) {
+    if (it->second.expires_at <= now) {
+      it = cache.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  while (cache.size() > max_entries) {
+    cache.erase(cache.begin());
+  }
+}
+
 static eastl::ring_buffer<uint64_t> previously_sent_battlelogs;
 static std::mutex                   previously_sent_battlelogs_mtx;
 static std::mutex                   battle_feed_file_mtx;
@@ -725,6 +744,7 @@ void cache_player_names(std::unique_ptr<std::string>&& bytes)
     {
       std::lock_guard lk(player_data_cache_mtx);
       player_data_cache.insert(names.begin(), names.end());
+      prune_resolver_cache_locked(player_data_cache, kPlayerDataCacheMaxEntries, std::chrono::steady_clock::now());
     }
   } else {
     spdlog::error("Failed to parse user profile");
@@ -748,6 +768,7 @@ void cache_alliance_names(std::unique_ptr<std::string>&& bytes)
     {
       std::lock_guard lk(alliance_data_cache_mtx);
       alliance_data_cache.insert(names.begin(), names.end());
+      prune_resolver_cache_locked(alliance_data_cache, kAllianceDataCacheMaxEntries, std::chrono::steady_clock::now());
     }
 
   } else {
@@ -899,6 +920,7 @@ static void ship_combat_log_data()
                   {"name", name}, {"alliance_id", alliance_id}, {"alliance_name", nullptr}, {"alliance_tag", nullptr}};
               player_data_cache[player_id] = {name, alliance_id, expires_at};
             }
+            prune_resolver_cache_locked(player_data_cache, kPlayerDataCacheMaxEntries, now);
           } catch (const json::exception& exception) {
             spdlog::error("Failed to parse user profiles: {}", exception.what());
           }
@@ -929,6 +951,7 @@ static void ship_combat_log_data()
 
               alliance_data_cache[id] = {name, tag, expires_at};
             }
+            prune_resolver_cache_locked(alliance_data_cache, kAllianceDataCacheMaxEntries, now);
           } catch (json::exception& exception) {
             spdlog::error("Failed to parse alliance profiles: {}", exception.what());
           }

--- a/mods/src/patches/sync_transport.cc
+++ b/mods/src/patches/sync_transport.cc
@@ -256,6 +256,7 @@ void sync_log_trace(const std::string& type, const std::string& target, const st
 
 static const std::string CURL_TYPE_UPLOAD   = "UPLOAD";
 static const std::string CURL_TYPE_DOWNLOAD = "DOWNLOAD";
+static constexpr size_t  kTargetWorkerMaxQueuedRequests = 256;
 
 struct TargetWorker {
   TargetWorker() = default;
@@ -270,6 +271,7 @@ struct TargetWorker {
   std::queue<request_t>         request_queue;
   std::mutex                    queue_mtx;
   std::condition_variable       queue_cv;
+  uint64_t                      dropped_requests = 0;
 };
 
 static std::unordered_map<std::string, std::shared_ptr<TargetWorker>> target_workers;
@@ -423,6 +425,14 @@ void send_data(SyncConfig::Type type, const std::string& post_data, bool is_firs
 
       {
         std::lock_guard lk(worker->queue_mtx);
+        if (worker->request_queue.size() >= kTargetWorkerMaxQueuedRequests) {
+          ++worker->dropped_requests;
+          sync_log_warn(CURL_TYPE_UPLOAD, target_identifier,
+                        STR_FORMAT("Dropping request because target queue is full (queue size: {}, dropped: {})",
+                                   worker->request_queue.size(), worker->dropped_requests));
+          continue;
+        }
+
         worker->request_queue.emplace(target_identifier, post_data, is_first_sync);
         sync_log_trace(CURL_TYPE_UPLOAD, target_identifier,
                        STR_FORMAT("Queued request (queue size: {})", worker->request_queue.size()));


### PR DESCRIPTION
## Summary

Fixes #103 by bounding sync target request queues and battle-log resolver caches.

## Problem

Sync target workers used an unbounded per-target HTTP request queue. Battle-log player/alliance resolver caches used TTLs, but only removed expired entries opportunistically and had no max-entry cap.

## Changes

- Cap each `TargetWorker` request queue at 256 pending requests.
- Track and log dropped per-target requests when a target queue is full.
- Prune expired player/alliance resolver cache entries after cache writes.
- Cap player resolver cache at 4096 entries.
- Cap alliance resolver cache at 1024 entries.

## Acceptance Checks

- Sync upload bursts cannot grow a target worker queue without bound.
- Resolver caches cannot grow without bound across long sessions.
- Existing TTL behavior remains: expired entries are still removed.

## Validation

- `xmake -y`
- `git diff --check`
