### PR TITLE
[codex] Add Majel capability snapshot event

### DIFF
--- a/docs/MAJEL_INGEST_CONTRACT.md
+++ b/docs/MAJEL_INGEST_CONTRACT.md
@@ -14,6 +14,10 @@ to Majel. Both paths are opt-in sync targets.
 Sidecar broker mode remains the preferred durability/retry path. Direct Majel mode is best-effort from the mod process.
 Neither mode enables callbacks, remote settings writes, or gameplay commands.
 
+When sync starts, Majel-envelope targets receive one redacted `stfc.mod.capability_snapshot.v1` event. It lists the mod
+version, platform, enabled sync categories, target modes, and supported schemas. It does not include target URLs, tokens,
+callbacks, remote settings, raw game payloads, or endpoint credentials.
+
 ## Envelope
 
 Majel-mode and sidecar-broker-mode targets POST one event envelope per queued sync item:
@@ -40,6 +44,7 @@ Payload rules:
 - Existing legacy sync arrays are wrapped as `stfc.sync.delta_batch.v1` with `syncType` and `items`.
 - Fleet runtime snapshots emit as `stfc.fleet.runtime_snapshot.v1`.
 - Battle sync targets map to `stfc.battle.summary.v1` until a narrower battle projection is split out.
+- Majel-envelope targets also receive `stfc.mod.capability_snapshot.v1` once at sync startup.
 
 ## Privacy
 

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -44,6 +44,7 @@ public:
     Inventory,
     Jobs,
     Missions,
+    ModCapabilities,
     Officer,
     Research,
     Resources,
