### PR TITLE
[codex] Sync fleet runtime to sidecar

### DIFF
--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -317,10 +317,10 @@ void fleet_notifications_init()
   notification_audio_init();
 }
 
-void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
+const char* fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
 {
   if (!fleet) {
-    return;
+    return nullptr;
   }
 
   auto fleetId        = fleet->Id;
@@ -338,6 +338,8 @@ void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
     hadPreviousState = true;
   }
 
+  const char* runtimeTriggerSource = nullptr;
+
   s_fleet_bar_ship_names[fleetId] = shipName;
   if (!resourceName.empty()) {
     s_fleet_bar_resource_names[fleetId] = resourceName;
@@ -346,9 +348,12 @@ void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
 
   if (hadPreviousState && previousState != currentState) {
     maybe_notify_fleet_bar_transition(fleetId, shipName, previousState, currentState, resourceName, cargoText);
+    runtimeTriggerSource = fleet_runtime_trigger_source_for_state_transition(static_cast<int>(previousState),
+                                                                             static_cast<int>(currentState));
   }
 
   s_fleet_bar_states[fleetId] = currentState;
+  return runtimeTriggerSource;
 }
 
 void fleet_notifications_observe_node_depleted(int64_t fleetId)

--- a/mods/src/patches/fleet_notifications.h
+++ b/mods/src/patches/fleet_notifications.h
@@ -22,10 +22,11 @@ struct FleetPlayerData;
 void fleet_notifications_init();
 
 /**
- * @brief Observe a fleet-bar state refresh and emit notifications as needed.
+ * @brief Observe a fleet-bar state refresh, emit notifications, and report a meaningful runtime trigger source.
  * @param fleet The fleet currently bound to the widget.
+ * @return A high-signal runtime trigger source name for meaningful state transitions, or nullptr.
  */
