### PR TITLE
[codex] Clean up maintenance landmines

### DIFF
--- a/mods/src/file.cc
+++ b/mods/src/file.cc
@@ -9,7 +9,17 @@
 #include "file.h"
 #include "platform_bridge.h"
 #include "windowtitle.h"
- 
+
+namespace
+{
+std::filesystem::path path_with_extension(const std::filesystem::path& path, const char* extension)
+{
+  auto result = path;
+  result.replace_extension(extension);
+  return result;
+}
+} // namespace
+
 std::filesystem::path File::Path()
 {
   if (!File::initialized) {
@@ -81,17 +91,10 @@ std::wstring File::Title()
   return cacheNameTitle;
 }
 
-#if !_WIN32
-std::u8string File::MakePath(std::string_view filename, bool create_dir, bool old_path)
+std::string File::MakePath(std::string_view filename, bool create_dir, bool old_path)
 {
-  return platform_bridge::ModStoragePath(filename, create_dir, old_path).u8string();
+  return MakePathString(filename, create_dir, old_path);
 }
-#else
-std::string_view File::MakePath(std::string_view filename, bool create_dir, bool old_path)
-{
-  return filename;
-}
-#endif
 
 std::string File::MakePathString(std::string_view filename, bool create_dir, bool old_path)
 {
@@ -133,13 +136,15 @@ void File::Init()
       configPath     = std::filesystem::path(cacheNameDefault);
     }
 
+    const auto configured_base_path = configPath;
+
     /*******************************
      *
      * Set the battle log file name
      *
      *******************************/
     if (File::override) {
-      cacheNameBattles = configPath.replace_extension(FILE_EXT_JSON).string();
+      cacheNameBattles = path_with_extension(configured_base_path, FILE_EXT_JSON).string();
     } else {
       cacheNameBattles = std::string(FILE_DEF_BL);
     }
@@ -150,7 +155,7 @@ void File::Init()
      *
      *******************************/
     if (File::override) {
-      cacheNameLog = configPath.replace_extension(FILE_EXT_LOG).string();
+      cacheNameLog = path_with_extension(configured_base_path, FILE_EXT_LOG).string();
     } else {
       cacheNameLog = std::string(FILE_DEF_LOG);
     }
@@ -162,7 +167,7 @@ void File::Init()
      *******************************/
 
     if (File::override) {
-      cacheNameVar = configPath.replace_extension(FILE_EXT_VARS).string();
+      cacheNameVar = path_with_extension(configured_base_path, FILE_EXT_VARS).string();
     } else {
       cacheNameVar = std::string(FILE_DEF_VARS);
     }
@@ -173,7 +178,8 @@ void File::Init()
      *
      *******************************/
     if (File::override) {
-      cacheNameConfig = configPath.replace_extension(FILE_EXT_TOML).string();
+      configPath      = path_with_extension(configured_base_path, FILE_EXT_TOML);
+      cacheNameConfig = configPath.string();
     } else {
       cacheNameConfig = std::string(FILE_DEF_CONFIG);
     }

--- a/mods/src/file.h
+++ b/mods/src/file.h
@@ -84,11 +84,7 @@ public:
    * @param old_path    Use the legacy bundle-id directory (macOS migration).
    * @return Platform-appropriate path string.
    */
-#if _WIN32
-  static std::string_view MakePath(std::string_view filename, bool create_dir = false, bool old_path = false);
-#else
-  static std::u8string MakePath(std::string_view filename, bool create_dir = false, bool old_path = false);
-#endif
+  static std::string      MakePath(std::string_view filename, bool create_dir = false, bool old_path = false);
 
   /** @brief Build a full path as a UTF-8 std::string for narrow C/C++ file APIs. */
   static std::string MakePathString(std::string_view filename, bool create_dir = false, bool old_path = false);

--- a/mods/src/patches/hook_registry.h
+++ b/mods/src/patches/hook_registry.h
@@ -93,13 +93,14 @@ size_t hook_registry_owner_count_for_testing();
 
 #define HOOK_REGISTRY_SPUD_STATIC_DETOUR(registry, descriptor, addr, fn) \
   do { \
+    const auto hook_registry_addr = (addr); \
     (registry).record_detour_attempted((descriptor)); \
-    if (!hook_registry_claim_owner((descriptor), #registry, static_cast<const void*>(addr))) { \
+    if (!hook_registry_claim_owner((descriptor), #registry, static_cast<const void*>(hook_registry_addr))) { \
       (registry).record_detour_failed((descriptor), "duplicate detour owner — single-owner policy"); \
       break; \
     } \
     try { \
-      SPUD_STATIC_DETOUR((addr), fn); \
+      SPUD_STATIC_DETOUR(hook_registry_addr, fn); \
       (registry).record_detour_installed((descriptor)); \
     } catch (const std::exception& ex) { \
       (registry).record_detour_failed((descriptor), ex.what()); \

--- a/mods/src/patches/live_debug_observation_compare.cc
+++ b/mods/src/patches/live_debug_observation_compare.cc
@@ -6,7 +6,7 @@
 
 bool same_top_canvas_observation(const TopCanvasObservation& left, const TopCanvasObservation& right)
 {
-  return left.found == right.found && left.pointer == right.pointer &&
+  return left.found == right.found && left.pointerValue == right.pointerValue && left.pointer == right.pointer &&
       left.className == right.className && left.classNamespace == right.classNamespace &&
       left.name == right.name && left.visible == right.visible && left.enabled == right.enabled &&
       left.internalVisible == right.internalVisible && left.activeChildNames == right.activeChildNames;
@@ -73,7 +73,8 @@ bool same_navigation_interaction_observation(const NavigationInteractionObservat
   for (size_t index = 0; index < left.entries.size(); ++index) {
     const auto& left_entry = left.entries[index];
     const auto& right_entry = right.entries[index];
-    if (left_entry.pointer != right_entry.pointer ||
+    if (left_entry.pointerValue != right_entry.pointerValue ||
+        left_entry.pointer != right_entry.pointer ||
         left_entry.hasContext != right_entry.hasContext ||
         left_entry.contextDataState != right_entry.contextDataState ||
         left_entry.inputInteractionType != right_entry.inputInteractionType ||

--- a/mods/src/patches/live_debug_ui_observations.h
+++ b/mods/src/patches/live_debug_ui_observations.h
@@ -7,6 +7,7 @@
 
 struct TopCanvasObservation {
   bool                     found = false;
+  uintptr_t                pointerValue = 0;
   std::string              pointer;
   std::string              className;
   std::string              classNamespace;
@@ -30,6 +31,7 @@ struct StationWarningObservation {
 
 struct NavigationInteractionObservation {
   struct Entry {
+    uintptr_t   pointerValue = 0;
     std::string pointer;
     bool        hasContext = false;
     int         contextDataState = -1;

--- a/mods/src/patches/live_debug_ui_runtime_observers.cc
+++ b/mods/src/patches/live_debug_ui_runtime_observers.cc
@@ -124,6 +124,7 @@ NavigationInteractionObservation observe_navigation_interaction(const LiveDebugU
   for (auto* controller : controllers) {
     trace_step(trace_hooks, "nav/before-entry", "observe_navigation_interaction", controller);
     NavigationInteractionObservation::Entry entry;
+    entry.pointerValue = reinterpret_cast<uintptr_t>(controller);
     entry.pointer = pointer_to_string(controller);
 
     trace_step(trace_hooks, "nav/before-canvas-context", "observe_navigation_interaction", controller);

--- a/mods/src/patches/live_debug_viewer_runtime.cc
+++ b/mods/src/patches/live_debug_viewer_runtime.cc
@@ -218,6 +218,7 @@ TopCanvasObservation observe_top_canvas()
   const auto canvas_class = canvas_object ? canvas_object->klass : nullptr;
   const auto canvas_controller = reinterpret_cast<CanvasController*>(top_canvas);
 
+  observation.pointerValue = reinterpret_cast<uintptr_t>(top_canvas);
   observation.pointer = pointer_to_string(top_canvas);
   observation.className = (canvas_class && canvas_class->name) ? canvas_class->name : "";
   observation.classNamespace = (canvas_class && canvas_class->namespaze) ? canvas_class->namespaze : "";

--- a/mods/src/patches/parts/live_debug.cc
+++ b/mods/src/patches/parts/live_debug.cc
@@ -66,6 +66,7 @@ using json = nlohmann::json;
 constexpr std::string_view kNavigationHookTraceFile                = "community_patch_navhook_trace.log";
 constexpr auto             kNavigationHookTraceMaxBytes            = 512 * 1024;
 constexpr auto             kNavigationHookTraceRotateCheckInterval = 128;
+constexpr auto             kNavigationHookTraceBackupCount         = 3;
 
 bool                                             g_recent_observations_initialized = false;
 TopCanvasObservation                             g_last_top_canvas;
@@ -100,6 +101,8 @@ RecentNavigationHookFollowUp g_recent_navigation_hook_follow_up;
 std::string                  g_last_navigation_poll_actionable_pointer;
 bool                         g_logged_navigation_hook_tick_enter         = false;
 bool                         g_logged_navigation_hook_tick_after_ui_poll = false;
+std::FILE*                   g_navigation_hook_trace_file               = nullptr;
+std::filesystem::path        g_navigation_hook_trace_open_path;
 
 constexpr bool                        kEnableLiveDebugUiPollingFromTick            = false;
 constexpr bool                        kEnableLiveDebugTopCanvasPolling             = true;
@@ -140,6 +143,41 @@ bool has_recent_live_debug_request_activity()
 std::filesystem::path get_live_debug_path(std::string_view filename)
 { return std::filesystem::path(File::MakePathString(filename)); }
 
+void close_navigation_hook_trace_file()
+{
+  if (!g_navigation_hook_trace_file) {
+    return;
+  }
+
+  std::fclose(g_navigation_hook_trace_file);
+  g_navigation_hook_trace_file = nullptr;
+  g_navigation_hook_trace_open_path.clear();
+}
+
+std::FILE* open_navigation_hook_trace_file(const std::filesystem::path& trace_path)
+{
+  if (g_navigation_hook_trace_file && g_navigation_hook_trace_open_path == trace_path) {
+    return g_navigation_hook_trace_file;
+  }
+
+  close_navigation_hook_trace_file();
+
+  const auto path_text = trace_path.string();
+  g_navigation_hook_trace_file = std::fopen(path_text.c_str(), "ab");
+  if (g_navigation_hook_trace_file) {
+    g_navigation_hook_trace_open_path = trace_path;
+  }
+
+  return g_navigation_hook_trace_file;
+}
+
+std::filesystem::path rotated_navigation_hook_trace_path(const std::filesystem::path& trace_path, int index)
+{
+  auto rotated_path = trace_path;
+  rotated_path.replace_extension("." + std::to_string(index) + ".log");
+  return rotated_path;
+}
+
 void rotate_navigation_hook_trace_if_needed(const std::filesystem::path& trace_path)
 {
   static uint32_t check_counter = 0;
@@ -153,11 +191,21 @@ void rotate_navigation_hook_trace_if_needed(const std::filesystem::path& trace_p
     return;
   }
 
-  auto rotated_path = trace_path;
-  rotated_path.replace_extension(".1.log");
-  std::filesystem::remove(rotated_path, error);
+  close_navigation_hook_trace_file();
+
+  std::filesystem::remove(rotated_navigation_hook_trace_path(trace_path, kNavigationHookTraceBackupCount), error);
   error.clear();
-  std::filesystem::rename(trace_path, rotated_path, error);
+  for (int index = kNavigationHookTraceBackupCount - 1; index >= 1; --index) {
+    const auto source = rotated_navigation_hook_trace_path(trace_path, index);
+    const auto target = rotated_navigation_hook_trace_path(trace_path, index + 1);
+    if (std::filesystem::exists(source, error)) {
+      error.clear();
+      std::filesystem::rename(source, target, error);
+      error.clear();
+    }
+  }
+
+  std::filesystem::rename(trace_path, rotated_navigation_hook_trace_path(trace_path, 1), error);
 }
 
 std::string pointer_to_string(const void* pointer)
@@ -177,8 +225,7 @@ void append_navigation_hook_trace_step(const char* step, const char* phase, cons
                                        const void* sender = nullptr, const void* callback_context = nullptr)
 {
   const auto trace_path = get_live_debug_path(kNavigationHookTraceFile);
-  const auto path_text  = trace_path.string();
-  auto*      trace_file = std::fopen(path_text.c_str(), "ab");
+  auto*      trace_file = open_navigation_hook_trace_file(trace_path);
   if (!trace_file) {
     return;
   }
@@ -187,7 +234,6 @@ void append_navigation_hook_trace_step(const char* step, const char* phase, cons
                static_cast<long long>(current_time_millis_utc()), step ? step : "", phase ? phase : "", controller,
                sender, callback_context);
   std::fflush(trace_file);
-  std::fclose(trace_file);
   rotate_navigation_hook_trace_if_needed(trace_path);
 }
 
@@ -259,9 +305,9 @@ find_navigation_interaction_entry(const NavigationInteractionObservation& observ
     return nullptr;
   }
 
-  const auto controller_pointer = pointer_to_string(controller);
+  const auto controller_pointer = reinterpret_cast<uintptr_t>(controller);
   for (const auto& entry : observation.entries) {
-    if (entry.pointer == controller_pointer) {
+    if (entry.pointerValue == controller_pointer) {
       return &entry;
     }
   }
@@ -297,7 +343,7 @@ void append_navigation_hook_actionable_follow_up_event(const NavigationInteracti
 
   const bool sender_matches_top_canvas =
       g_recent_navigation_hook_follow_up.sender && g_last_top_canvas.found
-      && pointer_to_string(g_recent_navigation_hook_follow_up.sender) == g_last_top_canvas.pointer;
+      && reinterpret_cast<uintptr_t>(g_recent_navigation_hook_follow_up.sender) == g_last_top_canvas.pointerValue;
   if (!sender_matches_top_canvas) {
     append_navigation_hook_trace_step("followup/clear-top-canvas-miss", g_recent_navigation_hook_follow_up.phase,
                                       g_recent_navigation_hook_follow_up.controller,
@@ -478,7 +524,8 @@ void flush_pending_navigation_hook_note()
     }
 
     if (note.sender && note.prePollTopCanvas.found) {
-      details["prePollSenderMatchesTopCanvas"] = pointer_to_string(note.sender) == note.prePollTopCanvas.pointer;
+      details["prePollSenderMatchesTopCanvas"] =
+          reinterpret_cast<uintptr_t>(note.sender) == note.prePollTopCanvas.pointerValue;
     }
     append_navigation_hook_trace_step("flush/after-pre-poll-match-loop", note.phase, note.controller, note.sender,
                                       note.callbackContext);
@@ -503,7 +550,7 @@ void flush_pending_navigation_hook_note()
   if (note.sender && g_last_top_canvas.found) {
     append_navigation_hook_trace_step("flush/before-sender-compare", note.phase, note.controller, note.sender,
                                       note.callbackContext);
-    details["senderMatchesTopCanvas"] = pointer_to_string(note.sender) == g_last_top_canvas.pointer;
+    details["senderMatchesTopCanvas"] = reinterpret_cast<uintptr_t>(note.sender) == g_last_top_canvas.pointerValue;
     append_navigation_hook_trace_step(details["senderMatchesTopCanvas"].get<bool>() ? "flush/after-sender-compare/match"
                                                                                     : "flush/after-sender-compare/miss",
                                       note.phase, note.controller, note.sender, note.callbackContext);


### PR DESCRIPTION
## Summary
- make `File::MakePath` return an owned UTF-8 string on all platforms
- derive profile log/vars/battle/config paths from an immutable base path instead of sequentially mutating `configPath`
- make `HOOK_REGISTRY_SPUD_STATIC_DETOUR` evaluate the target address once
- compare live-debug pointer identity via raw `uintptr_t` values while keeping formatted pointer strings for output
- keep the nav-hook trace file open across trace steps and rotate through three backup files

Fixes #111.

## Validation
- `xmake -y`
- `xmake build stfc-mod-tests`
- `build\\windows\\x64\\release\\stfc-mod-tests.exe`
- `git diff --check`