### PR TITLE
[codex] Add Majel sync target envelope mode

### DIFF
--- a/docs/MAJEL_INGEST_CONTRACT.md
+++ b/docs/MAJEL_INGEST_CONTRACT.md
@@ -1,0 +1,48 @@
+# Majel Ingest Contract
+
+This mod can send optional fire-and-forget telemetry to Majel directly, or to a local sidecar broker that later uploads
+to Majel. Both paths are opt-in sync targets.
+
+## Target Modes
+
+`[sync.targets.<name>]` supports:
+
+- `mode = "legacy"`: existing sync behavior. Sends the original sync JSON body with `stfc-sync-token`.
+- `mode = "sidecar_broker"`: sends a Majel-safe ingest envelope to a local sidecar endpoint with `stfc-sync-token`.
+- `mode = "majel"`: sends a Majel-safe ingest envelope directly to Majel with `Authorization: Bearer <token>`.
+
+Sidecar broker mode remains the preferred durability/retry path. Direct Majel mode is best-effort from the mod process.
+Neither mode enables callbacks, remote settings writes, or gameplay commands.
+
+## Envelope
+
+Majel-mode and sidecar-broker-mode targets POST one event envelope per queued sync item:
+
+```json
+{
+  "protocolVersion": "majel.ingest.v1",
+  "eventId": "uuid-or-stable-fallback",
+  "source": "stfc-community-mod",
+  "sourceVersion": "2.0.1-guffa.1",
+  "installId": "not_configured",
+  "sessionId": "launch-local-uuid",
+  "sequence": 1,
+  "observedAt": "2026-05-17T22:00:00Z",
+  "schema": "stfc.fleet.runtime_snapshot.v1",
+  "classification": "cloud_private",
+  "payload": {}
+}
+```
+
+Payload rules:
+
+- Payloads that already carry `schemaVersion` or `schema` keep that schema and payload shape.
+- Existing legacy sync arrays are wrapped as `stfc.sync.delta_batch.v1` with `syncType` and `items`.
+- Fleet runtime snapshots emit as `stfc.fleet.runtime_snapshot.v1`.
+- Battle sync targets map to `stfc.battle.summary.v1` until a narrower battle projection is split out.
+
+## Privacy
+
+Do not send raw Scopely auth/session headers, cookies, coordinates, raw battle token streams, opaque protocol dumps, raw
+logs, or gameplay command data. Target tokens are credentials and must stay redacted in logs, runtime snapshots, JSONL,
+and diagnostics exports.

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -857,6 +857,9 @@ allow_unsafe_tls_without_certificate_validation = false
 # The url of the server to send data to
 # url = ""
 
+# Outbound contract for this target: legacy, sidecar_broker, or majel.
+# mode = "legacy"
+
 # Example local sidecar target. Keep battlelogs disabled here so the target only
 # receives canonical realtime battle feed events on /api/events. Prefer this
 # ingress path over long-lived local JSONL capture. You can temporarily enable
@@ -865,6 +868,7 @@ allow_unsafe_tls_without_certificate_validation = false
 #[sync.targets.sidecar]
 # token = "testtoken123"
 # url = "http://127.0.0.1:43127/api/events"
+# mode = "sidecar_broker"
 # battlelogs = false
 # battlelogs_realtime = true
 
@@ -874,11 +878,24 @@ allow_unsafe_tls_without_certificate_validation = false
 #[sync.targets.sidecar_fleet]
 # token = "testtoken123"
 # url = "http://127.0.0.1:43127/api/fleet/sync"
+# mode = "legacy"
 # battlelogs = false
 # battlelogs_realtime = false
 # fleet_runtime = true
 # ships = true
 # slots = true
+
+# Optional direct Majel target. This sends one-way cloud-safe ingest envelopes
+# with Authorization: Bearer <token>. The token must be a Majel ingest token,
+# not a game/session credential. No callbacks or remote settings writes are
+# enabled by this target.
+#[sync.targets.majel]
+# token = ""
+# url = "https://majel.example.test/api/ingest/events"
+# mode = "majel"
+# battlelogs = false
+# battlelogs_realtime = true
+# fleet_runtime = true
 
 #  <[=============================================================================================================]>
 #

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -612,6 +612,22 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
     return;
   }
 