-void fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet);
+const char* fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet);
 
 /**
  * @brief Observe a mining node depletion event for a fleet.

--- a/mods/src/patches/fleet_runtime_diagnostics.cc
+++ b/mods/src/patches/fleet_runtime_diagnostics.cc
@@ -1,0 +1,348 @@
+/**
+ * @file fleet_runtime_diagnostics.cc
+ * @brief Redacted fleet-runtime diagnostics for logs and recent-event breadcrumbs.
+ */
+#include "patches/fleet_runtime_diagnostics.h"
+
+#ifndef STFC_MOD_TESTS
+#include "patches/live_debug_event_dispatcher.h"
+#endif
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cctype>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace {
+using json = nlohmann::json;
+
+std::mutex                     s_state_mutex;
+FleetRuntimeDiagnosticsSnapshot s_snapshot;
+std::atomic_uint64_t           s_next_local_sequence{0};
+
+int64_t current_time_millis_utc()
+{
+  const auto now = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+}
+
+std::string ascii_lower(std::string_view text)
+{
+  std::string lowered;
+  lowered.reserve(text.size());
+
+  for (const auto ch : text) {
+    lowered.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+  }
+
+  return lowered;
+}
+
+std::string slot_state_label(const FleetSlotObservation& slot)
+{
+  if (!slot.present) {
+    return "empty";
+  }
+
+  auto label = ascii_lower(fleet_state_name_from_value(slot.currentState));
+  if (label.empty() || label == "none") {
+    return "unknown";
+  }
+
+  return label;
+}
+
+std::string build_status_summary(const std::array<FleetSlotObservation, kFleetIndexMax>& slots)
+{
+  std::map<std::string, int> counts;
+  for (const auto& slot : slots) {
+    ++counts[slot_state_label(slot)];
+  }
+
+  std::ostringstream stream;
+  bool               first = true;
+  for (const auto& entry : counts) {
+    if (!first) {
+      stream << ",";
+    }
+    first = false;
+    stream << entry.first << ":" << entry.second;
+  }
+
+  return stream.str();
+}
+
+template <typename Mutator>
+FleetRuntimeDiagnosticsSnapshot update_snapshot(Mutator&& mutator)
+{
+  std::lock_guard<std::mutex> lock(s_state_mutex);
+  mutator(s_snapshot);
+  return s_snapshot;
+}
+
+FleetRuntimeDiagnosticsSnapshot snapshot_copy()
+{
+  std::lock_guard<std::mutex> lock(s_state_mutex);
+  return s_snapshot;
+}
+
+json snapshot_to_json(const FleetRuntimeDiagnosticsSnapshot& snapshot)
+{
+  return json{{"triggerCount", snapshot.triggerCount},
+              {"captureAttemptCount", snapshot.captureAttemptCount},
+              {"suppressedUnchangedCount", snapshot.suppressedUnchangedCount},
+              {"suppressedNonMeaningfulCount", snapshot.suppressedNonMeaningfulCount},
+              {"schedulerQueueAcceptedCount", snapshot.schedulerQueueAcceptedCount},
+              {"schedulerQueueDroppedCount", snapshot.schedulerQueueDroppedCount},
+              {"targetQueueAcceptedCount", snapshot.targetQueueAcceptedCount},
+              {"targetQueueDroppedCount", snapshot.targetQueueDroppedCount},
+              {"postSuccessCount", snapshot.postSuccessCount},
+              {"postFailureCount", snapshot.postFailureCount},
+              {"latestTriggerSource", snapshot.latestTriggerSource},
+              {"latestTriggerAtMs", snapshot.latestTriggerAtMs},
+              {"latestLocalSequence", snapshot.latestLocalSequence},
+              {"latestObservedAtMs", snapshot.latestObservedAtMs}};
+}
+
+json with_summary(json details, const FleetRuntimeDiagnosticsSnapshot& snapshot)
+{
+  details["summary"] = snapshot_to_json(snapshot);
+  return details;
+}
+
+void record_recent_event(std::string_view kind, json details)
+{
+#ifndef STFC_MOD_TESTS
+  live_debug_events::RecordEvent(kind, std::move(details));
+#else
+  (void)kind;
+  (void)details;
+#endif
+}
+} // namespace
+
+void fleet_runtime_diagnostics_trigger(std::string_view source)
+{
+  const auto trigger_at_ms = current_time_millis_utc();
+  const auto snapshot = update_snapshot([&](auto& state) {
+    ++state.triggerCount;
+    state.latestTriggerSource = std::string(source);
+    state.latestTriggerAtMs = trigger_at_ms;
+  });
+
+  spdlog::info("[FleetRuntimeTrigger] source={} triggerMs={}", source, trigger_at_ms);
+  record_recent_event("fleet-runtime-trigger",
+                      with_summary(json{{"source", source}, {"triggerMs", trigger_at_ms}}, snapshot));
+}
+
+void fleet_runtime_diagnostics_capture_attempt(std::string_view source, int64_t capture_duration_ms)
+{
+  const auto snapshot = update_snapshot([&](auto& state) { ++state.captureAttemptCount; });
+
+  spdlog::info("[FleetRuntimeCapture] source={} status=attempt durationMs={}", source, capture_duration_ms);
+  record_recent_event("fleet-runtime-capture",
+                      with_summary(json{{"source", source},
+                                        {"status", "attempt"},
+                                        {"durationMs", capture_duration_ms}},
+                                   snapshot));
+}
+
+void fleet_runtime_diagnostics_suppressed_unchanged(std::string_view source, int64_t capture_duration_ms)
+{
+  const auto snapshot = update_snapshot([&](auto& state) { ++state.suppressedUnchangedCount; });
+
+  spdlog::info("[FleetRuntimeSuppressed] source={} reason=unchanged durationMs={}", source, capture_duration_ms);
+  record_recent_event("fleet-runtime-suppressed",
+                      with_summary(json{{"source", source},
+                                        {"reason", "unchanged"},
+                                        {"durationMs", capture_duration_ms}},
+                                   snapshot));
+}
+
+void fleet_runtime_diagnostics_suppressed_non_meaningful(std::string_view source, int64_t capture_duration_ms)
+{
+  const auto snapshot = update_snapshot([&](auto& state) { ++state.suppressedNonMeaningfulCount; });
+
+  spdlog::info("[FleetRuntimeSuppressed] source={} reason=non-meaningful durationMs={}", source,
+               capture_duration_ms);
+  record_recent_event("fleet-runtime-suppressed",
+                      with_summary(json{{"source", source},
+                                        {"reason", "non-meaningful"},
+                                        {"durationMs", capture_duration_ms}},
+                                   snapshot));
+}
+
+FleetRuntimeTraceContext fleet_runtime_diagnostics_make_trace(
+    std::string_view source,
+    const FleetObservation&,
+    const std::array<FleetSlotObservation, kFleetIndexMax>& slots,
+    const int64_t observed_at_ms,
+    const int64_t capture_duration_ms)
+{
+  FleetRuntimeTraceContext trace;
+  trace.localSequence = s_next_local_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+  trace.observedAtMs = observed_at_ms;
+  trace.captureDurationMs = capture_duration_ms;
+  trace.slotCount = static_cast<int>(slots.size());
+  trace.presentShipCount = static_cast<int>(std::count_if(slots.begin(), slots.end(), [](const auto& slot) {
+    return slot.present;
+  }));
+  trace.source = std::string(source);
+  trace.statusSummary = build_status_summary(slots);
+
+  update_snapshot([&](auto& state) {
+    state.latestLocalSequence = trace.localSequence;
+    state.latestObservedAtMs = observed_at_ms;
+  });
+
+  return trace;
+}
+
+void fleet_runtime_diagnostics_scheduler_queue(const FleetRuntimeTraceContext& trace,
+                                               const bool accepted,
+                                               const size_t queue_depth,
+                                               const std::string_view reason)
+{
+  const auto snapshot = update_snapshot([&](auto& state) {
+    if (accepted) {
+      ++state.schedulerQueueAcceptedCount;
+    } else {
+      ++state.schedulerQueueDroppedCount;
+    }
+  });
+
+  if (accepted) {
+    spdlog::info(
+        "[FleetRuntimeQueued] stage=scheduler source={} localSeq={} observedAtMs={} slotCount={} presentCount={} "
+        "states={} depth={} accepted=true",
+        trace.source, trace.localSequence, trace.observedAtMs, trace.slotCount, trace.presentShipCount,
+        trace.statusSummary, queue_depth);
+  } else {
+    spdlog::warn("[FleetRuntimeQueued] stage=scheduler source={} localSeq={} observedAtMs={} depth={} "
+                 "accepted=false reason={}",
+                 trace.source, trace.localSequence, trace.observedAtMs, queue_depth,
+                 reason.empty() ? "unknown" : reason);
+  }
+
+  auto details = json{{"stage", "scheduler"},
+                      {"accepted", accepted},
+                      {"source", trace.source},
+                      {"localSequence", trace.localSequence},
+                      {"observedAtMs", trace.observedAtMs},
+                      {"slotCount", trace.slotCount},
+                      {"presentShipCount", trace.presentShipCount},
+                      {"statusSummary", trace.statusSummary},
+                      {"queueDepth", queue_depth}};
+  if (!reason.empty()) {
+    details["reason"] = reason;
+  }
+  record_recent_event("fleet-runtime-queued", with_summary(std::move(details), snapshot));
+}
+
+void fleet_runtime_diagnostics_target_queue(const FleetRuntimeTraceContext& trace,
+                                            const std::string_view target,
+                                            const std::string_view mode,
+                                            const bool accepted,
+                                            const size_t queue_depth,
+                                            const uint64_t dropped_count,
+                                            const std::string_view reason)
+{
+  const auto snapshot = update_snapshot([&](auto& state) {
+    if (accepted) {
+      ++state.targetQueueAcceptedCount;
+    } else {
+      ++state.targetQueueDroppedCount;
+    }
+  });
+
+  if (accepted) {
+    spdlog::info(
+        "[FleetRuntimeQueued] stage=target source={} localSeq={} target={} mode={} depth={} accepted=true",
+        trace.source, trace.localSequence, target, mode, queue_depth);
+  } else {
+    spdlog::warn(
+        "[FleetRuntimeQueued] stage=target source={} localSeq={} target={} mode={} depth={} dropped={} "
+        "accepted=false reason={}",
+        trace.source, trace.localSequence, target, mode, queue_depth, dropped_count,
+        reason.empty() ? "unknown" : reason);
+  }
+
+  auto details = json{{"stage", "target"},
+                      {"accepted", accepted},
+                      {"source", trace.source},
+                      {"localSequence", trace.localSequence},
+                      {"observedAtMs", trace.observedAtMs},
+                      {"slotCount", trace.slotCount},
+                      {"presentShipCount", trace.presentShipCount},
+                      {"statusSummary", trace.statusSummary},
+                      {"target", target},
+                      {"mode", mode},
+                      {"queueDepth", queue_depth},
+                      {"droppedCount", dropped_count}};
+  if (!reason.empty()) {
+    details["reason"] = reason;
+  }
+  record_recent_event("fleet-runtime-queued", with_summary(std::move(details), snapshot));
+}
+
+void fleet_runtime_diagnostics_post_result(const FleetRuntimeTraceContext& trace,
+                                           const std::string_view target,
+                                           const std::string_view mode,
+                                           const bool success,
+                                           const long status_code,
+                                           const std::string_view error_class,
+                                           const int64_t elapsed_ms)
+{
+  const auto snapshot = update_snapshot([&](auto& state) {
+    if (success) {
+      ++state.postSuccessCount;
+    } else {
+      ++state.postFailureCount;
+    }
+  });
+
+  if (success) {
+    spdlog::info(
+        "[FleetRuntimePost] source={} localSeq={} target={} mode={} outcome=success statusCode={} elapsedMs={}",
+        trace.source, trace.localSequence, target, mode, status_code, elapsed_ms);
+  } else {
+    spdlog::warn(
+        "[FleetRuntimePost] source={} localSeq={} target={} mode={} outcome=failure statusCode={} errorClass={} "
+        "elapsedMs={}",
+        trace.source, trace.localSequence, target, mode, status_code, error_class, elapsed_ms);
+  }
+
+  record_recent_event("fleet-runtime-post",
+                      with_summary(json{{"source", trace.source},
+                                        {"localSequence", trace.localSequence},
+                                        {"observedAtMs", trace.observedAtMs},
+                                        {"target", target},
+                                        {"mode", mode},
+                                        {"success", success},
+                                        {"statusCode", status_code},
+                                        {"errorClass", error_class},
+                                        {"elapsedMs", elapsed_ms}},
+                                   snapshot));
+}
+
+FleetRuntimeDiagnosticsSnapshot fleet_runtime_diagnostics_snapshot()
+{
+  return snapshot_copy();
+}
+
+void fleet_runtime_diagnostics_reset()
+{
+  {
+    std::lock_guard<std::mutex> lock(s_state_mutex);
+    s_snapshot = {};
+  }
+  s_next_local_sequence.store(0, std::memory_order_relaxed);
+}

