### PR TITLE
[codex] Add Majel fleet assignment projection

### DIFF
--- a/docs/MAJEL_INGEST_CONTRACT.md
+++ b/docs/MAJEL_INGEST_CONTRACT.md
@@ -42,6 +42,7 @@ Payload rules:
 
 - Payloads that already carry `schemaVersion` or `schema` keep that schema and payload shape.
 - Existing legacy sync arrays are wrapped as `stfc.sync.delta_batch.v1` with `syncType` and `items`.
+- Fleet preset slot deltas also emit Majel-only `stfc.fleet.assignment_snapshot.v1` events.
 - Fleet runtime snapshots emit as `stfc.fleet.runtime_snapshot.v1`.
 - Battle sync targets map to `stfc.battle.summary.v1` until a narrower battle projection is split out.
 - Majel-envelope targets also receive `stfc.mod.capability_snapshot.v1` once at sync startup.

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -44,6 +44,7 @@ public:
     Inventory,
     Jobs,
     Missions,
+    FleetAssignments,
     ModCapabilities,
     Officer,
     Research,
@@ -116,6 +117,9 @@ constexpr std::string to_string(const SyncConfig::Type type)
 {
   if (type == SyncConfig::Type::ModCapabilities) {
     return "mod_capabilities";
+  }
+  if (type == SyncConfig::Type::FleetAssignments) {
+    return "fleet_assignments";
   }
 
   for (const auto& opt : SyncOptions) {

--- a/mods/src/patches/sync_capability_snapshot.cc
+++ b/mods/src/patches/sync_capability_snapshot.cc
@@ -75,6 +75,7 @@ void queue_mod_capability_snapshot()
           {
               "stfc.mod.capability_snapshot.v1",
               "stfc.sync.delta_batch.v1",
+              "stfc.fleet.assignment_snapshot.v1",
               "stfc.fleet.runtime_snapshot.v1",
               "stfc.battle.summary.v1",
           },

--- a/mods/src/patches/sync_payload_builders.cc
+++ b/mods/src/patches/sync_payload_builders.cc
@@ -9,6 +9,7 @@
 #include "patches/sync_battle_logs.h"
 #include "patches/sync_scheduler.h"
 #include "patches/sync_transport.h"
+#include "patches/sync_transport_policy.h"
 
 #include <Digit.PrimeServer.Models.pb.h>
 #include <prime/EntityGroup.h>
@@ -647,6 +648,19 @@ void process_global_active_buffs(std::unique_ptr<std::string>&& bytes)
 static std::unordered_map<int64_t, int64_t> slot_states;
 static std::mutex                           slot_states_mtx;
 
+static void queue_fleet_assignment_snapshots(const nlohmann::json& slot_array)
+{
+  for (const auto& slot_delta : slot_array) {
+    if (slot_delta.value("slot_type", -1) != Digit::PrimeServer::Models::SLOTTYPE_FLEETPRESET) {
+      continue;
+    }
+
+    if (auto snapshot = http::BuildFleetAssignmentSnapshot(slot_delta); snapshot.has_value()) {
+      queue_data(SyncConfig::Type::FleetAssignments, snapshot.value());
+    }
+  }
+}
+
 inline std::optional<std::chrono::time_point<std::chrono::system_clock>> parse_timestamp(const std::string& timestamp)
 {
 #ifdef _WIN32
@@ -747,6 +761,7 @@ void process_entity_slots(std::unique_ptr<std::string>&& bytes)
 
     if (!slot_array.empty()) {
       queue_data(SyncConfig::Type::Slots, slot_array);
+      queue_fleet_assignment_snapshots(slot_array);
     }
   } else {
     spdlog::error("Failed to parse entity slots");
@@ -845,6 +860,7 @@ void process_entity_slots_rtc(std::unique_ptr<std::string>&& json_payload)
                               {"params", slot_params}});
 
         queue_data(SyncConfig::Type::Slots, slot_array);
+        queue_fleet_assignment_snapshots(slot_array);
       }
     }
   } catch (json::exception& e) {

--- a/mods/src/patches/sync_transport_policy.cc
+++ b/mods/src/patches/sync_transport_policy.cc
@@ -29,6 +29,8 @@ std::string schema_for_sync_type(const SyncConfig::Type type, const nlohmann::js
     case SyncConfig::Type::Battles:
     case SyncConfig::Type::BattlelogsRealtime:
       return "stfc.battle.summary.v1";
+    case SyncConfig::Type::FleetAssignments:
+      return "stfc.fleet.assignment_snapshot.v1";
     case SyncConfig::Type::FleetRuntime:
       return "stfc.fleet.runtime_snapshot.v1";
     case SyncConfig::Type::ModCapabilities:
@@ -83,6 +85,9 @@ bool SyncTargetAcceptsType(const SyncTargetConfig& target_config, const SyncConf
   if (type == SyncConfig::Type::ModCapabilities) {
     return SyncTargetUsesMajelEnvelope(target_config.mode);
   }
+  if (type == SyncConfig::Type::FleetAssignments) {
+    return SyncTargetUsesMajelEnvelope(target_config.mode) && target_config.slots;
+  }
 
   for (const auto& option : SyncOptions) {
     if (option.type == type) {
@@ -134,6 +139,79 @@ nlohmann::json BuildModCapabilitySnapshot(const ModCapabilitySnapshotInput& inpu
            {"containsCallbacks", false},
            {"readOnly", true},
        }},
+  };
+}
+
+static nlohmann::json json_id_to_string(const nlohmann::json& value)
+{
+  if (value.is_null() || value.is_discarded()) {
+    return nullptr;
+  }
+  if (value.is_string()) {
+    return value;
+  }
+  if (value.is_number_unsigned()) {
+    return std::to_string(value.get<uint64_t>());
+  }
+  if (value.is_number_integer()) {
+    return std::to_string(value.get<int64_t>());
+  }
+
+  return nullptr;
+}
+
+static nlohmann::json officer_ids_to_strings(const nlohmann::json& value)
+{
+  auto officer_ids = nlohmann::json::array();
+  if (!value.is_array()) {
+    return officer_ids;
+  }
+
+  for (const auto& officer_id : value) {
+    if (auto normalized = json_id_to_string(officer_id); !normalized.is_null()) {
+      officer_ids.push_back(std::move(normalized));
+    }
+  }
+
+  return officer_ids;
+}
+
+std::optional<nlohmann::json> BuildFleetAssignmentSnapshot(const nlohmann::json& slot_delta)
+{
+  if (!slot_delta.is_object()) {
+    return std::nullopt;
+  }
+
+  const auto params = slot_delta.find("params");
+  if (params == slot_delta.end() || !params->is_object()) {
+    return std::nullopt;
+  }
+
+  const auto setup = params->find("setup");
+  if (setup == params->end() || !setup->is_array()) {
+    return std::nullopt;
+  }
+
+  auto assignments = nlohmann::json::array();
+  for (const auto& item : *setup) {
+    if (!item.is_object()) {
+      continue;
+    }
+
+    assignments.push_back({
+        {"drydockId", json_id_to_string(item.value("drydock_id", nlohmann::json(nullptr)))},
+        {"shipId", json_id_to_string(item.value("ship_id", nlohmann::json(nullptr)))},
+        {"officerIds", officer_ids_to_strings(item.value("officer_ids", nlohmann::json::array()))},
+    });
+  }
+
+  return nlohmann::json{
+      {"schemaVersion", "stfc.fleet.assignment_snapshot.v1"},
+      {"sourceSlotId", json_id_to_string(slot_delta.value("sid", nlohmann::json(nullptr)))},
+      {"sourceSlotSpecId", slot_delta.value("spec_id", nlohmann::json(nullptr))},
+      {"presetName", params->value("name", "")},
+      {"presetOrder", params->value("order", nlohmann::json(nullptr))},
+      {"assignments", std::move(assignments)},
   };
 }
 

--- a/mods/src/patches/sync_transport_policy.h
+++ b/mods/src/patches/sync_transport_policy.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -57,5 +58,6 @@ struct ModCapabilitySnapshotInput {
 [[nodiscard]] std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig& target_config,
                                                                         std::string powered_by);
 [[nodiscard]] nlohmann::json BuildModCapabilitySnapshot(const ModCapabilitySnapshotInput& input);
+[[nodiscard]] std::optional<nlohmann::json> BuildFleetAssignmentSnapshot(const nlohmann::json& slot_delta);
 [[nodiscard]] nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input);
 } // namespace http