@@ -113,6 +114,10 @@ constexpr std::array SyncOptions{
 
 constexpr std::string to_string(const SyncConfig::Type type)
 {
+  if (type == SyncConfig::Type::ModCapabilities) {
+    return "mod_capabilities";
+  }
+
   for (const auto& opt : SyncOptions) {
     if (opt.type == type) {
       return std::string(opt.type_str);

--- a/mods/src/patches/parts/sync.cc
+++ b/mods/src/patches/parts/sync.cc
@@ -45,6 +45,7 @@
 #include "errormsg.h"
 #include "str_utils.h"
 #include "patches/sync_battle_logs.h"
+#include "patches/sync_capability_snapshot.h"
 #include "patches/sync_payload_builders.h"
 #include "patches/sync_scheduler.h"
 #include "patches/sync_transport.h"
@@ -364,5 +365,6 @@ void InstallSyncPatches()
   }
 
   StartSyncSchedulerWorker();
+  queue_mod_capability_snapshot();
   StartCombatLogWorker();
 }

--- a/mods/src/patches/sync_capability_snapshot.cc
+++ b/mods/src/patches/sync_capability_snapshot.cc
@@ -1,0 +1,84 @@
+/**
+ * @file sync_capability_snapshot.cc
+ * @brief Emits a startup capability/config snapshot to Majel-envelope sync targets.
+ */
+#include "patches/sync_capability_snapshot.h"
+
+#include "config.h"
+#include "patches/sync_scheduler.h"
+#include "patches/sync_transport_policy.h"
+#include "version.h"
+
+#include <ranges>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+const char* current_platform_name()
+{
+#if _WIN32
+  return "windows";
+#elif __APPLE__
+  return "macos";
+#elif __linux__
+  return "linux";
+#else
+  return "unknown";
+#endif
+}
+
+std::vector<std::string> enabled_sync_type_names(const SyncConfig& config)
+{
+  std::vector<std::string> names;
+  names.reserve(SyncOptions.size());
+  for (const auto& option : SyncOptions) {
+    if (config.enabled(option.type)) {
+      names.push_back(std::string(option.type_str));
+    }
+  }
+
+  return names;
+}
+
+std::vector<http::SyncTargetCapabilityInfo> majel_capability_targets(const Config& config)
+{
+  std::vector<http::SyncTargetCapabilityInfo> targets;
+
+  for (const auto& [name, target] : config.sync_targets
+       | std::views::filter([](const auto& item) { return http::SyncTargetUsesMajelEnvelope(item.second.mode); })) {
+    targets.push_back({
+        .name               = name,
+        .mode               = target.mode,
+        .enabled_sync_types = enabled_sync_type_names(target),
+    });
+  }
+
+  return targets;
+}
+} // namespace
+
+void queue_mod_capability_snapshot()
+{
+  const auto& config  = Config::Get();
+  auto        targets = majel_capability_targets(config);
+  if (targets.empty()) {
+    return;
+  }
+
+  const auto snapshot = http::BuildModCapabilitySnapshot({
+      .source_version = VER_FILE_VERSION_STR,
+      .platform       = current_platform_name(),
+      .targets        = std::move(targets),
+      .supported_schemas =
+          {
+              "stfc.mod.capability_snapshot.v1",
+              "stfc.sync.delta_batch.v1",
+              "stfc.fleet.runtime_snapshot.v1",
+              "stfc.battle.summary.v1",
+          },
+  });
+
+  queue_data(SyncConfig::Type::ModCapabilities, snapshot, true);
+}

--- a/mods/src/patches/sync_capability_snapshot.h
+++ b/mods/src/patches/sync_capability_snapshot.h
@@ -1,0 +1,7 @@
+/**
+ * @file sync_capability_snapshot.h
+ * @brief Redacted mod capability snapshot for Majel ingest targets.
+ */
+#pragma once
+
+void queue_mod_capability_snapshot();

--- a/mods/src/patches/sync_transport.cc
+++ b/mods/src/patches/sync_transport.cc
@@ -503,7 +503,8 @@ void send_data(SyncConfig::Type type, const std::string& post_data, bool is_firs
   });
 
   for (const auto& [target, target_config] : targets
-       | std::views::filter([type](const auto& target_entry) { return target_entry.second.enabled(type); })) {
+       | std::views::filter(
+           [type](const auto& target_entry) { return SyncTargetAcceptsType(target_entry.second, type); })) {
     const auto target_identifier = STR_FORMAT("{} ({})", target, to_string(type));
 
     try {

--- a/mods/src/patches/sync_transport_policy.cc
+++ b/mods/src/patches/sync_transport_policy.cc
@@ -31,6 +31,8 @@ std::string schema_for_sync_type(const SyncConfig::Type type, const nlohmann::js
       return "stfc.battle.summary.v1";
     case SyncConfig::Type::FleetRuntime:
       return "stfc.fleet.runtime_snapshot.v1";
+    case SyncConfig::Type::ModCapabilities:
+      return "stfc.mod.capability_snapshot.v1";
     default:
       return "stfc.sync.delta_batch.v1";
   }
@@ -76,6 +78,21 @@ ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSna
 bool SyncTargetUsesMajelEnvelope(const SyncTargetConfig::Mode mode)
 { return mode == SyncTargetConfig::Mode::Majel || mode == SyncTargetConfig::Mode::SidecarBroker; }
 
+bool SyncTargetAcceptsType(const SyncTargetConfig& target_config, const SyncConfig::Type type)
+{
+  if (type == SyncConfig::Type::ModCapabilities) {
+    return SyncTargetUsesMajelEnvelope(target_config.mode);
+  }
+
+  for (const auto& option : SyncOptions) {
+    if (option.type == type) {
+      return target_config.*option.option;
+    }
+  }
+
+  return false;
+}
+
 std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig& target_config,
                                                           std::string powered_by)
 {
@@ -91,6 +108,33 @@ std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig
   }
 
   return headers;
+}
+
+nlohmann::json BuildModCapabilitySnapshot(const ModCapabilitySnapshotInput& input)
+{
+  auto targets = nlohmann::json::array();
+  for (const auto& target : input.targets) {
+    targets.push_back({
+        {"name", target.name},
+        {"mode", to_string(target.mode)},
+        {"enabledSyncTypes", target.enabled_sync_types},
+    });
+  }
+
+  return nlohmann::json{
+      {"schemaVersion", "stfc.mod.capability_snapshot.v1"},
+      {"modVersion", input.source_version},
+      {"platform", input.platform},
+      {"targets", std::move(targets)},
+      {"supportedSchemas", input.supported_schemas},
+      {"privacy",
+       {
+           {"tokenRedacted", true},
+           {"containsEndpointUrls", false},
+           {"containsCallbacks", false},
+           {"readOnly", true},
+       }},
+  };
 }
 
 nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input)

--- a/mods/src/patches/sync_transport_policy.h
+++ b/mods/src/patches/sync_transport_policy.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -35,11 +36,26 @@ struct MajelIngestEnvelopeInput {
   std::string      observed_at;
 };
 