--- a/mods/src/patches/fleet_runtime_diagnostics.h
+++ b/mods/src/patches/fleet_runtime_diagnostics.h
@@ -1,0 +1,75 @@
+/**
+ * @file fleet_runtime_diagnostics.h
+ * @brief Redacted fleet-runtime diagnostics for logs and recent-event breadcrumbs.
+ */
+#pragma once
+
+#include "patches/live_debug_fleet_runtime_observers.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+struct FleetRuntimeTraceContext {
+  uint64_t    localSequence = 0;
+  int64_t     observedAtMs = 0;
+  int64_t     captureDurationMs = 0;
+  int         slotCount = 0;
+  int         presentShipCount = 0;
+  std::string source;
+  std::string statusSummary;
+};
+
+struct FleetRuntimeDiagnosticsSnapshot {
+  uint64_t    triggerCount = 0;
+  uint64_t    captureAttemptCount = 0;
+  uint64_t    suppressedUnchangedCount = 0;
+  uint64_t    suppressedNonMeaningfulCount = 0;
+  uint64_t    schedulerQueueAcceptedCount = 0;
+  uint64_t    schedulerQueueDroppedCount = 0;
+  uint64_t    targetQueueAcceptedCount = 0;
+  uint64_t    targetQueueDroppedCount = 0;
+  uint64_t    postSuccessCount = 0;
+  uint64_t    postFailureCount = 0;
+  std::string latestTriggerSource;
+  int64_t     latestTriggerAtMs = 0;
+  uint64_t    latestLocalSequence = 0;
+  int64_t     latestObservedAtMs = 0;
+};
+
+void fleet_runtime_diagnostics_trigger(std::string_view source);
+void fleet_runtime_diagnostics_capture_attempt(std::string_view source, int64_t capture_duration_ms);
+void fleet_runtime_diagnostics_suppressed_unchanged(std::string_view source, int64_t capture_duration_ms);
+void fleet_runtime_diagnostics_suppressed_non_meaningful(std::string_view source, int64_t capture_duration_ms);
+
+FleetRuntimeTraceContext fleet_runtime_diagnostics_make_trace(
+    std::string_view source,
+    const FleetObservation& fleet,
+    const std::array<FleetSlotObservation, kFleetIndexMax>& slots,
+    int64_t observed_at_ms,
+    int64_t capture_duration_ms);
+
+void fleet_runtime_diagnostics_scheduler_queue(const FleetRuntimeTraceContext& trace,
+                                               bool accepted,
+                                               size_t queue_depth,
+                                               std::string_view reason = {});
+
+void fleet_runtime_diagnostics_target_queue(const FleetRuntimeTraceContext& trace,
+                                            std::string_view target,
+                                            std::string_view mode,
+                                            bool accepted,
+                                            size_t queue_depth,
+                                            uint64_t dropped_count = 0,
+                                            std::string_view reason = {});
+
+void fleet_runtime_diagnostics_post_result(const FleetRuntimeTraceContext& trace,
+                                           std::string_view target,
+                                           std::string_view mode,
+                                           bool success,
+                                           long status_code,
+                                           std::string_view error_class,
+                                           int64_t elapsed_ms);
+
+FleetRuntimeDiagnosticsSnapshot fleet_runtime_diagnostics_snapshot();
+void                            fleet_runtime_diagnostics_reset();

--- a/mods/src/patches/fleet_runtime_sync.cc
+++ b/mods/src/patches/fleet_runtime_sync.cc
@@ -4,16 +4,21 @@
  */
 #include "patches/fleet_runtime_sync.h"
 
+#include "config.h"
+#include "patches/fleet_runtime_diagnostics.h"
 #include "patches/live_debug_fleet_runtime_observers.h"
 #include "patches/sync_scheduler.h"
 
 #include <nlohmann/json.hpp>
+
+#include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <array>
 #include <chrono>
 #include <compare>
 #include <cstdint>
+#include <exception>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -152,14 +157,14 @@ json slots_to_json(const std::array<FleetSlotObservation, kFleetIndexMax>& slots
   return result;
 }
 
-json build_snapshot_payload(std::string_view source, const FleetObservation& fleet,
+json build_snapshot_payload(std::string_view source, int64_t observed_at_ms, const FleetObservation& fleet,
                             const std::array<FleetSlotObservation, kFleetIndexMax>& slots)
 {
   return json{
       {"type", "fleet.runtime"},
       {"schemaVersion", "stfc.fleet.runtime_snapshot.v1"},
       {"source", source},
-      {"observedAtMs", current_time_millis_utc()},
+      {"observedAtMs", observed_at_ms},
       {"fleetBarTracked", fleet.tracked},
       {"selectedIndex", fleet.selectedIndex},
       {"fleet", fleet_to_json(fleet)},
@@ -168,21 +173,50 @@ json build_snapshot_payload(std::string_view source, const FleetObservation& fle
 }
 } // namespace
 
+void fleet_runtime_sync_trigger(std::string_view source)
+{
+  if (!Config::Get().installSyncPatches || !Config::Get().sync_options.fleet_runtime) {
+    return;
+  }
+
+  fleet_runtime_diagnostics_trigger(source);
+
+  try {
+    fleet_runtime_sync_capture(source);
+  } catch (const std::exception& ex) {
+    spdlog::error("[FleetRuntimeSync] source={} status=failed error='{}'", source, ex.what());
+  } catch (...) {
+    spdlog::error("[FleetRuntimeSync] source={} status=failed error='unknown exception'", source);
+  }
+}
+
 void fleet_runtime_sync_capture(std::string_view source)
 {
   static std::optional<FleetStateKey> last_state;
 
+  const auto capture_started_at = std::chrono::steady_clock::now();
   const auto snapshot = observe_fleet_runtime_snapshot();
   const auto state = make_state_key(snapshot.fleet, snapshot.slots);
+  const auto observed_at_ms = current_time_millis_utc();
+  const auto capture_duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                       std::chrono::steady_clock::now() - capture_started_at)
+                                       .count();
+
+  fleet_runtime_diagnostics_capture_attempt(source, capture_duration_ms);
 
   if (!is_meaningful_state(state) && !last_state.has_value()) {
+    fleet_runtime_diagnostics_suppressed_non_meaningful(source, capture_duration_ms);
     return;
   }
 
   if (last_state.has_value() && *last_state == state) {
+    fleet_runtime_diagnostics_suppressed_unchanged(source, capture_duration_ms);
     return;
   }
 
   last_state = state;
-  queue_data(SyncConfig::Type::FleetRuntime, build_snapshot_payload(source, snapshot.fleet, snapshot.slots));
+  const auto trace = fleet_runtime_diagnostics_make_trace(source, snapshot.fleet, snapshot.slots, observed_at_ms,
+                                                          capture_duration_ms);
+  queue_data(SyncConfig::Type::FleetRuntime,
+             build_snapshot_payload(source, observed_at_ms, snapshot.fleet, snapshot.slots), false, trace);
 }

--- a/mods/src/patches/fleet_runtime_sync.h
+++ b/mods/src/patches/fleet_runtime_sync.h
@@ -7,6 +7,11 @@
 #include <string_view>
 
 /**
+ * @brief Process a trigger source through diagnostics and change-gated capture when fleet runtime sync is enabled.
+ */
+void fleet_runtime_sync_trigger(std::string_view source);
+
+/**
  * @brief Observe current fleet-bar runtime state and enqueue a sync snapshot when it meaningfully changes.
  */
 void fleet_runtime_sync_capture(std::string_view source);

--- a/mods/src/patches/live_debug_fleet_change_events.cc
+++ b/mods/src/patches/live_debug_fleet_change_events.cc
@@ -8,6 +8,8 @@
 
 #include "prime/FleetPlayerData.h"
 
+#include "testable_functions.h"
+
 #include <nlohmann/json.hpp>
 
 namespace {
@@ -22,35 +24,8 @@ const char* classify_fleet_slot_transition_kind(const FleetSlotObservation& prev
   if (previous.present && !current.present) {
     return "fleet-slot-cleared";
   }
-  if (from == static_cast<int>(FleetState::Docked) && to == static_cast<int>(FleetState::Repairing)) {
-    return "fleet-slot-repair-started";
-  }
-  if (from == static_cast<int>(FleetState::Repairing) && to == static_cast<int>(FleetState::Docked)) {
-    return "fleet-slot-repair-completed";
-  }
-  if (to == static_cast<int>(FleetState::Battling) && from != static_cast<int>(FleetState::Battling)) {
-    return "fleet-slot-combat-started";
-  }
-  if (from == static_cast<int>(FleetState::Battling) && to != static_cast<int>(FleetState::Battling)) {
-    return "fleet-slot-combat-ended";
-  }
-  if (to == static_cast<int>(FleetState::WarpCharging)) {
-    return "fleet-slot-warp-started";
-  }
-  if (to == static_cast<int>(FleetState::Warping)) {
-    return "fleet-slot-warp-engaged";
-  }
-  if (from == static_cast<int>(FleetState::Warping) && to == static_cast<int>(FleetState::Impulsing)) {
-    return "fleet-slot-arrived-in-system";
-  }
-  if (to == static_cast<int>(FleetState::Docked) && from != static_cast<int>(FleetState::Repairing)) {
-    return "fleet-slot-docked";
-  }
-  if (to == static_cast<int>(FleetState::Mining) && from != static_cast<int>(FleetState::Mining)) {
-    return "fleet-slot-mining-started";
-  }
-  if (from == static_cast<int>(FleetState::Mining) && to != static_cast<int>(FleetState::Mining)) {
-    return "fleet-slot-mining-stopped";
+  if (const auto* kind = fleet_runtime_trigger_source_for_state_transition(from, to)) {
+    return kind;
   }
 
   return "fleet-slot-state-changed";

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -10,6 +10,7 @@
 #include "errormsg.h"
 
 #include <patches/fleet_notifications.h>
+#include <patches/fleet_runtime_sync.h>
 #include <patches/live_debug.h>
 #include <il2cpp/il2cpp_helper.h>
 #include <prime/FleetPlayerData.h>
@@ -78,7 +79,9 @@ FleetPlayerData* fleet_bar_widget_context(void* self)
 void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
 {
   auto* fleet = fleet_bar_widget_context(self);
-  fleet_notifications_observe_fleet_bar(fleet);
+  if (const auto* trigger_source = fleet_notifications_observe_fleet_bar(fleet)) {
+    fleet_runtime_sync_trigger(trigger_source);
+  }
 
   original(self);
 }

--- a/mods/src/patches/parts/live_debug.cc
+++ b/mods/src/patches/parts/live_debug.cc
@@ -14,6 +14,7 @@
 #include "patches/live_debug_fleet_runtime_observers.h"
 #include "patches/live_debug_fleet_runtime_serializers.h"
 #include "patches/live_debug_fleet_serializers.h"
+#include "patches/fleet_runtime_diagnostics.h"
 #include "patches/fleet_runtime_sync.h"
 #include "patches/live_debug_observation_compare.h"
 #include "patches/live_debug_recent_event_requests.h"
@@ -725,21 +726,6 @@ void capture_recent_model_events(std::string_view source)
   g_last_fleet_slots = fleet_slots;
 }
 
-void capture_fleet_runtime_sync_event(std::string_view source)
-{
-  if (!Config::Get().installSyncPatches || !Config::Get().sync_options.fleet_runtime) {
-    return;
-  }
-
-  try {
-    fleet_runtime_sync_capture(source);
-  } catch (const std::exception& ex) {
-    spdlog::error("[FleetRuntimeSync] source={} status=failed error='{}'", source, ex.what());
-  } catch (...) {
-    spdlog::error("[FleetRuntimeSync] source={} status=failed error='unknown exception'", source);
-  }
-}
-
 void DeploymentEvents_TriggerFleetStateChangeEvent_Hook(auto original, IList* fleets)
 {
   original(fleets);
@@ -749,14 +735,14 @@ void DeploymentEvents_TriggerFleetStateChangeEvent_Hook(auto original, IList* fl
                                         {"fleets", deployed_fleet_list_to_json(fleets)}});
   }
   capture_recent_model_events("deployment-fleet-state-event");
-  capture_fleet_runtime_sync_event("deployment-fleet-state-event");
+  fleet_runtime_sync_trigger("deployment-fleet-state-event");
 }
 
 void DeploymentEvents_TriggerPlayerFleetsUpdatedEvent_Hook(auto original, IList* fleets)
 {
   original(fleets);
   capture_recent_model_events("deployment-player-fleets-updated-event");
-  capture_fleet_runtime_sync_event("deployment-player-fleets-updated-event");
+  fleet_runtime_sync_trigger("deployment-player-fleets-updated-event");
 }
 
 void DeploymentEvents_TriggerCoursePlannedEvent_Hook(auto original, IList* courses)
@@ -766,7 +752,7 @@ void DeploymentEvents_TriggerCoursePlannedEvent_Hook(auto original, IList* cours
     live_debug_events::RecordEvent("deployment-course-planned-event", json{{"courseCount", count_list_items(courses)}});
   }
   capture_recent_model_events("deployment-course-planned-event");
-  capture_fleet_runtime_sync_event("deployment-course-planned-event");
+  fleet_runtime_sync_trigger("deployment-course-planned-event");
 }
 
 void DeploymentEvents_TriggerCourseStartEvent_Hook(auto original, IList* courses)