+  const auto parse_mode = [](const std::string_view target_section,
+                             const std::optional<std::string>& value) -> SyncTargetConfig::Mode {
+    if (!value.has_value() || value->empty() || *value == "legacy") {
+      return SyncTargetConfig::Mode::Legacy;
+    }
+    if (*value == "majel") {
+      return SyncTargetConfig::Mode::Majel;
+    }
+    if (*value == "sidecar_broker") {
+      return SyncTargetConfig::Mode::SidecarBroker;
+    }
+
+    spdlog::warn("Invalid target [{}] mode '{}'; using legacy.", target_section, *value);
+    return SyncTargetConfig::Mode::Legacy;
+  };
+
   for (const auto& [target_key, target_config] : *targets) {
     if (!target_config.is_table()) {
       continue;
@@ -635,6 +651,7 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
       target.url        = url.value();
       target.token      = token.value();
       target.proxy      = proxy.value_or(defaults.proxy);
+      target.mode       = parse_mode(target_section, values["mode"].value<std::string>());
       target.verify_ssl = values["verify_ssl"].value<bool>().value_or(defaults.verify_ssl);
       target.allow_unsafe_tls_without_certificate_validation =
           values["allow_unsafe_tls_without_certificate_validation"].value<bool>().value_or(
@@ -642,6 +659,7 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
 
       parsed_target.insert("url", target.url);
       parsed_target.insert("token", config_redaction::redact_secret_for_runtime_snapshot(target.token));
+      parsed_target.insert("mode", std::string(to_string(target.mode)));
       parsed_target.insert("proxy", config_redaction::mask_proxy_userinfo(target.proxy));
       parsed_target.insert("verify_ssl", target.verify_ssl);
       parsed_target.insert("allow_unsafe_tls_without_certificate_validation",
@@ -658,9 +676,10 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
 
     if (sync_targets.emplace(target_key.str(), target).second) {
       new_config["sync"]["targets"].as_table()->emplace<toml::table>(target_key.str(), parsed_target);
-      spdlog::debug("config value {} url: {}, token: {}", target_section, target.url, mask_token(target.token));
-      spdlog::info("target [{}] proxy: '{}', verify_ssl: {}, allow_unsafe_tls_without_certificate_validation: {}",
-                   target_section, mask_proxy_for_log(target.proxy), target.verify_ssl,
+      spdlog::debug("config value {} url: {}, token: {}, mode: {}", target_section, target.url,
+                    mask_token(target.token), to_string(target.mode));
+      spdlog::info("target [{}] mode: {}, proxy: '{}', verify_ssl: {}, allow_unsafe_tls_without_certificate_validation: {}",
+                   target_section, to_string(target.mode), mask_proxy_for_log(target.proxy), target.verify_ssl,
                    target.allow_unsafe_tls_without_certificate_validation);
     }
   }

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -12,6 +12,7 @@
 #include <bitset>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <toml++/toml.h>
@@ -136,9 +137,30 @@ constexpr std::string operator+(const SyncConfig::Type type, const std::string& 
 class SyncTargetConfig : public SyncConfig
 {
 public:
+  enum class Mode {
+    Legacy,
+    Majel,
+    SidecarBroker,
+  };
+
   std::string url;   ///< Endpoint URL for this sync target.
   std::string token; ///< Bearer token / API key.
+  Mode        mode = Mode::Legacy; ///< Outbound wire contract for this target.
 };
+
+constexpr std::string_view to_string(const SyncTargetConfig::Mode mode)
+{
+  switch (mode) {
+    case SyncTargetConfig::Mode::Legacy:
+      return "legacy";
+    case SyncTargetConfig::Mode::Majel:
+      return "majel";
+    case SyncTargetConfig::Mode::SidecarBroker:
+      return "sidecar_broker";
+  }
+
+  return "legacy";
+}
 
 /**
  * @brief Unified OS-notification selection model.

--- a/mods/src/patches/sync_transport.cc
+++ b/mods/src/patches/sync_transport.cc
@@ -25,7 +25,9 @@
 #endif
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
+#include <ctime>
 #include <format>
 #include <memory>
 #include <mutex>
@@ -268,6 +270,7 @@ void sync_log_trace(const std::string& type, const std::string& target, const st
 static const std::string CURL_TYPE_UPLOAD   = "UPLOAD";
 static const std::string CURL_TYPE_DOWNLOAD = "DOWNLOAD";
 static constexpr size_t  kTargetWorkerMaxQueuedRequests = 256;
+static constexpr size_t  kMajelIngestMaxEventBytes       = 256 * 1024;
 
 struct TargetWorker {
   TargetWorker() = default;
@@ -277,6 +280,7 @@ struct TargetWorker {
   using request_t = std::tuple<std::string, std::string, bool>;
 
   std::shared_ptr<cpr::Session> session;
+  SyncTargetConfig::Mode        mode = SyncTargetConfig::Mode::Legacy;
   std::thread                   worker_thread;
   std::atomic_bool              stop_requested{false};
   std::queue<request_t>         request_queue;
@@ -288,6 +292,77 @@ struct TargetWorker {
 static std::unordered_map<std::string, std::shared_ptr<TargetWorker>> target_workers;
 static std::mutex target_workers_mtx;
 static std::atomic_bool target_workers_shutdown_requested = false;
+static std::atomic_uint64_t majel_event_sequence = 0;
+
+std::string current_time_iso_utc()
+{
+  const auto now = std::chrono::system_clock::now();
+  const auto now_time = std::chrono::system_clock::to_time_t(now);
+
+  std::tm utc{};
+#if _WIN32
+  gmtime_s(&utc, &now_time);
+#else
+  gmtime_r(&now_time, &utc);
+#endif
+
+  char buffer[sizeof("2026-05-17T22:00:00Z")];
+  if (std::strftime(buffer, sizeof(buffer), "%Y-%m-%dT%H:%M:%SZ", &utc) == 0) {
+    return {};
+  }
+
+  return buffer;
+}
+
+std::string majel_session_id()
+{
+  static const std::string session_id = [] {
+    auto value = newUUID();
+    return value.empty() ? std::string{"unknown-session"} : value;
+  }();
+  return session_id;
+}
+
+std::string make_target_post_data(const SyncTargetConfig& target_config, SyncConfig::Type type,
+                                  const std::string& post_data, const std::string& target_identifier)
+{
+  if (!SyncTargetUsesMajelEnvelope(target_config.mode)) {
+    return post_data;
+  }
+
+  auto payload = nlohmann::json::parse(post_data, nullptr, false);
+  if (payload.is_discarded()) {
+    sync_log_warn(CURL_TYPE_UPLOAD, target_identifier,
+                  "Dropping Majel ingest event because the sync payload was not valid JSON");
+    return {};
+  }
+
+  const auto sequence = majel_event_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+  auto       event_id = newUUID();
+  if (event_id.empty()) {
+    event_id = STR_FORMAT("stfc-community-mod-{}", sequence);
+  }
+
+  auto envelope = BuildMajelIngestEnvelope({
+      .sync_type = type,
+      .payload = std::move(payload),
+      .event_id = std::move(event_id),
+      .source_version = VER_FILE_VERSION_STR,
+      .install_id = "not_configured",
+      .session_id = majel_session_id(),
+      .sequence = sequence,
+      .observed_at = current_time_iso_utc(),
+  }).dump();
+
+  if (envelope.size() > kMajelIngestMaxEventBytes) {
+    sync_log_warn(CURL_TYPE_UPLOAD, target_identifier,
+                  STR_FORMAT("Dropping Majel ingest event because the envelope is too large ({} bytes, max: {})",
+                             envelope.size(), kMajelIngestMaxEventBytes));
+    return {};
+  }
+
+  return envelope;
+}
 
 static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
 {
@@ -327,7 +402,7 @@ static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
       const auto httpClient = worker->session;
       auto& request_headers = httpClient->GetHeader();
 
-      if (is_first_sync) {
+      if (worker->mode == SyncTargetConfig::Mode::Legacy && is_first_sync) {
         request_headers.insert_or_assign("X-PRIME-SYNC", "2");
         sync_log_trace(CURL_TYPE_UPLOAD, identifier, "Adding X-Prime-Sync header for initial sync");
       } else {
@@ -379,6 +454,7 @@ static std::shared_ptr<TargetWorker> get_curl_client_sync(const std::string& tar
   auto worker = std::make_shared<TargetWorker>();
   worker->session = std::make_shared<cpr::Session>();
   const auto& target_config = Config::Get().sync_targets[target];
+  worker->mode = target_config.mode;
 
   worker->session->SetUrl(target_config.url);
   worker->session->SetUserAgent("stfc community patch " VER_FILE_VERSION_STR " (libcurl/" LIBCURL_VERSION ")");
@@ -399,11 +475,11 @@ static std::shared_ptr<TargetWorker> get_curl_client_sync(const std::string& tar
     );
   }
 
-  worker->session->SetHeader({
-    {"Content-Type", "application/json"},
-    {"X-Powered-By", headers::poweredBy},
-    {"stfc-sync-token", target_config.token},
-  });
+  cpr::Header target_headers;
+  for (const auto& [key, value] : BuildSyncTargetHeaders(target_config, headers::poweredBy)) {
+    target_headers.emplace(key, value);
+  }
+  worker->session->SetHeader(std::move(target_headers));
 
   worker->worker_thread = std::thread(target_worker_thread, worker);
   target_workers[target] = worker;
@@ -426,13 +502,16 @@ void send_data(SyncConfig::Type type, const std::string& post_data, bool is_firs
     }
   });
 
-  for (const auto& target : targets
-       | std::views::filter([type](const auto& target_entry) { return target_entry.second.enabled(type); })
-       | std::views::keys) {
+  for (const auto& [target, target_config] : targets
+       | std::views::filter([type](const auto& target_entry) { return target_entry.second.enabled(type); })) {
     const auto target_identifier = STR_FORMAT("{} ({})", target, to_string(type));
 
     try {
       const auto worker = get_curl_client_sync(target);
+      const auto target_post_data = make_target_post_data(target_config, type, post_data, target_identifier);
+      if (target_post_data.empty()) {
+        continue;
+      }
 
       {
         std::lock_guard lk(worker->queue_mtx);
@@ -444,7 +523,7 @@ void send_data(SyncConfig::Type type, const std::string& post_data, bool is_firs
           continue;
         }
 
-        worker->request_queue.emplace(target_identifier, post_data, is_first_sync);
+        worker->request_queue.emplace(target_identifier, target_post_data, is_first_sync);
         sync_log_trace(CURL_TYPE_UPLOAD, target_identifier,
                        STR_FORMAT("Queued request (queue size: {})", worker->request_queue.size()));
       }

--- a/mods/src/patches/sync_transport_policy.cc
+++ b/mods/src/patches/sync_transport_policy.cc
@@ -13,6 +13,37 @@ std::string format_instance_id(const int32_t instance_id)
 
   return std::string(3 - value.size(), '0') + value;
 }
+
+std::string schema_for_sync_type(const SyncConfig::Type type, const nlohmann::json& payload)
+{
+  if (payload.is_object()) {
+    if (const auto found = payload.find("schemaVersion"); found != payload.end() && found->is_string()) {
+      return found->get<std::string>();
+    }
+    if (const auto found = payload.find("schema"); found != payload.end() && found->is_string()) {
+      return found->get<std::string>();
+    }
+  }
+
+  switch (type) {
+    case SyncConfig::Type::Battles:
+    case SyncConfig::Type::BattlelogsRealtime:
+      return "stfc.battle.summary.v1";
+    case SyncConfig::Type::FleetRuntime:
+      return "stfc.fleet.runtime_snapshot.v1";
+    default:
+      return "stfc.sync.delta_batch.v1";
+  }
+}
+
+nlohmann::json payload_for_sync_type(const SyncConfig::Type type, const nlohmann::json& payload)
+{
+  if (schema_for_sync_type(type, payload) != "stfc.sync.delta_batch.v1") {
+    return payload;
+  }
+
+  return nlohmann::json{{"syncType", to_string(type)}, {"items", payload}};
+}
 } // namespace
 
 namespace http
@@ -39,6 +70,45 @@ ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSna
       snapshot.primeVersion,
       format_instance_id(snapshot.instanceId),
       snapshot.unityVersion,
+  };
+}
+
+bool SyncTargetUsesMajelEnvelope(const SyncTargetConfig::Mode mode)
+{ return mode == SyncTargetConfig::Mode::Majel || mode == SyncTargetConfig::Mode::SidecarBroker; }
+
+std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig& target_config,
+                                                          std::string powered_by)
+{
+  std::map<std::string, std::string> headers{
+      {"Content-Type", "application/json"},
+      {"X-Powered-By", std::move(powered_by)},
+  };
+
+  if (target_config.mode == SyncTargetConfig::Mode::Majel) {
+    headers.emplace("Authorization", "Bearer " + target_config.token);
+  } else {
+    headers.emplace("stfc-sync-token", target_config.token);
+  }
+
+  return headers;
+}
+
+nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input)
+{
+  const auto schema = schema_for_sync_type(input.sync_type, input.payload);
+
+  return nlohmann::json{
+      {"protocolVersion", "majel.ingest.v1"},
+      {"eventId", input.event_id},
+      {"source", "stfc-community-mod"},
+      {"sourceVersion", input.source_version},
+      {"installId", input.install_id},
+      {"sessionId", input.session_id},
+      {"sequence", input.sequence},
+      {"observedAt", input.observed_at},
+      {"schema", schema},
+      {"classification", "cloud_private"},
+      {"payload", payload_for_sync_type(input.sync_type, input.payload)},
   };
 }
 } // namespace http

--- a/mods/src/patches/sync_transport_policy.h
+++ b/mods/src/patches/sync_transport_policy.h
@@ -2,7 +2,11 @@
 
 #include "patches/sync_transport.h"
 
+#include <cstdint>
+#include <map>
 #include <string>
+
+#include <nlohmann/json.hpp>
 
 namespace http
 {
@@ -20,7 +24,22 @@ struct ScopelySessionHeaders {
   std::string unity_version;
 };
 
+struct MajelIngestEnvelopeInput {
+  SyncConfig::Type sync_type = SyncConfig::Type::Ships;
+  nlohmann::json   payload;
+  std::string      event_id;
+  std::string      source_version;
+  std::string      install_id;
+  std::string      session_id;
+  uint64_t         sequence = 0;
+  std::string      observed_at;
+};
+
 [[nodiscard]] SyncTlsVerificationDecision DecideSyncTlsVerification(const SyncConfig& config);
 [[nodiscard]] ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSnapshot& snapshot,
                                                               std::string transaction_id);
+[[nodiscard]] bool SyncTargetUsesMajelEnvelope(SyncTargetConfig::Mode mode);
+[[nodiscard]] std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig& target_config,
+                                                                        std::string powered_by);
+[[nodiscard]] nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input);
 } // namespace http

--- a/tests/src/test_sync_transport_policy.cc
+++ b/tests/src/test_sync_transport_policy.cc
@@ -56,4 +56,68 @@ TEST_SUITE("sync_transport_policy")
     CHECK(second_headers.instance_id == "042");
     CHECK(second_headers.unity_version == "6000.0.60f1");
   }
+
+  TEST_CASE("target mode controls auth header and Majel envelope use")
+  {
+    SyncTargetConfig target;
+    target.token = "secret-token";
+
+    auto headers = http::BuildSyncTargetHeaders(target, "test-powered-by");
+    CHECK(headers["stfc-sync-token"] == "secret-token");
+    CHECK(headers.find("Authorization") == headers.end());
+    CHECK_FALSE(http::SyncTargetUsesMajelEnvelope(target.mode));
+
+    target.mode = SyncTargetConfig::Mode::Majel;
+    headers = http::BuildSyncTargetHeaders(target, "test-powered-by");
+    CHECK(headers["Authorization"] == "Bearer secret-token");
+    CHECK(headers.find("stfc-sync-token") == headers.end());
+    CHECK(http::SyncTargetUsesMajelEnvelope(target.mode));
+
+    target.mode = SyncTargetConfig::Mode::SidecarBroker;
+    headers = http::BuildSyncTargetHeaders(target, "test-powered-by");
+    CHECK(headers["stfc-sync-token"] == "secret-token");
+    CHECK(headers.find("Authorization") == headers.end());
+    CHECK(http::SyncTargetUsesMajelEnvelope(target.mode));
+  }
+
+  TEST_CASE("Majel envelope preserves schema payloads and wraps legacy deltas")
+  {
+    const auto fleet_payload = nlohmann::json{
+        {"schemaVersion", "stfc.fleet.runtime_snapshot.v1"},
+        {"selectedIndex", 1},
+    };
+
+    auto envelope = http::BuildMajelIngestEnvelope({
+        .sync_type = SyncConfig::Type::FleetRuntime,
+        .payload = fleet_payload,
+        .event_id = "event-1",
+        .source_version = "2.0.1-test",
+        .install_id = "install-1",
+        .session_id = "session-1",
+        .sequence = 7,
+        .observed_at = "2026-05-17T22:00:00Z",
+    });
+
+    CHECK(envelope["protocolVersion"] == "majel.ingest.v1");
+    CHECK(envelope["source"] == "stfc-community-mod");
+    CHECK(envelope["schema"] == "stfc.fleet.runtime_snapshot.v1");
+    CHECK(envelope["classification"] == "cloud_private");
+    CHECK(envelope["payload"] == fleet_payload);
+
+    const auto legacy_items = nlohmann::json::array({{{"sid", "slot-1"}}});
+    envelope = http::BuildMajelIngestEnvelope({
+        .sync_type = SyncConfig::Type::Slots,
+        .payload = legacy_items,
+        .event_id = "event-2",
+        .source_version = "2.0.1-test",
+        .install_id = "install-1",
+        .session_id = "session-1",
+        .sequence = 8,
+        .observed_at = "2026-05-17T22:00:01Z",
+    });
+
+    CHECK(envelope["schema"] == "stfc.sync.delta_batch.v1");
+    CHECK(envelope["payload"]["syncType"] == "slot");
+    CHECK(envelope["payload"]["items"] == legacy_items);
+  }
 }


### PR DESCRIPTION
## Summary
- add per-target `mode` for `legacy`, `sidecar_broker`, and `majel` outbound contracts
- wrap Majel/sidecar-broker sync payloads in `majel.ingest.v1` cloud-private envelopes
- use `Authorization: Bearer <token>` for direct Majel targets while preserving `stfc-sync-token` for legacy/sidecar targets
- add a 256 KiB Majel envelope cap so oversized events are dropped before transport
- document direct Majel vs sidecar broker behavior and add example config

## Issue #125 Scope
This is the first mod-side Majel contract slice. It does not close #125 yet. Remaining slices include config/capability snapshot emission, durable fleet assignment projection, and narrower normalized battle/roster projections.

## Validation
- `git diff --check`
- `xmake build -y stfc-mod-tests`
- `build\\windows\\x64\\releasedbg\\stfc-mod-tests.exe` -> 223/223 passed
- `xmake build -y mods`
- `pwsh -NoProfile -File .ax\\ax.ps1 validate`