### PR TITLE
[codex] Fix chat, slot, and service key logic

### DIFF
--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -351,8 +351,12 @@ bool hotkey_router_screen_update(ScreenManager* _this)
       space_action_inputs.repair_key = fleet_repair_winner->key;
     }
     if (fleet_service_winner) {
-      space_action_inputs.recall_key = fleet_service_winner->key;
-      space_action_inputs.repair_key = fleet_service_winner->key;
+      if (!fleet_recall_winner) {
+        space_action_inputs.recall_key = fleet_service_winner->key;
+      }
+      if (!fleet_repair_winner) {
+        space_action_inputs.repair_key = fleet_service_winner->key;
+      }
     }
 
     // Escape to hide object viewers

--- a/mods/src/patches/parts/chat.cc
+++ b/mods/src/patches/parts/chat.cc
@@ -168,7 +168,9 @@ void ChatPreviewController_OnPanelFocused(auto original, ChatPreviewController* 
   }
 
   const auto [cadetChatIdx, galaxyChatIdx, veilChatIdx, allianceChatIdx] = GetChatTabIndices();
-  if (disableGalaxyChat || (veilChatIdx != -1 && disableVeilChat)) {
+  const auto disabledTarget = (disableGalaxyChat && index == galaxyChatIdx) ||
+                              (disableVeilChat && veilChatIdx != -1 && index == veilChatIdx);
+  if (disabledTarget) {
     const auto swipeScroller = _this->_swipeScroller;
     _this->_focusedPanel = ChatChannelCategory::Alliance;
     original(_this, allianceChatIdx);

--- a/mods/src/patches/sync_payload_builders.cc
+++ b/mods/src/patches/sync_payload_builders.cc
@@ -721,13 +721,14 @@ void process_entity_slots(std::unique_ptr<std::string>&& bytes)
 
               for (const auto& setup : preset.setups()) {
                 setup_json.push_back({{"drydock_id", setup.drydockid()},
-                                      {"ship_id", setup.shipids()[0]},
+                                      {"ship_id", setup.shipids_size() > 0 ? json(setup.shipids()[0]) : json(nullptr)},
                                       {"officer_ids", setup.officerids()}});
               }
 
               slot_params = {{"name", preset.name()}, {"order", preset.order()}, {"setup", setup_json}};
               state_value = static_cast<int64_t>(std::hash<json>{}(slot_params));
             }
+            break;
           default:
             continue;
         }
@@ -810,7 +811,10 @@ void process_entity_slots_rtc(std::unique_ptr<std::string>&& json_payload)
         if (const auto& params = data["fleet_preset_slot_params"]; !params.is_null()) {
           auto setup_json = json::array();
           for (const auto& setup : params["setups"]) {
-            setup_json.push_back({{"drydock_id", setup["d"]}, {"ship_id", setup["s"][0]}, {"officer_ids", setup["o"]}});
+            const auto& ships = setup["s"];
+            setup_json.push_back({{"drydock_id", setup["d"]},
+                                  {"ship_id", ships.is_array() && !ships.empty() ? ships[0] : json(nullptr)},
+                                  {"officer_ids", setup["o"]}});
           }
 
           slot_params = {{"name", params["name"]}, {"order", params["order"]}, {"setup", setup_json}};


### PR DESCRIPTION
## Summary
- only redirect chat preview focus when the requested target tab is disabled
- keep fleet preset slot serialization from falling through to the default case
- preserve explicit fleet recall/repair key metadata when FleetService is also bound
- tolerate fleet preset setups with no ship id in both protobuf and RTC JSON builders

Fixes #106.

## Validation
- `xmake -y`
- `xmake build stfc-mod-tests`
- `build\\windows\\x64\\release\\stfc-mod-tests.exe`
- `git diff --check`