@@ -776,7 +762,7 @@ void DeploymentEvents_TriggerCourseStartEvent_Hook(auto original, IList* courses
     live_debug_events::RecordEvent("deployment-course-start-event", json{{"courseCount", count_list_items(courses)}});
   }
   capture_recent_model_events("deployment-course-start-event");
-  capture_fleet_runtime_sync_event("deployment-course-start-event");
+  fleet_runtime_sync_trigger("deployment-course-start-event");
 }
 
 void DeploymentEvents_TriggerCourseChangeEvent_Hook(auto original, IList* old_courses, IList* new_courses)
@@ -788,7 +774,7 @@ void DeploymentEvents_TriggerCourseChangeEvent_Hook(auto original, IList* old_co
         json{{"oldCourseCount", count_list_items(old_courses)}, {"newCourseCount", count_list_items(new_courses)}});
   }
   capture_recent_model_events("deployment-course-change-event");
-  capture_fleet_runtime_sync_event("deployment-course-change-event");
+  fleet_runtime_sync_trigger("deployment-course-change-event");
 }
 
 void DeploymentEvents_TriggerCourseEndEvent_Hook(auto original, IList* courses)
@@ -798,7 +784,7 @@ void DeploymentEvents_TriggerCourseEndEvent_Hook(auto original, IList* courses)
     live_debug_events::RecordEvent("deployment-course-end-event", json{{"courseCount", count_list_items(courses)}});
   }
   capture_recent_model_events("deployment-course-end-event");
-  capture_fleet_runtime_sync_event("deployment-course-end-event");
+  fleet_runtime_sync_trigger("deployment-course-end-event");
 }
 
 void DeploymentEvents_TriggerSetCourseResponseEvent_Hook(auto original, long fleet_id, bool success,
@@ -813,7 +799,7 @@ void DeploymentEvents_TriggerSetCourseResponseEvent_Hook(auto original, long fle
                                         {"hasCourseData", planned_course_data != nullptr}});
   }
   capture_recent_model_events("deployment-set-course-response-event");
-  capture_fleet_runtime_sync_event("deployment-set-course-response-event");
+  fleet_runtime_sync_trigger("deployment-set-course-response-event");
 }
 
 void DeploymentEvents_TriggerBattleStartEvent_Hook(auto original, IList* fleets)
@@ -825,7 +811,7 @@ void DeploymentEvents_TriggerBattleStartEvent_Hook(auto original, IList* fleets)
         json{{"fleetCount", count_list_items(fleets)}, {"fleets", deployed_fleet_list_to_json(fleets)}});
   }
   capture_recent_model_events("deployment-battle-start-event");
-  capture_fleet_runtime_sync_event("deployment-battle-start-event");
+  fleet_runtime_sync_trigger("deployment-battle-start-event");
 }
 
 void DeploymentEvents_TriggerBattleEndEvent_Hook(auto original, IList* fleets)
@@ -837,7 +823,7 @@ void DeploymentEvents_TriggerBattleEndEvent_Hook(auto original, IList* fleets)
                                         {"fleets", deployed_fleet_list_to_json(fleets)}});
   }
   capture_recent_model_events("deployment-battle-end-event");
-  capture_fleet_runtime_sync_event("deployment-battle-end-event");
+  fleet_runtime_sync_trigger("deployment-battle-end-event");
 }
 
 void DeploymentEvents_TriggerStaleFleetDataDetected_Hook(auto original)
@@ -847,7 +833,7 @@ void DeploymentEvents_TriggerStaleFleetDataDetected_Hook(auto original)
     live_debug_events::RecordEvent("deployment-stale-fleet-data-detected-event", json::object());
   }
   capture_recent_model_events("deployment-stale-fleet-data-detected-event");