+struct SyncTargetCapabilityInfo {
+  std::string              name;
+  SyncTargetConfig::Mode   mode = SyncTargetConfig::Mode::Legacy;
+  std::vector<std::string> enabled_sync_types;
+};
+
+struct ModCapabilitySnapshotInput {
+  std::string                           source_version;
+  std::string                           platform;
+  std::vector<SyncTargetCapabilityInfo> targets;
+  std::vector<std::string>              supported_schemas;
+};
+
 [[nodiscard]] SyncTlsVerificationDecision DecideSyncTlsVerification(const SyncConfig& config);
 [[nodiscard]] ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSnapshot& snapshot,
                                                               std::string transaction_id);
 [[nodiscard]] bool SyncTargetUsesMajelEnvelope(SyncTargetConfig::Mode mode);
+[[nodiscard]] bool SyncTargetAcceptsType(const SyncTargetConfig& target_config, SyncConfig::Type type);
 [[nodiscard]] std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig& target_config,
                                                                         std::string powered_by);
+[[nodiscard]] nlohmann::json BuildModCapabilitySnapshot(const ModCapabilitySnapshotInput& input);
 [[nodiscard]] nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input);
 } // namespace http

--- a/tests/src/test_sync_transport_policy.cc
+++ b/tests/src/test_sync_transport_policy.cc
@@ -80,6 +80,49 @@ TEST_SUITE("sync_transport_policy")
     CHECK(http::SyncTargetUsesMajelEnvelope(target.mode));
   }
 
+  TEST_CASE("mod capability snapshots only target Majel-envelope transports")
+  {
+    SyncTargetConfig target;
+    target.ships = true;
+
+    CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::Ships));
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
+
+    target.mode = SyncTargetConfig::Mode::Majel;
+    CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
+
+    target.mode = SyncTargetConfig::Mode::SidecarBroker;
+    CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
+  }
+
+  TEST_CASE("mod capability snapshot is redacted and declares supported schemas")
+  {
+    const auto snapshot = http::BuildModCapabilitySnapshot({
+        .source_version = "2.0.1-test",
+        .platform = "windows",
+        .targets =
+            {
+                {
+                    .name = "majel",
+                    .mode = SyncTargetConfig::Mode::Majel,
+                    .enabled_sync_types = {"ship", "slot", "fleet_runtime"},
+                },
+            },
+        .supported_schemas = {"stfc.mod.capability_snapshot.v1", "stfc.sync.delta_batch.v1"},
+    });
+
+    CHECK(snapshot["schemaVersion"] == "stfc.mod.capability_snapshot.v1");
+    CHECK(snapshot["modVersion"] == "2.0.1-test");
+    CHECK(snapshot["platform"] == "windows");
+    CHECK(snapshot["targets"][0]["name"] == "majel");
+    CHECK(snapshot["targets"][0]["mode"] == "majel");
+    CHECK(snapshot["targets"][0]["enabledSyncTypes"][2] == "fleet_runtime");
+    CHECK(snapshot["privacy"]["tokenRedacted"] == true);
+    CHECK(snapshot["privacy"]["containsEndpointUrls"] == false);
+    CHECK(snapshot.dump().find("secret-token") == std::string::npos);
+    CHECK(snapshot.dump().find("https://") == std::string::npos);
+  }
+
   TEST_CASE("Majel envelope preserves schema payloads and wraps legacy deltas")
   {
     const auto fleet_payload = nlohmann::json{


### PR DESCRIPTION
## Summary

- emits a redacted `stfc.mod.capability_snapshot.v1` event once when sync starts for Majel-envelope targets
- gates the snapshot to `majel` and `sidecar_broker` target modes so legacy Spocks/sync targets keep their existing contract
- documents the startup capability event and adds policy tests for target filtering/redaction

## Validation

- `git diff --check`
- `xmake build -y stfc-mod-tests`
- `build\windows\x64\releasedbg\stfc-mod-tests.exe`
- `xmake build -y mods`
- `pwsh -NoProfile -File .ax\ax.ps1 validate`

Notes: AX validation returned `validationOk: true`; its review health flags noted the expected dirty worktree/game-running/deploy-fresh local conditions during validation.

Part of #125.