### PR TITLE
[codex] Add event-driven fleet runtime sync

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -796,6 +796,7 @@ battlelogs = true
 battlelogs_realtime = false
 buffs = true
 buildings = true
+fleet_runtime = false
 inventory = true
 jobs = true
 missions = true
@@ -875,6 +876,7 @@ allow_unsafe_tls_without_certificate_validation = false
 # url = "http://127.0.0.1:43127/api/fleet/sync"
 # battlelogs = false
 # battlelogs_realtime = false
+# fleet_runtime = true
 # ships = true
 # slots = true
 

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -39,6 +39,7 @@ public:
     Buffs,
     Buildings,
     EmeraldChain,
+    FleetRuntime,
     Inventory,
     Jobs,
     Missions,
@@ -72,6 +73,7 @@ public:
   bool battlelogs_realtime = false;
   bool buffs               = false;
   bool buildings           = false;
+  bool fleet_runtime       = false;
   bool inventory           = false;
   bool jobs                = false;
   bool missions            = false;
@@ -95,6 +97,7 @@ constexpr std::array SyncOptions{
     SyncConfig::Option{SyncConfig::Type::Buffs, "buff", "buffs", &SyncConfig::buffs},
     SyncConfig::Option{SyncConfig::Type::Buildings, "module", "buildings", &SyncConfig::buildings},
     SyncConfig::Option{SyncConfig::Type::EmeraldChain, "emerald_chain", "buffs", &SyncConfig::buffs},
+    SyncConfig::Option{SyncConfig::Type::FleetRuntime, "fleet_runtime", "fleet_runtime", &SyncConfig::fleet_runtime},
     SyncConfig::Option{SyncConfig::Type::Inventory, "inventory", "inventory", &SyncConfig::inventory},
     SyncConfig::Option{SyncConfig::Type::Jobs, "job", "jobs", &SyncConfig::jobs},
     SyncConfig::Option{SyncConfig::Type::Missions, "mission", "missions", &SyncConfig::missions},

--- a/mods/src/config_release_validation.cc
+++ b/mods/src/config_release_validation.cc
@@ -64,6 +64,7 @@ namespace
       "sync.buffs",
       "sync.buildings",
       "sync.debug",
+      "sync.fleet_runtime",
       "sync.inventory",
       "sync.jobs",
       "sync.logging",

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -325,6 +325,7 @@ namespace Sync
   constexpr bool battlelogs_realtime = false; ///< Export canonical battle feed events to realtime ingest targets.
   constexpr bool buffs               = true;  ///< Sync buff / Emerald Chain data.
   constexpr bool buildings           = true;  ///< Sync station module data.
+  constexpr bool fleet_runtime       = false; ///< Sync low-rate fleet-bar runtime state.
   constexpr bool inventory           = true;  ///< Sync inventory contents.
   constexpr bool jobs                = true;  ///< Sync active job/build queues.
   constexpr bool missions            = true;  ///< Sync mission progress.

--- a/mods/src/patches/fleet_actions.cc
+++ b/mods/src/patches/fleet_actions.cc
@@ -59,6 +59,7 @@ FleetActionExecutionResult TryExecuteRepair(FleetBarViewController* fleet_bar);
 namespace
 {
 fleet_deferred_action::State deferred_space_action_state;
+PreScanTargetWidget*         last_shown_pre_scan_target = nullptr;
 
 struct ScanSubmission {
   uint64_t                              fleet_id        = 0;
@@ -372,24 +373,35 @@ bool TryExecuteArmadaAttack(PreScanTargetWidget* pre_scan_widget, ScanEngageButt
 
 bool DeferredSpaceActionTargetMatches(FleetPlayerData* fleet, PreScanTargetWidget* widget, BattleTargetData* target);
 
+void AppendVisiblePreScanTargetContext(SpaceActionRuntimeContext& runtime_context, FleetPlayerData* fleet,
+                                       PreScanTargetWidget* pre_scan_widget)
+{
+  if (!IsViewerVisible(pre_scan_widget)) {
+    return;
+  }
+
+  ++runtime_context.visible_pre_scan_target_count;
+
+  auto scan_engage_buttons_widget = pre_scan_widget->_scanEngageButtonsWidget;
+  auto target_context             = scan_engage_buttons_widget ? scan_engage_buttons_widget->Context : nullptr;
+  runtime_context.visible_pre_scan_targets.push_back(
+      {pre_scan_widget, scan_engage_buttons_widget, target_context, GetHullTypeFromBattleTarget(target_context),
+       DeferredSpaceActionTargetMatches(fleet, pre_scan_widget, target_context)});
+}
+
 SpaceActionRuntimeContext GatherSpaceActionRuntimeContext(FleetPlayerData* fleet)
 {
   SpaceActionRuntimeContext runtime_context;
 
-  const auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAllNonNull();
-  runtime_context.visible_pre_scan_targets.reserve(all_pre_scan_widgets.size());
-  for (auto pre_scan_widget : all_pre_scan_widgets) {
-    if (!IsViewerVisible(pre_scan_widget)) {
-      continue;
+  if (IsViewerVisible(last_shown_pre_scan_target)) {
+    runtime_context.visible_pre_scan_targets.reserve(1);
+    AppendVisiblePreScanTargetContext(runtime_context, fleet, last_shown_pre_scan_target);
+  } else {
+    const auto all_pre_scan_widgets = ObjectFinder<PreScanTargetWidget>::GetAllNonNull();
+    runtime_context.visible_pre_scan_targets.reserve(all_pre_scan_widgets.size());
+    for (auto pre_scan_widget : all_pre_scan_widgets) {
+      AppendVisiblePreScanTargetContext(runtime_context, fleet, pre_scan_widget);
     }
-
-    ++runtime_context.visible_pre_scan_target_count;
-
-    auto scan_engage_buttons_widget = pre_scan_widget->_scanEngageButtonsWidget;
-    auto target_context             = scan_engage_buttons_widget ? scan_engage_buttons_widget->Context : nullptr;
-    runtime_context.visible_pre_scan_targets.push_back(
-        {pre_scan_widget, scan_engage_buttons_widget, target_context, GetHullTypeFromBattleTarget(target_context),
-         DeferredSpaceActionTargetMatches(fleet, pre_scan_widget, target_context)});
   }
 
   runtime_context.mining_viewer_widget  = ObjectFinder<MiningObjectViewerWidget>::Get();
@@ -422,6 +434,11 @@ void ClearDeferredSpaceAction()
 {
   fleet_deferred_action::Clear(deferred_space_action_state);
   force_space_action_next_frame = deferred_space_action_state.pending;
+}
+
+void RememberShownPreScanTarget(PreScanTargetWidget* pre_scan_widget)
+{
+  last_shown_pre_scan_target = pre_scan_widget;
 }
 
 uint64_t DeferredSpaceActionGeneration()
@@ -942,6 +959,7 @@ bool ExecuteSpaceAction(FleetBarViewController* fleet_bar, const SpaceActionInpu
 
   auto action_queue   = ActionQueueManager::Instance();
   auto queue_unlocked = has_queue && action_queue && action_queue->IsQueueUnlocked();
+  auto queue_full     = queue_unlocked && action_queue->IsQueueFull(fleet);
 
   for (const auto& pre_scan_target : runtime_context.visible_pre_scan_targets) {
     auto pre_scan_widget             = pre_scan_target.widget;
@@ -987,7 +1005,7 @@ bool ExecuteSpaceAction(FleetBarViewController* fleet_bar, const SpaceActionInpu
       auto queue_input               = primary_input;
       queue_input.queue_mode_enabled = true;
       queue_input.queue_unlocked     = true;
-      queue_input.queue_full         = action_queue->IsQueueFull(fleet);
+      queue_input.queue_full         = queue_full;
       const auto queue_outcome       = DecideFleetPrimary(queue_input);
 
       if (TryHandlePreScanQueueOutcome(queue_outcome, fleet, pre_scan_widget, context, queue_input.queue_full,

--- a/mods/src/patches/fleet_actions.h
+++ b/mods/src/patches/fleet_actions.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 
 struct BattleTargetData;
+struct PreScanTargetWidget;
 
 /** When true, the next frame will re-attempt the primary space action (deferred engage). */
 extern bool force_space_action_next_frame;
@@ -36,6 +37,14 @@ uint64_t DeferredSpaceActionGeneration();
  * @return true if the selection was handled (caller should skip original).
  */
 bool     HandleShipSelection(int ship_select_request);
+
+/**
+ * @brief Remember the most recently shown pre-scan target widget for the fast space-action path.
+ *
+ * The ShowWithFleet hook gives us the target widget the game just displayed.  Space actions can use that pointer
+ * before falling back to a broader tracked-object scan.
+ */
+void     RememberShownPreScanTarget(PreScanTargetWidget* pre_scan_widget);
 
 /**
  * @brief Execute the contextual space action for the currently selected fleet.

--- a/mods/src/patches/fleet_runtime_sync.cc
+++ b/mods/src/patches/fleet_runtime_sync.cc
@@ -1,0 +1,188 @@
+/**
+ * @file fleet_runtime_sync.cc
+ * @brief Change-driven fleet runtime sync snapshots.
+ */
+#include "patches/fleet_runtime_sync.h"
+
+#include "patches/live_debug_fleet_runtime_observers.h"
+#include "patches/sync_scheduler.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <compare>
+#include <cstdint>
+#include <optional>
+#include <ranges>
+#include <string>
+
+namespace
+{
+using json = nlohmann::json;
+
+struct FleetSlotStateKey {
+  bool        selected = false;
+  bool        present = false;
+  uint64_t    fleet_id = 0;
+  int         current_state = -1;
+  int         previous_state = -1;
+  int         cargo_fill_percent = -1;
+  std::string hull_name;
+
+  auto operator<=>(const FleetSlotStateKey&) const = default;
+};
+
+struct FleetStateKey {
+  bool tracked = false;
+  int  selected_index = -1;
+
+  bool        fleet_present = false;
+  uint64_t    fleet_id = 0;
+  int         current_state = -1;
+  int         previous_state = -1;
+  int         cargo_fill_percent = -1;
+  std::string hull_name;
+
+  std::array<FleetSlotStateKey, kFleetIndexMax> slots{};
+
+  auto operator<=>(const FleetStateKey&) const = default;
+};
+
+int64_t current_time_millis_utc()
+{
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+}
+
+int cargo_fill_percent_bucket(int basis_points, int percent)
+{
+  if (percent >= 0) {
+    return percent;
+  }
+  if (basis_points >= 0) {
+    return basis_points / 100;
+  }
+  return -1;
+}
+
+FleetStateKey make_state_key(const FleetObservation& fleet,
+                             const std::array<FleetSlotObservation, kFleetIndexMax>& slots)
+{
+  FleetStateKey key;
+  key.tracked = fleet.tracked;
+  key.selected_index = fleet.selectedIndex;
+  key.fleet_present = fleet.hasFleet;
+  key.fleet_id = fleet.fleetId;
+  key.current_state = fleet.currentState;
+  key.previous_state = fleet.previousState;
+  key.cargo_fill_percent = cargo_fill_percent_bucket(fleet.cargoFillBasisPoints, fleet.cargoFillPercent);
+  key.hull_name = fleet.hullName;
+
+  for (size_t index = 0; index < slots.size(); ++index) {
+    const auto& slot = slots[index];
+    auto&       state = key.slots[index];
+    state.selected = slot.selected;
+    state.present = slot.present;
+    state.fleet_id = slot.fleetId;
+    state.current_state = slot.currentState;
+    state.previous_state = slot.previousState;
+    state.cargo_fill_percent = cargo_fill_percent_bucket(slot.cargoFillBasisPoints, slot.cargoFillPercent);
+    state.hull_name = slot.hullName;
+  }
+
+  return key;
+}
+
+bool is_meaningful_state(const FleetStateKey& state)
+{
+  return state.tracked || state.fleet_present
+      || std::ranges::any_of(state.slots, [](const auto& slot) { return slot.present; });
+}
+
+json fleet_to_json(const FleetObservation& fleet)
+{
+  json result = {{"present", fleet.hasFleet}};
+
+  if (!fleet.hasFleet) {
+    return result;
+  }
+
+  result["id"] = fleet.fleetId;
+  result["currentState"] = fleet.currentState;
+  result["currentStateName"] = fleet_state_name_from_value(fleet.currentState);
+  result["previousState"] = fleet.previousState;
+  result["previousStateName"] = fleet_state_name_from_value(fleet.previousState);
+  result["cargoFillPercent"] = fleet.cargoFillPercent;
+  result["cargoFillBasisPoints"] = fleet.cargoFillBasisPoints;
+  result["hullName"] = fleet.hullName;
+  return result;
+}
+
+json fleet_slot_to_json(const FleetSlotObservation& slot)
+{
+  json result = {
+      {"slotIndex", slot.slotIndex},
+      {"selected", slot.selected},
+      {"present", slot.present},
+  };
+
+  if (!slot.present) {
+    return result;
+  }
+
+  result["fleetId"] = slot.fleetId;
+  result["currentState"] = slot.currentState;
+  result["currentStateName"] = fleet_state_name_from_value(slot.currentState);
+  result["previousState"] = slot.previousState;
+  result["previousStateName"] = fleet_state_name_from_value(slot.previousState);
+  result["cargoFillPercent"] = slot.cargoFillPercent;
+  result["cargoFillBasisPoints"] = slot.cargoFillBasisPoints;
+  result["hullName"] = slot.hullName;
+  return result;
+}
+
+json slots_to_json(const std::array<FleetSlotObservation, kFleetIndexMax>& slots)
+{
+  auto result = json::array();
+  for (const auto& slot : slots) {
+    result.push_back(fleet_slot_to_json(slot));
+  }
+  return result;
+}
+
+json build_snapshot_payload(std::string_view source, const FleetObservation& fleet,
+                            const std::array<FleetSlotObservation, kFleetIndexMax>& slots)
+{
+  return json{
+      {"type", "fleet.runtime"},
+      {"schemaVersion", "stfc.fleet.runtime_snapshot.v1"},
+      {"source", source},
+      {"observedAtMs", current_time_millis_utc()},
+      {"fleetBarTracked", fleet.tracked},
+      {"selectedIndex", fleet.selectedIndex},
+      {"fleet", fleet_to_json(fleet)},
+      {"slots", slots_to_json(slots)},
+  };
+}
+} // namespace
+
+void fleet_runtime_sync_capture(std::string_view source)
+{
+  static std::optional<FleetStateKey> last_state;
+
+  const auto snapshot = observe_fleet_runtime_snapshot();
+  const auto state = make_state_key(snapshot.fleet, snapshot.slots);
+
+  if (!is_meaningful_state(state) && !last_state.has_value()) {
+    return;
+  }
+
+  if (last_state.has_value() && *last_state == state) {
+    return;
+  }
+
+  last_state = state;
+  queue_data(SyncConfig::Type::FleetRuntime, build_snapshot_payload(source, snapshot.fleet, snapshot.slots));
+}

--- a/mods/src/patches/fleet_runtime_sync.h
+++ b/mods/src/patches/fleet_runtime_sync.h
@@ -1,0 +1,12 @@
+/**
+ * @file fleet_runtime_sync.h
+ * @brief Event-driven fleet runtime sync producer.
+ */
+#pragma once
+
+#include <string_view>
+
+/**
+ * @brief Observe current fleet-bar runtime state and enqueue a sync snapshot when it meaningfully changes.
+ */
+void fleet_runtime_sync_capture(std::string_view source);

--- a/mods/src/patches/frame_tick.cc
+++ b/mods/src/patches/frame_tick.cc
@@ -89,12 +89,12 @@ void ScreenManager_Update_FrameTick_Hook(auto original, ScreenManager* screen_ma
 {
   ScopedModImpactTimer impact_timer(ModImpactProbe::FrameTickTotal, ModImpactMonitorEnabled());
 
-  tick_live_debug(screen_manager);
-
   const auto should_call_original = tick_hotkeys(screen_manager);
   if (should_call_original) {
-    return impact_timer.ExcludeCall([&] { original(screen_manager); });
+    impact_timer.ExcludeCall([&] { original(screen_manager); });
   }
+
+  tick_live_debug(screen_manager);
 }
 }
 

--- a/mods/src/patches/hotkey_router.cc
+++ b/mods/src/patches/hotkey_router.cc
@@ -462,4 +462,7 @@ void hotkey_router_bind_context(RewardsButtonWidget* _this)
 { HandleCargoBindContext(_this); }
 
 void hotkey_router_show_fleet(PreScanTargetWidget* _this)
-{ HandleCargoShowFleet(_this); }
+{
+  RememberShownPreScanTarget(_this);
+  HandleCargoShowFleet(_this);
+}

--- a/mods/src/patches/live_debug_fleet_runtime_observers.cc
+++ b/mods/src/patches/live_debug_fleet_runtime_observers.cc
@@ -51,27 +51,10 @@ FleetSlotObservation observe_fleet_slot(int slot_index, FleetBarViewController* 
 
   return observation;
 }
-}
 
-int get_selected_fleet_index(FleetBarViewController* fleet_bar)
-{
-  if (!fleet_bar) {
-    return -1;
-  }
-
-  for (int index = 0; index < kFleetIndexMax; ++index) {
-    if (fleet_bar->IsIndexSelected(index)) {
-      return index;
-    }
-  }
-
-  return -1;
-}
-
-FleetObservation observe_fleetbar()
+FleetObservation observe_fleetbar(FleetBarViewController* fleet_bar)
 {
   FleetObservation observation;
-  auto fleet_bar = GetLatestTrackedObject<FleetBarViewController>();
   observation.tracked = fleet_bar != nullptr;
 
   if (!fleet_bar) {
@@ -101,21 +84,79 @@ FleetObservation observe_fleetbar()
   return observation;
 }
 
-std::array<FleetSlotObservation, kFleetIndexMax> observe_fleet_slots()
+std::array<FleetSlotObservation, kFleetIndexMax> observe_fleet_slots(FleetBarViewController* fleet_bar)
 {
   std::array<FleetSlotObservation, kFleetIndexMax> observations{};
-  auto fleet_bar = GetLatestTrackedObject<FleetBarViewController>();
+  if (!fleet_bar) {
+    for (int slot_index = 0; slot_index < kFleetIndexMax; ++slot_index) {
+      observations[static_cast<size_t>(slot_index)].slotIndex = slot_index;
+    }
+    return observations;
+  }
 
+  auto fleets_manager = FleetsManager::Instance();
   for (int slot_index = 0; slot_index < kFleetIndexMax; ++slot_index) {
     auto& observation = observations[static_cast<size_t>(slot_index)];
     observation.slotIndex = slot_index;
+    observation.selected = fleet_bar->IsIndexSelected(slot_index);
 
-    if (!fleet_bar) {
+    if (!fleets_manager) {
       continue;
     }
 
-    observation = observe_fleet_slot(slot_index, fleet_bar);
+    auto fleet = fleets_manager->GetFleetPlayerData(slot_index);
+    if (!fleet) {
+      continue;
+    }
+
+    observation.present = true;
+    observation.fleetId = fleet->Id;
+    observation.currentState = static_cast<int>(fleet->CurrentState);
+    observation.previousState = static_cast<int>(fleet->PreviousState);
+    observation.cargoFillPercent = static_cast<int>(fleet->CargoResourceFillLevel * 100.0f);
+    observation.cargoFillBasisPoints = static_cast<int>(fleet->CargoResourceFillLevel * 10000.0f);
+
+    if (auto hull = fleet->Hull; hull && hull->Name) {
+      observation.hullName = to_string(hull->Name);
+    }
   }
 
   return observations;
+}
+}
+
+int get_selected_fleet_index(FleetBarViewController* fleet_bar)
+{
+  if (!fleet_bar) {
+    return -1;
+  }
+
+  for (int index = 0; index < kFleetIndexMax; ++index) {
+    if (fleet_bar->IsIndexSelected(index)) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+FleetObservation observe_fleetbar()
+{
+  auto fleet_bar = GetLatestTrackedObject<FleetBarViewController>();
+  return observe_fleetbar(fleet_bar);
+}
+
+std::array<FleetSlotObservation, kFleetIndexMax> observe_fleet_slots()
+{
+  auto fleet_bar = GetLatestTrackedObject<FleetBarViewController>();
+  return observe_fleet_slots(fleet_bar);
+}
+
+FleetRuntimeSnapshot observe_fleet_runtime_snapshot()
+{
+  FleetRuntimeSnapshot snapshot;
+  auto fleet_bar = GetLatestTrackedObject<FleetBarViewController>();
+  snapshot.fleet = observe_fleetbar(fleet_bar);
+  snapshot.slots = observe_fleet_slots(fleet_bar);
+  return snapshot;
 }

--- a/mods/src/patches/live_debug_fleet_runtime_observers.h
+++ b/mods/src/patches/live_debug_fleet_runtime_observers.h
@@ -10,6 +10,12 @@
 
 struct FleetBarViewController;
 
+struct FleetRuntimeSnapshot {
+  FleetObservation                                 fleet;
+  std::array<FleetSlotObservation, kFleetIndexMax> slots{};
+};
+
 int get_selected_fleet_index(FleetBarViewController* fleet_bar);
 FleetObservation observe_fleetbar();
 std::array<FleetSlotObservation, kFleetIndexMax> observe_fleet_slots();
+FleetRuntimeSnapshot observe_fleet_runtime_snapshot();

--- a/mods/src/patches/live_debug_state_results.cc
+++ b/mods/src/patches/live_debug_state_results.cc
@@ -65,8 +65,9 @@ nlohmann::json TopCanvas()
 nlohmann::json FleetbarState()
 {
   auto fleet_bar = GetLatestTrackedObject<FleetBarViewController>();
+  const auto snapshot = observe_fleet_runtime_snapshot();
 
-  nlohmann::json result = {{"tracked", fleet_bar != nullptr}};
+  nlohmann::json result = {{"tracked", snapshot.fleet.tracked}};
 
   if (!fleet_bar) {
     return result;
@@ -76,9 +77,23 @@ nlohmann::json FleetbarState()
   auto fleet = fleet_controller ? fleet_controller->fleet : nullptr;
 
   result["pointer"] = pointer_to_string(fleet_bar);
-  result["selectedIndex"] = get_selected_fleet_index(fleet_bar);
+  result["selectedIndex"] = snapshot.fleet.selectedIndex;
   result["hasController"] = fleet_controller != nullptr;
-  result["fleet"] = fleet_to_json(fleet);
+  result["fleet"] = {{"present", snapshot.fleet.hasFleet}};
+  if (snapshot.fleet.hasFleet) {
+    result["fleet"]["id"] = snapshot.fleet.fleetId;
+    result["fleet"]["currentState"] = snapshot.fleet.currentState;
+    result["fleet"]["currentStateName"] = fleet_state_name_from_value(snapshot.fleet.currentState);
+    result["fleet"]["previousState"] = snapshot.fleet.previousState;
+    result["fleet"]["previousStateName"] = fleet_state_name_from_value(snapshot.fleet.previousState);
+    result["fleet"]["cargoFill"] = fleet ? fleet->CargoResourceFillLevel : 0.0f;
+
+    if (fleet && fleet->Hull) {
+      result["fleet"]["hull"] = fleet_to_json(fleet)["hull"];
+    } else {
+      result["fleet"]["hull"] = nullptr;
+    }
+  }
   return result;
 }
 
@@ -86,7 +101,8 @@ nlohmann::json FleetSlotsState()
 {
   auto fleet_bar = GetLatestTrackedObject<FleetBarViewController>();
 
-  const auto slot_observations = observe_fleet_slots();
+  const auto snapshot = observe_fleet_runtime_snapshot();
+  const auto& slot_observations = snapshot.slots;
   size_t present_count = 0;
   for (const auto& slot : slot_observations) {
     if (slot.present) {

--- a/mods/src/patches/parts/live_debug.cc
+++ b/mods/src/patches/parts/live_debug.cc
@@ -14,6 +14,7 @@
 #include "patches/live_debug_fleet_runtime_observers.h"
 #include "patches/live_debug_fleet_runtime_serializers.h"
 #include "patches/live_debug_fleet_serializers.h"
+#include "patches/fleet_runtime_sync.h"
 #include "patches/live_debug_observation_compare.h"
 #include "patches/live_debug_recent_event_requests.h"
 #include "patches/live_debug_request_dispatch.h"
@@ -592,9 +593,11 @@ void initialize_recent_model_observations(std::string_view source)
     return;
   }
 
+  const auto fleet_runtime = observe_fleet_runtime_snapshot();
+
   const auto top_canvas             = kEnableLiveDebugTopCanvasPolling ? observe_top_canvas() : TopCanvasObservation{};
-  const auto fleet                  = observe_fleetbar();
-  const auto fleet_slots            = observe_fleet_slots();
+  const auto& fleet                 = fleet_runtime.fleet;
+  const auto& fleet_slots           = fleet_runtime.slots;
   const auto station_warning        = kEnableLiveDebugStationWarningPolling
                                           ? observe_station_warning(ui_observer_trace_hooks())
                                           : StationWarningObservation{};
@@ -704,8 +707,10 @@ void capture_recent_model_events(std::string_view source)
 
   poll_recent_ui_events();
 
-  const auto fleet       = observe_fleetbar();
-  const auto fleet_slots = observe_fleet_slots();
+  const auto fleet_runtime = observe_fleet_runtime_snapshot();
+
+  const auto& fleet       = fleet_runtime.fleet;
+  const auto& fleet_slots = fleet_runtime.slots;
 
   if (!same_fleet_observation(fleet, g_last_fleet)) {
     append_fleet_change_events(g_last_fleet, fleet);
@@ -720,84 +725,129 @@ void capture_recent_model_events(std::string_view source)
   g_last_fleet_slots = fleet_slots;
 }
 
+void capture_fleet_runtime_sync_event(std::string_view source)
+{
+  if (!Config::Get().installSyncPatches || !Config::Get().sync_options.fleet_runtime) {
+    return;
+  }
+
+  try {
+    fleet_runtime_sync_capture(source);
+  } catch (const std::exception& ex) {
+    spdlog::error("[FleetRuntimeSync] source={} status=failed error='{}'", source, ex.what());
+  } catch (...) {
+    spdlog::error("[FleetRuntimeSync] source={} status=failed error='unknown exception'", source);
+  }
+}
+
 void DeploymentEvents_TriggerFleetStateChangeEvent_Hook(auto original, IList* fleets)
 {
   original(fleets);
-  live_debug_events::RecordEvent("deployment-fleet-state-event", json{{"fleetCount", count_list_items(fleets)},
-                                                                      {"fleets", deployed_fleet_list_to_json(fleets)}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent("deployment-fleet-state-event",
+                                   json{{"fleetCount", count_list_items(fleets)},
+                                        {"fleets", deployed_fleet_list_to_json(fleets)}});
+  }
   capture_recent_model_events("deployment-fleet-state-event");
+  capture_fleet_runtime_sync_event("deployment-fleet-state-event");
 }
 
 void DeploymentEvents_TriggerPlayerFleetsUpdatedEvent_Hook(auto original, IList* fleets)
 {
   original(fleets);
   capture_recent_model_events("deployment-player-fleets-updated-event");
+  capture_fleet_runtime_sync_event("deployment-player-fleets-updated-event");
 }
 
 void DeploymentEvents_TriggerCoursePlannedEvent_Hook(auto original, IList* courses)
 {
   original(courses);
-  live_debug_events::RecordEvent("deployment-course-planned-event", json{{"courseCount", count_list_items(courses)}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent("deployment-course-planned-event", json{{"courseCount", count_list_items(courses)}});
+  }
   capture_recent_model_events("deployment-course-planned-event");
+  capture_fleet_runtime_sync_event("deployment-course-planned-event");
 }
 
 void DeploymentEvents_TriggerCourseStartEvent_Hook(auto original, IList* courses)
 {
   original(courses);
-  live_debug_events::RecordEvent("deployment-course-start-event", json{{"courseCount", count_list_items(courses)}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent("deployment-course-start-event", json{{"courseCount", count_list_items(courses)}});
+  }
   capture_recent_model_events("deployment-course-start-event");
+  capture_fleet_runtime_sync_event("deployment-course-start-event");
 }
 
 void DeploymentEvents_TriggerCourseChangeEvent_Hook(auto original, IList* old_courses, IList* new_courses)
 {
   original(old_courses, new_courses);
-  live_debug_events::RecordEvent(
-      "deployment-course-change-event",
-      json{{"oldCourseCount", count_list_items(old_courses)}, {"newCourseCount", count_list_items(new_courses)}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent(
+        "deployment-course-change-event",
+        json{{"oldCourseCount", count_list_items(old_courses)}, {"newCourseCount", count_list_items(new_courses)}});
+  }
   capture_recent_model_events("deployment-course-change-event");
+  capture_fleet_runtime_sync_event("deployment-course-change-event");
 }
 
 void DeploymentEvents_TriggerCourseEndEvent_Hook(auto original, IList* courses)
 {
   original(courses);
-  live_debug_events::RecordEvent("deployment-course-end-event", json{{"courseCount", count_list_items(courses)}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent("deployment-course-end-event", json{{"courseCount", count_list_items(courses)}});
+  }
   capture_recent_model_events("deployment-course-end-event");
+  capture_fleet_runtime_sync_event("deployment-course-end-event");
 }
 
 void DeploymentEvents_TriggerSetCourseResponseEvent_Hook(auto original, long fleet_id, bool success,
                                                          bool is_recall_course, void* planned_course_data)
 {
   original(fleet_id, success, is_recall_course, planned_course_data);
-  live_debug_events::RecordEvent("deployment-set-course-response-event",
-                                 json{{"fleetId", fleet_id},
-                                      {"success", success},
-                                      {"isRecallCourse", is_recall_course},
-                                      {"hasCourseData", planned_course_data != nullptr}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent("deployment-set-course-response-event",
+                                   json{{"fleetId", fleet_id},
+                                        {"success", success},
+                                        {"isRecallCourse", is_recall_course},
+                                        {"hasCourseData", planned_course_data != nullptr}});
+  }
   capture_recent_model_events("deployment-set-course-response-event");
+  capture_fleet_runtime_sync_event("deployment-set-course-response-event");
 }
 
 void DeploymentEvents_TriggerBattleStartEvent_Hook(auto original, IList* fleets)
 {
   original(fleets);
-  live_debug_events::RecordEvent(
-      "deployment-battle-start-event",
-      json{{"fleetCount", count_list_items(fleets)}, {"fleets", deployed_fleet_list_to_json(fleets)}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent(
+        "deployment-battle-start-event",
+        json{{"fleetCount", count_list_items(fleets)}, {"fleets", deployed_fleet_list_to_json(fleets)}});
+  }
   capture_recent_model_events("deployment-battle-start-event");
+  capture_fleet_runtime_sync_event("deployment-battle-start-event");
 }
 
 void DeploymentEvents_TriggerBattleEndEvent_Hook(auto original, IList* fleets)
 {
   original(fleets);
-  live_debug_events::RecordEvent("deployment-battle-end-event", json{{"fleetCount", count_list_items(fleets)},
-                                                                     {"fleets", deployed_fleet_list_to_json(fleets)}});
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent("deployment-battle-end-event",
+                                   json{{"fleetCount", count_list_items(fleets)},
+                                        {"fleets", deployed_fleet_list_to_json(fleets)}});
+  }
   capture_recent_model_events("deployment-battle-end-event");
+  capture_fleet_runtime_sync_event("deployment-battle-end-event");
 }
 
 void DeploymentEvents_TriggerStaleFleetDataDetected_Hook(auto original)
 {
   original();
-  live_debug_events::RecordEvent("deployment-stale-fleet-data-detected-event", json::object());
+  if (LiveDebugChannelEnabled()) {
+    live_debug_events::RecordEvent("deployment-stale-fleet-data-detected-event", json::object());
+  }
   capture_recent_model_events("deployment-stale-fleet-data-detected-event");
+  capture_fleet_runtime_sync_event("deployment-stale-fleet-data-detected-event");
 }
 
 json handle_recent_events(const std::string& request_id, const json& request)

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -146,9 +146,10 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
   spdlog::info("");
 
   spdlog::info("Initializing code hooks:");
-  auto             install_live_debug_hooks           = LiveDebugChannelEnabled();
+  auto             install_live_debug_hooks           =
+      LiveDebugChannelEnabled() || (cfg.installSyncPatches && cfg.sync_options.fleet_runtime);
   auto             install_refinery_diagnostics_hooks = RefineryDiagnosticsEnabled();
-  auto             install_frame_tick_hooks           = cfg.installHotkeyHooks || install_live_debug_hooks;
+  auto             install_frame_tick_hooks           = cfg.installHotkeyHooks || LiveDebugChannelEnabled();
   const PatchEntry patches[]                          = {
       {"UiScaleHooks", {InstallUiScaleHooks, &cfg.installUiScaleHooks}},
       {"ZoomHooks", {InstallZoomHooks, &cfg.installZoomHooks}},


### PR DESCRIPTION
## Summary
- add `sync.fleet_runtime` as an opt-in runtime sync category
- move fleet runtime capture off `ScreenManager.Update` and onto deployment event hooks
- consolidate fleet runtime observations so live-debug and sync share one snapshot path
- speed up the target/primary_action path by using the game-shown pre-scan target first, with the full scan as fallback

## Root Cause
Frame-driven fleet runtime polling touched the fleet bar controller outside the game's normal UI cadence. Even low-rate polling could make the fleet bar display count continuously instead of chunking at the game's native cadence.

## Validation
- `git diff --check`
- `pwsh -NoProfile -File .ax\ax.ps1 validate`
- local releasedbg tests: 221/221 passed
- local releasedbg DLL build passed
- live smoke: fleet bar cadence returned to normal, hostile select and primary/right-click attack loop looked clean