-  capture_fleet_runtime_sync_event("deployment-stale-fleet-data-detected-event");
+  fleet_runtime_sync_trigger("deployment-stale-fleet-data-detected-event");
 }
 
 json handle_recent_events(const std::string& request_id, const json& request)

--- a/mods/src/patches/sync_scheduler.cc
+++ b/mods/src/patches/sync_scheduler.cc
@@ -31,7 +31,7 @@ struct WinRtApartmentGuard {
 
 namespace
 {
-using SyncQueueItem = std::tuple<SyncConfig::Type, std::string, bool>;
+using SyncQueueItem = std::tuple<SyncConfig::Type, std::string, bool, std::optional<FleetRuntimeTraceContext>>;
 
 constexpr size_t              kSyncDataQueueMaxDepth = 256;
 AsyncWorkQueue<SyncQueueItem> s_sync_data_queue(kSyncDataQueueMaxDepth);
@@ -48,10 +48,16 @@ void log_worker_join_time(const std::string_view worker_name, const std::chrono:
 }
 } // namespace
 
-void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync)
+void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync,
+                std::optional<FleetRuntimeTraceContext> fleet_runtime_trace)
 {
-  if (!s_sync_data_queue.enqueue({type, data, is_first_sync})) {
+  if (!s_sync_data_queue.enqueue({type, data, is_first_sync, fleet_runtime_trace})) {
     const auto diagnostics = s_sync_data_queue.diagnostics();
+    if (fleet_runtime_trace.has_value()) {
+      fleet_runtime_diagnostics_scheduler_queue(
+          *fleet_runtime_trace, false, diagnostics.depth,
+          diagnostics.shutdown_requested ? "scheduler-shutdown" : "scheduler-full");
+    }
     http::sync_log_warn("QUEUE", to_string(type),
                         diagnostics.shutdown_requested
                             ? "Dropping data because sync scheduler shutdown is in progress"
@@ -59,18 +65,34 @@ void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sy
     return;
   }
 
+  if (fleet_runtime_trace.has_value()) {
+    const auto diagnostics = s_sync_data_queue.diagnostics();
+    fleet_runtime_diagnostics_scheduler_queue(*fleet_runtime_trace, true, diagnostics.depth);
+  }
+
   http::sync_log_trace("QUEUE", to_string(type), "Added data to sync queue");
 }
 
-void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync)
+void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync,
+                std::optional<FleetRuntimeTraceContext> fleet_runtime_trace)
 {
-  if (!s_sync_data_queue.enqueue({type, data.dump(), is_first_sync})) {
+  if (!s_sync_data_queue.enqueue({type, data.dump(), is_first_sync, fleet_runtime_trace})) {
     const auto diagnostics = s_sync_data_queue.diagnostics();
+    if (fleet_runtime_trace.has_value()) {
+      fleet_runtime_diagnostics_scheduler_queue(
+          *fleet_runtime_trace, false, diagnostics.depth,
+          diagnostics.shutdown_requested ? "scheduler-shutdown" : "scheduler-full");
+    }
     http::sync_log_warn("QUEUE", to_string(type),
                         diagnostics.shutdown_requested
                             ? "Dropping data because sync scheduler shutdown is in progress"
                             : "Dropping data because sync scheduler queue is full");
     return;
+  }
+
+  if (fleet_runtime_trace.has_value()) {
+    const auto diagnostics = s_sync_data_queue.diagnostics();
+    fleet_runtime_diagnostics_scheduler_queue(*fleet_runtime_trace, true, diagnostics.depth);
   }
 
   http::sync_log_trace("QUEUE", to_string(type), "Added " + std::to_string(data.size()) + " entries to sync queue");
@@ -87,8 +109,8 @@ static void ship_sync_data()
     while (s_sync_data_queue.wait_pop(sync_data)) {
 
       try {
-        auto& [type, data, is_first_sync] = sync_data;
-        http::send_data(type, data, is_first_sync);
+        auto& [type, data, is_first_sync, fleet_runtime_trace] = sync_data;
+        http::send_data(type, data, is_first_sync, fleet_runtime_trace);
       } catch (const std::runtime_error& exception) {
         ErrorMsg::SyncRuntime("ship", exception);
       } catch (const std::exception& exception) {

--- a/mods/src/patches/sync_scheduler.h
+++ b/mods/src/patches/sync_scheduler.h
@@ -5,12 +5,16 @@
 #pragma once
 
 #include "config.h"
+#include "patches/fleet_runtime_diagnostics.h"
 
 #include <nlohmann/json.hpp>
 
+#include <optional>
 #include <string>
 
-void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync = false);
-void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync = false);
+void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync = false,
+				std::optional<FleetRuntimeTraceContext> fleet_runtime_trace = std::nullopt);
+void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync = false,
+				std::optional<FleetRuntimeTraceContext> fleet_runtime_trace = std::nullopt);
 void StartSyncSchedulerWorker();
 void ShutdownSyncSchedulerWorker();

--- a/mods/src/patches/sync_scheduler.h
+++ b/mods/src/patches/sync_scheduler.h
@@ -13,8 +13,8 @@
 #include <string>
 
 void queue_data(SyncConfig::Type type, const std::string& data, bool is_first_sync = false,
-				std::optional<FleetRuntimeTraceContext> fleet_runtime_trace = std::nullopt);
+                std::optional<FleetRuntimeTraceContext> fleet_runtime_trace = std::nullopt);
 void queue_data(SyncConfig::Type type, const nlohmann::json& data, bool is_first_sync = false,
-				std::optional<FleetRuntimeTraceContext> fleet_runtime_trace = std::nullopt);
+                std::optional<FleetRuntimeTraceContext> fleet_runtime_trace = std::nullopt);
 void StartSyncSchedulerWorker();
 void ShutdownSyncSchedulerWorker();

