### PR TITLE
[codex] Harden remaining crash paths

### DIFF
--- a/mods/src/patches/battle_log_decoder.cc
+++ b/mods/src/patches/battle_log_decoder.cc
@@ -268,7 +268,9 @@ void append_unique(std::vector<int64_t>& values, int64_t value)
 [[nodiscard]] nlohmann::json lossless_integer_json(const nlohmann::json& value, size_t depth)
 {
   if (depth >= kLosslessIntegerJsonMaxDepth) {
-    return nullptr;
+    return nlohmann::json{{"truncated", true},
+                          {"reason", "lossless_integer_json_max_depth"},
+                          {"maxDepth", kLosslessIntegerJsonMaxDepth}};
   }
 
   if (value.is_object()) {

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -30,13 +30,8 @@
 #include <cstring>
 #include <cstdlib>
 #include <exception>
-
-namespace
-{
-constexpr bool kLiveDebugOnlyHookIsolation = false;
-constexpr auto kLegacyLogMaxBytes          = 512 * 1024;
-constexpr auto kLegacyLogMaxFiles          = 2;
-}
+#include <cstdio>
+#include <string>
 
 #if _WIN32
 #include <Windows.h>
@@ -45,6 +40,24 @@ constexpr auto kLegacyLogMaxFiles          = 2;
 #include <libgen.h>
 #include <mach-o/dyld.h>
 #endif
+
+namespace
+{
+constexpr bool kLiveDebugOnlyHookIsolation = false;
+constexpr auto kLegacyLogMaxBytes          = 512 * 1024;
+constexpr auto kLegacyLogMaxFiles          = 2;
+
+void LogRootHookInstallFailure(const std::string& message)
+{
+  spdlog::error("{}", message);
+#if _WIN32
+  OutputDebugStringA(message.c_str());
+  OutputDebugStringA("\n");
+#else
+  std::fprintf(stderr, "%s\n", message.c_str());
+#endif
+}
+}
 
 // ─── Forward Declarations — per-module install functions ─────────────────────
 
@@ -260,9 +273,9 @@ void ApplyPatches()
 
       SPUD_STATIC_DETOUR(n, il2cpp_init_hook);
     } catch (const std::exception& exception) {
-      spdlog::error("Failed to install il2cpp_init hook: {}", exception.what());
+      LogRootHookInstallFailure(std::string{"Failed to install il2cpp_init hook: "} + exception.what());
     } catch (...) {
-      spdlog::error("Failed to install il2cpp_init hook: unknown exception");
+      LogRootHookInstallFailure("Failed to install il2cpp_init hook: unknown exception");
     }
   }
 }

--- a/tests/src/test_battle_log_decoder.cc
+++ b/tests/src/test_battle_log_decoder.cc
@@ -128,6 +128,10 @@ TEST_SUITE("battle_log_decoder")
 
     CHECK_NOTHROW(
         (void)battle_log_decoder::build_sidecar_battle_capture_event(journal, nlohmann::json::object(), 0, 0));
+
+    const auto capture =
+        battle_log_decoder::build_sidecar_battle_capture_event(journal, nlohmann::json::object(), 0, 0);
+    CHECK(capture.dump().find("lossless_integer_json_max_depth") != std::string::npos);
   }
 
   TEST_CASE("hostile display names ignore retrieving placeholders and derive from reward keys")


### PR DESCRIPTION
## Summary
- add a platform fallback for fatal root `il2cpp_init` hook install failures before file logging is guaranteed
- make the lossless battle-log JSON depth cap emit an explicit truncation sentinel instead of a silent null
- assert the depth-cap marker in the battle-log decoder test suite

## Issue Notes
Most of #112 was already addressed on `main` by earlier PRs: UUID creation/stringification is checked, root hook failures are logged, and lossless JSON traversal has a depth budget. This PR finishes the remaining polish from the review update.

Closes #112

## Validation
- `git diff --check`
- `xmake build -y stfc-mod-tests`
- `build\windows\x64\releasedbg\stfc-mod-tests.exe`
- `xmake build -y mods`