--- a/tests/src/test_sync_transport_policy.cc
+++ b/tests/src/test_sync_transport_policy.cc
@@ -84,15 +84,22 @@ TEST_SUITE("sync_transport_policy")
   {
     SyncTargetConfig target;
     target.ships = true;
+    target.slots = true;
 
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::Ships));
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
 
     target.mode = SyncTargetConfig::Mode::Majel;
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
+    CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
 
+    target.slots = false;
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
+    target.slots = true;
     target.mode = SyncTargetConfig::Mode::SidecarBroker;
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
+    CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
   }
 
   TEST_CASE("mod capability snapshot is redacted and declares supported schemas")
@@ -121,6 +128,48 @@ TEST_SUITE("sync_transport_policy")
     CHECK(snapshot["privacy"]["containsEndpointUrls"] == false);
     CHECK(snapshot.dump().find("secret-token") == std::string::npos);
     CHECK(snapshot.dump().find("https://") == std::string::npos);
+  }
+
+  TEST_CASE("fleet assignment snapshot projects existing fleet preset slot deltas")
+  {
+    const auto slot_delta = nlohmann::json{
+        {"type", "slot"},
+        {"sid", 123456},
+        {"slot_type", 7},
+        {"spec_id", 789},
+        {"item_id", nullptr},
+        {"params",
+         {
+             {"name", "Freebooter X"},
+             {"order", 2},
+             {"setup",
+              nlohmann::json::array({
+                  {
+                      {"drydock_id", 1},
+                      {"ship_id", 987654321},
+                      {"officer_ids", nlohmann::json::array({111, 222, 333})},
+                  },
+                  {
+                      {"drydock_id", 2},
+                      {"ship_id", nullptr},
+                      {"officer_ids", nlohmann::json::array()},
+                  },
+              })},
+         }},
+    };
+
+    const auto snapshot = http::BuildFleetAssignmentSnapshot(slot_delta);
+    REQUIRE(snapshot.has_value());
+    CHECK((*snapshot)["schemaVersion"] == "stfc.fleet.assignment_snapshot.v1");
+    CHECK((*snapshot)["sourceSlotId"] == "123456");
+    CHECK((*snapshot)["sourceSlotSpecId"] == 789);
+    CHECK((*snapshot)["presetName"] == "Freebooter X");
+    CHECK((*snapshot)["presetOrder"] == 2);
+    CHECK((*snapshot)["assignments"][0]["drydockId"] == "1");
+    CHECK((*snapshot)["assignments"][0]["shipId"] == "987654321");
+    CHECK((*snapshot)["assignments"][0]["officerIds"] == nlohmann::json::array({"111", "222", "333"}));
+    CHECK((*snapshot)["assignments"][1]["drydockId"] == "2");
+    CHECK((*snapshot)["assignments"][1]["shipId"].is_null());
   }
 
   TEST_CASE("Majel envelope preserves schema payloads and wraps legacy deltas")


### PR DESCRIPTION
## Summary

- projects existing `SLOTTYPE_FLEETPRESET` slot deltas into `stfc.fleet.assignment_snapshot.v1` Majel events
- keeps legacy `slot` sync payloads unchanged for Spocks/other existing consumers
- gates fleet assignment projection to Majel-envelope targets with `slots` enabled
- documents the assignment schema and advertises it in the startup capability snapshot

## Validation

- `git diff --check`
- `xmake build -y stfc-mod-tests`
- `build\windows\x64\release\stfc-mod-tests.exe`
- `xmake build -y mods`
- `pwsh -NoProfile -File .ax\ax.ps1 validate`

Notes: AX validation returned `validationOk: true`; its review health flags noted the expected dirty worktree/game-running/deploy-fresh local conditions during validation.

Part of #125.