--- a/mods/src/patches/sync_transport.cc
+++ b/mods/src/patches/sync_transport.cc
@@ -277,13 +277,19 @@ struct TargetWorker {
   TargetWorker(const TargetWorker&) = delete;
   TargetWorker& operator=(const TargetWorker&) = delete;
 
-  using request_t = std::tuple<std::string, std::string, bool>;
+  struct Request {
+    std::string                             target_name;
+    std::string                             target_identifier;
+    std::string                             post_data;
+    bool                                    is_first_sync = false;
+    std::optional<FleetRuntimeTraceContext> fleet_runtime_trace;
+  };
 
   std::shared_ptr<cpr::Session> session;
   SyncTargetConfig::Mode        mode = SyncTargetConfig::Mode::Legacy;
   std::thread                   worker_thread;
   std::atomic_bool              stop_requested{false};
-  std::queue<request_t>         request_queue;
+  std::queue<Request>           request_queue;
   std::mutex                    queue_mtx;
   std::condition_variable       queue_cv;
   uint64_t                      dropped_requests = 0;
@@ -371,9 +377,7 @@ static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
 #endif
 
   while (!worker->stop_requested.load(std::memory_order_acquire)) {
-    std::string identifier;
-    std::string post_data;
-    bool is_first_sync = false;
+    TargetWorker::Request request;
 
     {
       std::unique_lock lk(worker->queue_mtx);
@@ -388,13 +392,11 @@ static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
       if (!worker->request_queue.empty()) {
         auto item = std::move(worker->request_queue.front());
         worker->request_queue.pop();
-        identifier = std::move(std::get<0>(item));
-        post_data = std::move(std::get<1>(item));
-        is_first_sync = std::get<2>(item);
+        request = std::move(item);
       }
     }
 
-    if (post_data.empty()) {
+    if (request.post_data.empty()) {
       continue;
     }
 
@@ -402,39 +404,69 @@ static void target_worker_thread(std::shared_ptr<TargetWorker> worker)
       const auto httpClient = worker->session;
       auto& request_headers = httpClient->GetHeader();
 
-      if (worker->mode == SyncTargetConfig::Mode::Legacy && is_first_sync) {
+      if (worker->mode == SyncTargetConfig::Mode::Legacy && request.is_first_sync) {
         request_headers.insert_or_assign("X-PRIME-SYNC", "2");
-        sync_log_trace(CURL_TYPE_UPLOAD, identifier, "Adding X-Prime-Sync header for initial sync");
+        sync_log_trace(CURL_TYPE_UPLOAD, request.target_identifier, "Adding X-Prime-Sync header for initial sync");
       } else {
         request_headers.erase("X-PRIME-SYNC");
       }
 
-      httpClient->SetBody(cpr::Body{post_data});
+      httpClient->SetBody(cpr::Body{request.post_data});
 
-      sync_log_debug(CURL_TYPE_UPLOAD, identifier, "Sending data to " + httpClient->GetFullRequestUrl());
+      sync_log_debug(CURL_TYPE_UPLOAD, request.target_identifier, "Sending data to " + httpClient->GetFullRequestUrl());
 
       const auto response = httpClient->Post();
+      const auto elapsed_ms = static_cast<int64_t>(response.elapsed * 1000.0);
 
       if (response.status_code == 0) {
-        sync_log_error(CURL_TYPE_UPLOAD, identifier, "Failed to send request: " + response.error.message);
+        if (request.fleet_runtime_trace.has_value()) {
+          fleet_runtime_diagnostics_post_result(*request.fleet_runtime_trace, request.target_name,
+                                                to_string(worker->mode), false, 0, "transport", elapsed_ms);
+        }
+        sync_log_error(CURL_TYPE_UPLOAD, request.target_identifier, "Failed to send request: " + response.error.message);
       } else if (response.status_code >= 400) {
-        sync_log_error(CURL_TYPE_UPLOAD, identifier,
+        if (request.fleet_runtime_trace.has_value()) {
+          fleet_runtime_diagnostics_post_result(*request.fleet_runtime_trace, request.target_name,
+                                                to_string(worker->mode), false, response.status_code,
+                                                "http_status", elapsed_ms);
+        }
+        sync_log_error(CURL_TYPE_UPLOAD, request.target_identifier,
                        STR_FORMAT("Failed to communicate with server: {} (after {:.1f}s)", response.status_line,
                                   response.elapsed));
       } else {
-        sync_log_debug(CURL_TYPE_UPLOAD, identifier,
+        if (request.fleet_runtime_trace.has_value()) {
+          fleet_runtime_diagnostics_post_result(*request.fleet_runtime_trace, request.target_name,
+                                                to_string(worker->mode), true, response.status_code, "", elapsed_ms);
+        }
+        sync_log_debug(CURL_TYPE_UPLOAD, request.target_identifier,
                        STR_FORMAT("Response: {} ({:.1f}s elapsed)", response.status_line, response.elapsed));
       }
     } catch (const std::runtime_error& exception) {
-      ErrorMsg::SyncRuntime(identifier.c_str(), exception);
+      if (request.fleet_runtime_trace.has_value()) {
+        fleet_runtime_diagnostics_post_result(*request.fleet_runtime_trace, request.target_name,
+                                              to_string(worker->mode), false, 0, "runtime_error", 0);
+      }
+      ErrorMsg::SyncRuntime(request.target_identifier.c_str(), exception);
     } catch (const std::exception& exception) {
-      ErrorMsg::SyncException(identifier.c_str(), exception);
+      if (request.fleet_runtime_trace.has_value()) {
+        fleet_runtime_diagnostics_post_result(*request.fleet_runtime_trace, request.target_name,
+                                              to_string(worker->mode), false, 0, "exception", 0);
+      }
+      ErrorMsg::SyncException(request.target_identifier.c_str(), exception);
 #if _WIN32
     } catch (winrt::hresult_error const& exception) {
-      ErrorMsg::SyncWinRT(identifier.c_str(), exception);
+      if (request.fleet_runtime_trace.has_value()) {
+        fleet_runtime_diagnostics_post_result(*request.fleet_runtime_trace, request.target_name,
+                                              to_string(worker->mode), false, 0, "winrt", 0);
+      }
+      ErrorMsg::SyncWinRT(request.target_identifier.c_str(), exception);
 #endif
     } catch (...) {
-      ErrorMsg::SyncMsg(identifier.c_str(), "Unknown error occurred");
+      if (request.fleet_runtime_trace.has_value()) {
+        fleet_runtime_diagnostics_post_result(*request.fleet_runtime_trace, request.target_name,
+                                              to_string(worker->mode), false, 0, "unknown", 0);
+      }
+      ErrorMsg::SyncMsg(request.target_identifier.c_str(), "Unknown error occurred");
     }
   }
 }
@@ -487,7 +519,8 @@ static std::shared_ptr<TargetWorker> get_curl_client_sync(const std::string& tar
   return worker;
 }
 
-void send_data(SyncConfig::Type type, const std::string& post_data, bool is_first_sync)
+void send_data(SyncConfig::Type type, const std::string& post_data, bool is_first_sync,
+               std::optional<FleetRuntimeTraceContext> fleet_runtime_trace)
 {
   if (target_workers_shutdown_requested.load(std::memory_order_acquire)) {
     return;
@@ -511,6 +544,14 @@ void send_data(SyncConfig::Type type, const std::string& post_data, bool is_firs
       const auto worker = get_curl_client_sync(target);
       const auto target_post_data = make_target_post_data(target_config, type, post_data, target_identifier);
       if (target_post_data.empty()) {
+        if (fleet_runtime_trace.has_value()) {
+          const size_t queue_depth = [&] {
+            std::lock_guard lk(worker->queue_mtx);
+            return worker->request_queue.size();
+          }();
+          fleet_runtime_diagnostics_target_queue(*fleet_runtime_trace, target, to_string(target_config.mode), false,
+                                                 queue_depth, worker->dropped_requests, "target-payload-empty");
+        }
         continue;
       }
 
@@ -518,23 +559,50 @@ void send_data(SyncConfig::Type type, const std::string& post_data, bool is_firs
         std::lock_guard lk(worker->queue_mtx);
         if (worker->request_queue.size() >= kTargetWorkerMaxQueuedRequests) {
           ++worker->dropped_requests;
+          if (fleet_runtime_trace.has_value()) {
+            fleet_runtime_diagnostics_target_queue(*fleet_runtime_trace, target, to_string(target_config.mode), false,
+                                                   worker->request_queue.size(), worker->dropped_requests,
+                                                   "target-queue-full");
+          }
           sync_log_warn(CURL_TYPE_UPLOAD, target_identifier,
                         STR_FORMAT("Dropping request because target queue is full (queue size: {}, dropped: {})",
                                    worker->request_queue.size(), worker->dropped_requests));
           continue;
         }
 
-        worker->request_queue.emplace(target_identifier, target_post_data, is_first_sync);
+        worker->request_queue.emplace(TargetWorker::Request{
+            .target_name = target,
+            .target_identifier = target_identifier,
+            .post_data = target_post_data,
+            .is_first_sync = is_first_sync,
+            .fleet_runtime_trace = fleet_runtime_trace,
+        });
+        if (fleet_runtime_trace.has_value()) {
+          fleet_runtime_diagnostics_target_queue(*fleet_runtime_trace, target, to_string(target_config.mode), true,
+                                                 worker->request_queue.size(), worker->dropped_requests);
+        }
         sync_log_trace(CURL_TYPE_UPLOAD, target_identifier,
                        STR_FORMAT("Queued request (queue size: {})", worker->request_queue.size()));
       }
       worker->queue_cv.notify_all();
 
     } catch (const std::runtime_error& exception) {
+      if (fleet_runtime_trace.has_value()) {
+        fleet_runtime_diagnostics_target_queue(*fleet_runtime_trace, target, to_string(target_config.mode), false, 0,
+                                               0, "target-worker-init-runtime-error");
+      }
       spdlog::error("Failed to send sync data to target '{}' - Runtime error: {}", target_identifier, exception.what());
     } catch (const std::exception& exception) {
+      if (fleet_runtime_trace.has_value()) {
+        fleet_runtime_diagnostics_target_queue(*fleet_runtime_trace, target, to_string(target_config.mode), false, 0,
+                                               0, "target-worker-init-exception");
+      }
       spdlog::error("Failed to send sync data to target '{}' - Exception: {}", target_identifier, exception.what());
     } catch (...) {
+      if (fleet_runtime_trace.has_value()) {
+        fleet_runtime_diagnostics_target_queue(*fleet_runtime_trace, target, to_string(target_config.mode), false, 0,
+                                               0, "target-worker-init-unknown");
+      }
       spdlog::error("Failed to send sync data to target '{}' - Unknown error occurred", target_identifier);
     }
   }

--- a/mods/src/patches/sync_transport.h
+++ b/mods/src/patches/sync_transport.h
@@ -5,8 +5,10 @@
 #pragma once
 
 #include "config.h"
+#include "patches/fleet_runtime_diagnostics.h"
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 namespace http
@@ -35,7 +37,8 @@ void sync_log_info(const std::string& type, const std::string& target, const std
 void sync_log_debug(const std::string& type, const std::string& target, const std::string& text);
 void sync_log_trace(const std::string& type, const std::string& target, const std::string& text);
 
-void send_data(SyncConfig::Type type, const std::string& post_data, bool is_first_sync);
+void send_data(SyncConfig::Type type, const std::string& post_data, bool is_first_sync,
+               std::optional<FleetRuntimeTraceContext> fleet_runtime_trace = std::nullopt);
 std::string get_scopely_data(const std::string& path, const std::string& post_data);
 void shutdown_workers();
 } // namespace http

--- a/mods/src/testable_functions.cc
+++ b/mods/src/testable_functions.cc
@@ -1107,6 +1107,68 @@ bool fleet_state_can_dock_from_space(FleetBarTransitionState state)
 }
 } // namespace
 
+const char* fleet_runtime_trigger_source_for_state_transition(int old_state, int new_state)
+{
+  const auto oldState = fleet_bar_transition_state_from_value(old_state);
+  const auto newState = fleet_bar_transition_state_from_value(new_state);
+
+  if (oldState == newState) {
+    return nullptr;
+  }
+
+  if (oldState == FleetBarTransitionState::Docked && newState == FleetBarTransitionState::Repairing) {
+    return "fleet-slot-repair-started";
+  }
+
+  if (oldState == FleetBarTransitionState::Repairing && newState == FleetBarTransitionState::Docked) {
+    return "fleet-slot-repair-completed";
+  }
+
+  if (newState == FleetBarTransitionState::Battling && oldState != FleetBarTransitionState::Battling) {
+    return "fleet-slot-combat-started";
+  }
+
+  if (oldState == FleetBarTransitionState::Battling && newState != FleetBarTransitionState::Battling) {
+    return "fleet-slot-combat-ended";
+  }
+
+  if (oldState == FleetBarTransitionState::Mining && newState != FleetBarTransitionState::Mining) {
+    return "fleet-slot-mining-stopped";
+  }
+
+  if (oldState == FleetBarTransitionState::Warping && newState == FleetBarTransitionState::Impulsing) {
+    return "fleet-slot-arrived-in-system";
+  }
+
+  if (newState == FleetBarTransitionState::Docked && oldState != FleetBarTransitionState::Repairing
+      && fleet_state_can_dock_from_space(oldState)) {
+    return "fleet-slot-docked";
+  }
+
+  if (oldState == FleetBarTransitionState::Impulsing && fleet_state_can_arrive_at_destination(newState)) {
+    return "fleet-slot-arrived-at-destination";
+  }
+
+  if (newState == FleetBarTransitionState::Mining && oldState != FleetBarTransitionState::Mining) {
+    return "fleet-slot-mining-started";
+  }
+
+  if (newState == FleetBarTransitionState::WarpCharging && oldState != FleetBarTransitionState::WarpCharging) {
+    return "fleet-slot-warp-started";
+  }
+
+  if (newState == FleetBarTransitionState::Warping && oldState != FleetBarTransitionState::Warping) {
+    return "fleet-slot-warp-engaged";
+  }
+
+  if (newState == FleetBarTransitionState::Impulsing && oldState != FleetBarTransitionState::Impulsing
+      && oldState != FleetBarTransitionState::Warping) {
+    return "fleet-slot-impulse-started";
+  }
+
+  return nullptr;
+}
+
 FleetBarTransitionNotificationDecision
 fleet_bar_transition_notification_decision(const FleetBarTransitionNotificationInput& input)
 {

--- a/mods/src/testable_functions.h
+++ b/mods/src/testable_functions.h
@@ -316,6 +316,7 @@ bool fleet_bar_transition_arrived_in_system_event_enabled(bool osArrivedInSystem
 bool fleet_bar_transition_should_notify_os(FleetBarTransitionNotificationKind kind, bool osArrivedInSystemEnabled);
 bool fleet_bar_transition_should_notify_audio(FleetBarTransitionNotificationKind kind, bool audioEnabled,
                                               bool audioArrivedInSystemEnabled);
+const char* fleet_runtime_trigger_source_for_state_transition(int old_state, int new_state);
 FleetBarTransitionNotificationDecision
 fleet_bar_transition_notification_decision(const FleetBarTransitionNotificationInput& input);
 

--- a/tests/src/test_fleet_runtime_diagnostics.cc
+++ b/tests/src/test_fleet_runtime_diagnostics.cc
@@ -1,0 +1,81 @@
+#include <doctest/doctest.h>
+
+#include "patches/fleet_runtime_diagnostics.h"
+
+TEST_SUITE("fleet_runtime_diagnostics")
+{
+  TEST_CASE("suppressed unchanged increments counters and preserves latest trigger")
+  {
+    fleet_runtime_diagnostics_reset();
+
+    fleet_runtime_diagnostics_trigger("deployment-set-course-response-event");
+    fleet_runtime_diagnostics_capture_attempt("deployment-set-course-response-event", 4);
+    fleet_runtime_diagnostics_suppressed_unchanged("deployment-set-course-response-event", 4);
+
+    const auto snapshot = fleet_runtime_diagnostics_snapshot();
+    CHECK(snapshot.triggerCount == 1);
+    CHECK(snapshot.captureAttemptCount == 1);
+    CHECK(snapshot.suppressedUnchangedCount == 1);
+    CHECK(snapshot.suppressedNonMeaningfulCount == 0);
+    CHECK(snapshot.latestTriggerSource == "deployment-set-course-response-event");
+    CHECK(snapshot.latestTriggerAtMs > 0);
+  }
+
+  TEST_CASE("trace captures safe slot counts and redacted status summary")
+  {
+    fleet_runtime_diagnostics_reset();
+
+    FleetObservation fleet;
+    fleet.tracked = true;
+
+    std::array<FleetSlotObservation, kFleetIndexMax> slots{};
+    for (int index = 0; index < kFleetIndexMax; ++index) {
+      slots[static_cast<size_t>(index)].slotIndex = index;
+    }
+    slots[0].present = true;
+    slots[0].currentState = 2;
+    slots[1].present = true;
+    slots[1].currentState = 64;
+
+    const auto trace = fleet_runtime_diagnostics_make_trace("deployment-battle-end-event", fleet, slots, 123456, 7);
+
+    CHECK(trace.localSequence == 1);
+    CHECK(trace.observedAtMs == 123456);
+    CHECK(trace.captureDurationMs == 7);
+    CHECK(trace.slotCount == 10);
+    CHECK(trace.presentShipCount == 2);
+    CHECK(trace.source == "deployment-battle-end-event");
+    CHECK(trace.statusSummary == "battling:1,docked:1,empty:8");
+
+    const auto snapshot = fleet_runtime_diagnostics_snapshot();
+    CHECK(snapshot.latestLocalSequence == 1);
+    CHECK(snapshot.latestObservedAtMs == 123456);
+  }
+
+  TEST_CASE("queued and dropped diagnostics update queue and post counters")
+  {
+    fleet_runtime_diagnostics_reset();
+
+    FleetRuntimeTraceContext trace;
+    trace.localSequence = 9;
+    trace.observedAtMs = 222;
+    trace.source = "deployment-course-start-event";
+    trace.slotCount = 10;
+    trace.presentShipCount = 3;
+    trace.statusSummary = "docked:2,empty:7,mining:1";
+
+    fleet_runtime_diagnostics_scheduler_queue(trace, true, 1);
+    fleet_runtime_diagnostics_target_queue(trace, "local-sidecar", "sidecar_broker", false, 256, 5,
+                                           "target-queue-full");
+    fleet_runtime_diagnostics_post_result(trace, "local-sidecar", "sidecar_broker", true, 202, "", 35);
+    fleet_runtime_diagnostics_post_result(trace, "local-sidecar", "sidecar_broker", false, 0, "transport", 0);
+
+    const auto snapshot = fleet_runtime_diagnostics_snapshot();
+    CHECK(snapshot.schedulerQueueAcceptedCount == 1);
+    CHECK(snapshot.schedulerQueueDroppedCount == 0);
+    CHECK(snapshot.targetQueueAcceptedCount == 0);
+    CHECK(snapshot.targetQueueDroppedCount == 1);
+    CHECK(snapshot.postSuccessCount == 1);
+    CHECK(snapshot.postFailureCount == 1);
+  }
+}

--- a/tests/src/test_notifications_and_dedupe.cc
+++ b/tests/src/test_notifications_and_dedupe.cc
@@ -459,30 +459,30 @@ TEST_SUITE("fleet_notification_formatting")
     CHECK(repairComplete.body == "Your K'VORT finished repairs");
   }
 
-      TEST_CASE("fleet runtime trigger sources stay high-signal")
-      {
-        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::IdleInSpace),
-                        static_cast<int>(FleetBarTransitionState::Mining))
-          == std::string_view{"fleet-slot-mining-started"});
-        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Mining),
-                        static_cast<int>(FleetBarTransitionState::WarpCharging))
-          == std::string_view{"fleet-slot-mining-stopped"});
-        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::IdleInSpace),
-                        static_cast<int>(FleetBarTransitionState::Impulsing))
-          == std::string_view{"fleet-slot-impulse-started"});
-        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Warping),
-                        static_cast<int>(FleetBarTransitionState::Impulsing))
-          == std::string_view{"fleet-slot-arrived-in-system"});
-        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Impulsing),
-                        static_cast<int>(FleetBarTransitionState::IdleInSpace))
-          == std::string_view{"fleet-slot-arrived-at-destination"});
-        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Battling),
-                        static_cast<int>(FleetBarTransitionState::Impulsing))
-          == std::string_view{"fleet-slot-combat-ended"});
-        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Docked),
-                        static_cast<int>(FleetBarTransitionState::Docked))
-          == nullptr);
-      }
+  TEST_CASE("fleet runtime trigger sources stay high-signal")
+  {
+    CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::IdleInSpace),
+                    static_cast<int>(FleetBarTransitionState::Mining))
+      == std::string_view{"fleet-slot-mining-started"});
+    CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Mining),
+                    static_cast<int>(FleetBarTransitionState::WarpCharging))
+      == std::string_view{"fleet-slot-mining-stopped"});
+    CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::IdleInSpace),
+                    static_cast<int>(FleetBarTransitionState::Impulsing))
+      == std::string_view{"fleet-slot-impulse-started"});
+    CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Warping),
+                    static_cast<int>(FleetBarTransitionState::Impulsing))
+      == std::string_view{"fleet-slot-arrived-in-system"});
+    CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Impulsing),
+                    static_cast<int>(FleetBarTransitionState::IdleInSpace))
+      == std::string_view{"fleet-slot-arrived-at-destination"});
+    CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Battling),
+                    static_cast<int>(FleetBarTransitionState::Impulsing))
+      == std::string_view{"fleet-slot-combat-ended"});
+    CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Docked),
+                    static_cast<int>(FleetBarTransitionState::Docked))
+      == nullptr);
+  }
 
   TEST_CASE("fleet transition delivery policy separates OS and audio arrival toggles")
   {

--- a/tests/src/test_notifications_and_dedupe.cc
+++ b/tests/src/test_notifications_and_dedupe.cc
@@ -459,6 +459,31 @@ TEST_SUITE("fleet_notification_formatting")
     CHECK(repairComplete.body == "Your K'VORT finished repairs");
   }
 
+      TEST_CASE("fleet runtime trigger sources stay high-signal")
+      {
+        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::IdleInSpace),
+                        static_cast<int>(FleetBarTransitionState::Mining))
+          == std::string_view{"fleet-slot-mining-started"});
+        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Mining),
+                        static_cast<int>(FleetBarTransitionState::WarpCharging))
+          == std::string_view{"fleet-slot-mining-stopped"});
+        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::IdleInSpace),
+                        static_cast<int>(FleetBarTransitionState::Impulsing))
+          == std::string_view{"fleet-slot-impulse-started"});
+        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Warping),
+                        static_cast<int>(FleetBarTransitionState::Impulsing))
+          == std::string_view{"fleet-slot-arrived-in-system"});
+        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Impulsing),
+                        static_cast<int>(FleetBarTransitionState::IdleInSpace))
+          == std::string_view{"fleet-slot-arrived-at-destination"});
+        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Battling),
+                        static_cast<int>(FleetBarTransitionState::Impulsing))
+          == std::string_view{"fleet-slot-combat-ended"});
+        CHECK(fleet_runtime_trigger_source_for_state_transition(static_cast<int>(FleetBarTransitionState::Docked),
+                        static_cast<int>(FleetBarTransitionState::Docked))
+          == nullptr);
+      }
+
   TEST_CASE("fleet transition delivery policy separates OS and audio arrival toggles")
   {
     constexpr auto arrival = FleetBarTransitionNotificationKind::ArrivedInSystem;

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -16,6 +16,7 @@ do
     add_files("../mods/src/patches/live_debug_event_store.cc")
     add_files("../mods/src/patches/live_debug_recent_event_requests.cc")
     add_files("../mods/src/patches/live_debug_fleet_serializers.cc")
+    add_files("../mods/src/patches/fleet_runtime_diagnostics.cc")
     add_files("../mods/src/patches/live_debug_ui_serializers.cc")
     add_files("../mods/src/patches/live_debug_viewer_serializers.cc")
     add_files("../mods/src/patches/battle_log_decoder.cc")
@@ -36,6 +37,7 @@ do
     add_packages("doctest", "nlohmann_json", "toml++", "spdlog")
 
     add_defines("NOMINMAX")
+    add_defines("STFC_MOD_TESTS")
 
     if is_plat("windows") then
         add_cxflags("/bigobj")


### PR DESCRIPTION
## Summary

- capture and post fleet runtime snapshots to the local Sidecar path used by the Fleet projection broker
- add redacted fleet runtime diagnostics for triggers, capture attempts, queueing, and post outcomes
- tighten scheduler and transport handling around local runtime sync delivery
- extend test coverage for dedupe behavior and fleet runtime diagnostics

## Why

The local Fleet projection view depends on fresh runtime snapshots reaching Sidecar reliably. This change makes the native mod publish those snapshots through the local-first path while keeping diagnostics redacted and useful for runtime tracing.

## Impact

- newer fleet runtime observations can advance the local Sidecar projection without depending on cloud callbacks
- runtime logs and recent-event breadcrumbs make it easier to tell whether the mod triggered capture, queued work, suppressed a no-op, or posted successfully
- the diagnostics stay projection-safe and do not expose raw tokens, coordinates, or full payloads

## Validation

- `axf run stfc-mod validate`
- validation passed with `230` doctest cases and a successful releasedbg build

## Boundaries

- no cloud upload requirement
- no Sidecar dependency back into Majel history
- no cargo-gained trigger
- no raw secrets or full payloads in diagnostics
