### PR TITLE
[codex] fix: parse armada start text properly

### DIFF
--- a/docs/NOTIFICATION_FORMAT_INVESTIGATION_SOP.md
+++ b/docs/NOTIFICATION_FORMAT_INVESTIGATION_SOP.md
@@ -1,0 +1,59 @@
+# Notification Format Investigation SOP
+
+Purpose: make notification placeholder/rich-text regressions evidence-first. Use this when a Windows notification shows raw localization tokens such as `{1}`, `{5.000}`, or TMP/Unity rich text tags.
+
+## 1. Preserve The Symptom
+
+- Capture the notification screenshot or exact body text.
+- Note the toast title, approximate local time, and action that produced it.
+- Do not make another formatting guess until runtime evidence identifies the failing rung.
+
+## 2. Check Static Evidence
+
+Use AX research before editing:
+
+```powershell
+ax research-search "started an Armada" -Compact
+ax research-search "HUD.Toast kind=class" -Compact
+```
+
+Record the localization template, expected placeholder indexes, and the static `Toast` field layout.
+
+## 3. Add Bounded Runtime Evidence
+
+Use temporary `[NotifyProbe]` log markers in `community_patch.log`, and keep them scoped to the active investigation.
+
+Startup evidence should answer:
+
+- Which `LanguageManager.Localize` overloads exist.
+- Which overload was selected for `LocaleTextContext`.
+- Whether an overload exists for `LocaleTextContext + object[]`.
+- What fields the live `Digit.Prime.HUD.Toast` class exposes.
+
+Leak evidence should answer:
+
+- Toast state/title.
+- Toast and `LocaleTextContext` runtime class names.
+- Parameter source: toast field, toast property, LTC `_textParameters`, LTC `_identifierParameters`, LTC property, or none.
+- Parameter count and bounded parameter value preview.
+- Localized template before formatting and formatted body after stripping.
+
+Keep leak probes budgeted; a handful of samples should be enough, and they should not ship in the final patch.
+
+## 4. Interpret Before Patching
+
+- If no parameter source is found, inspect live toast/LTC fields and properties. For `LocaleTextContext`, check both
+  `_textParameters` and `_identifierParameters`; Armada toast templates have been observed with `_textParameters` null.
+- If parameters exist but no 3-argument `Localize` overload exists, fix manual substitution.
+- If the 3-argument overload exists but returns placeholders, verify parameter ordering and token syntax.
+- If parameter values are placeholders themselves, inspect nested `LocaleTextContext` resolution.
+- If tags remain but placeholders are resolved, isolate rich-text stripping.
+
+## 5. Close The Loop
+
+After the next smoke test:
+
+- Copy the relevant `[NotifyProbe]` lines into the task notes.
+- Remove probes that are no longer needed before final validation.
+- Keep a pure test for every formatter rule learned from the evidence.
+- Rebuild, deploy, cycle, and verify boot before asking for another live smoke test.

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -29,7 +29,9 @@
 
 #include <chrono>
 #include <exception>
+#include <initializer_list>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -41,43 +43,186 @@
 static const MethodInfo* s_localize_ltc             = nullptr;
 static bool              s_notification_initialized = false;
 
-static FieldInfo* find_il2cpp_field(Il2CppClass* klass, const char* primary_name, const char* fallback_name = nullptr)
+static FieldInfo* find_il2cpp_field(Il2CppClass* klass, std::initializer_list<const char*> candidate_names,
+                                    bool warn_on_missing = true)
 {
-  if (!klass || !primary_name) {
+  if (!klass) {
     return nullptr;
   }
 
-  auto* field = il2cpp_class_get_field_from_name(klass, primary_name);
-  if (!field && fallback_name) {
-    field = il2cpp_class_get_field_from_name(klass, fallback_name);
+  const char* first_name = nullptr;
+  for (const auto* name : candidate_names) {
+    if (!name || !*name) {
+      continue;
+    }
+
+    if (!first_name) {
+      first_name = name;
+    }
+
+    if (auto* field = il2cpp_class_get_field_from_name(klass, name)) {
+      return field;
+    }
   }
 
-  if (!field) {
+  if (warn_on_missing) {
     spdlog::warn("[Notify] Could not resolve {}.{} field",
-                 il2cpp_class_get_name(klass) ? il2cpp_class_get_name(klass) : "<unknown>", primary_name);
+                 il2cpp_class_get_name(klass) ? il2cpp_class_get_name(klass) : "<unknown>",
+                 first_name ? first_name : "<unknown>");
   }
 
-  return field;
+  return nullptr;
 }
 
 template <typename T>
-static T* read_il2cpp_reference_field(Il2CppObject* obj, const char* primary_name, const char* fallback_name = nullptr)
+static T* read_il2cpp_reference_field(Il2CppObject* obj, std::initializer_list<const char*> candidate_names,
+                                      bool warn_on_missing = true)
 {
   if (!obj || !obj->klass) {
     return nullptr;
   }
 
-  auto* field = find_il2cpp_field(obj->klass, primary_name, fallback_name);
+  auto* field = find_il2cpp_field(obj->klass, candidate_names, warn_on_missing);
   if (!field) {
     return nullptr;
   }
 
-  const auto field_offset = il2cpp_field_get_offset(field);
-  return *reinterpret_cast<T**>(reinterpret_cast<char*>(obj) + field_offset);
+  return *reinterpret_cast<T**>(reinterpret_cast<char*>(obj) + il2cpp_field_get_offset(field));
 }
 
 template <typename T> static T read_il2cpp_boxed_value(Il2CppObject* obj)
 { return *reinterpret_cast<T*>(reinterpret_cast<char*>(obj) + sizeof(Il2CppObject)); }
+
+static std::string read_il2cpp_string_field(Il2CppObject* obj, std::initializer_list<const char*> candidate_names,
+                                            bool warn_on_missing = true)
+{
+  if (auto* value = read_il2cpp_reference_field<Il2CppString>(obj, candidate_names, warn_on_missing)) {
+    return to_string(value);
+  }
+  return {};
+}
+
+static std::optional<int32_t> read_il2cpp_i32_field(Il2CppObject*                      obj,
+                                                    std::initializer_list<const char*> candidate_names)
+{
+  if (!obj || !obj->klass) {
+    return std::nullopt;
+  }
+
+  auto* field = find_il2cpp_field(obj->klass, candidate_names, false);
+  if (!field) {
+    return std::nullopt;
+  }
+
+  return *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(obj) + il2cpp_field_get_offset(field));
+}
+
+static bool ascii_starts_with(std::string_view text, std::string_view prefix)
+{ return text.size() >= prefix.size() && text.substr(0, prefix.size()) == prefix; }
+
+static std::optional<int32_t> parse_trailing_level_token(std::string_view text)
+{
+  const auto separator = text.rfind('_');
+  if (separator == std::string_view::npos || separator + 1 >= text.size()) {
+    return std::nullopt;
+  }
+
+  int32_t level = 0;
+  for (size_t i = separator + 1; i < text.size(); ++i) {
+    const auto ch = text[i];
+    if (ch < '0' || ch > '9') {
+      return std::nullopt;
+    }
+    level = (level * 10) + static_cast<int32_t>(ch - '0');
+  }
+
+  return level;
+}
+
+static std::string int_to_string_or_empty(std::optional<int32_t> value)
+{ return value ? fmt::format("{}", *value) : std::string{}; }
+
+static std::string armada_target_label(Il2CppObject* target_user, Il2CppObject* target_hull,
+                                       Il2CppObject* target_alliance, std::string_view target_user_id)
+{
+  if (auto name = read_il2cpp_string_field(target_user, {"name_"}, false); !name.empty()) {
+    return name;
+  }
+
+  if (auto name = read_il2cpp_string_field(target_hull, {"name_"}, false); !name.empty()) {
+    return name;
+  }
+
+  if (auto tag = read_il2cpp_string_field(target_alliance, {"tag_"}, false); !tag.empty()) {
+    return tag;
+  }
+
+  if (auto name = read_il2cpp_string_field(target_alliance, {"name_"}, false); !name.empty()) {
+    return name;
+  }
+
+  if (ascii_starts_with(target_user_id, "mar_")) {
+    return "Armada Target";
+  }
+
+  if (!target_user_id.empty()) {
+    return std::string(target_user_id);
+  }
+
+  return "Armada Target";
+}
+
+static std::string resolve_armada_created_formatted(Toast* toast, int state, std::string_view template_text)
+{
+  if (state != ArmadaCreated || !toast || template_text.empty()) {
+    return {};
+  }
+
+  auto* data = toast->get_Data();
+  if (!data) {
+    return {};
+  }
+
+  auto* armada_attack = read_il2cpp_reference_field<Il2CppObject>(data, {"ArmadaAttack"});
+  auto* alliance      = read_il2cpp_reference_field<Il2CppObject>(data, {"Alliance"});
+  if (!armada_attack) {
+    return {};
+  }
+
+  auto* owner       = read_il2cpp_reference_field<Il2CppObject>(armada_attack, {"<Owner>k__BackingField", "Owner"});
+  auto* target_user = read_il2cpp_reference_field<Il2CppObject>(armada_attack, {"<TargetUserProfile>k__BackingField"});
+  auto* target_alliance =
+      read_il2cpp_reference_field<Il2CppObject>(armada_attack, {"<TargetAllianceProfile>k__BackingField"});
+  auto* target_hull = read_il2cpp_reference_field<Il2CppObject>(armada_attack, {"<TargetHullSpec>k__BackingField"});
+  auto* target_info = read_il2cpp_reference_field<Il2CppObject>(armada_attack, {"target_"});
+
+  auto alliance_tag = read_il2cpp_string_field(alliance, {"tag_"});
+  if (alliance_tag.empty()) {
+    alliance_tag = read_il2cpp_string_field(alliance, {"name_"});
+  }
+
+  auto owner_name = read_il2cpp_string_field(owner, {"name_"});
+  if (owner_name.empty()) {
+    owner_name = read_il2cpp_string_field(armada_attack, {"ownerId_"});
+  }
+
+  auto target_user_id = read_il2cpp_string_field(target_info, {"userId_"});
+  auto target_level   = read_il2cpp_i32_field(target_user, {"level_"});
+  if (!target_level || *target_level <= 0) {
+    target_level = parse_trailing_level_token(target_user_id);
+  }
+
+  auto target_label = armada_target_label(target_user, target_hull, target_alliance, target_user_id);
+  auto fleet_count  = read_il2cpp_i32_field(armada_attack, {"fleetCapacity_"});
+
+  if (alliance_tag.empty() && owner_name.empty() && target_label.empty()) {
+    return {};
+  }
+
+  return notification_format_armada_created_body(template_text, "#ffffff", alliance_tag, owner_name,
+                                                 int_to_string_or_empty(fleet_count), "#ffffff",
+                                                 int_to_string_or_empty(target_level), target_label);
+}
 
 // ─── Toast State → Human-Readable Title ───────────────────────────────────────────────
 
@@ -286,27 +431,57 @@ bool notification_should_process_toast(Toast*)
 
 // ─── Toast Text Resolution ───────────────────────────────────────────────────────────
 
-/**
- * @brief Resolve the localized body text from a Toast's TextLocaleTextContext.
- *
- * Invokes the cached LanguageManager::Localize method via il2cpp_runtime_invoke
- * to produce a localized string from the toast's LTC data.
- *
- * @param toast The Toast to extract text from.
- * @return Localized text string, or empty on failure.
- */
-static std::string resolve_toast_text(Toast* toast)
+static Il2CppArray* resolve_ltc_text_parameters(Il2CppObject* ltc_object)
 {
-  if (!s_localize_ltc)
-    return {};
+  if (!ltc_object) {
+    return nullptr;
+  }
 
-  auto* ltc = toast->get_TextLocaleTextContext();
-  if (!ltc)
+  if (auto* text_parameters = read_il2cpp_reference_field<Il2CppArray>(
+          ltc_object, {"_textParameters", "TextParameters", "<TextParameters>k__BackingField"}, false)) {
+    return text_parameters;
+  }
+
+  return read_il2cpp_reference_field<Il2CppArray>(ltc_object, {"_identifierParameters"}, false);
+}
+
+static Il2CppArray* resolve_toast_text_parameters(Toast* toast, void* ltc)
+{
+  if (toast) {
+    auto* toast_object = reinterpret_cast<Il2CppObject*>(toast);
+    if (auto* text_parameters = read_il2cpp_reference_field<Il2CppArray>(
+            toast_object, {"<TextParameters>k__BackingField", "TextParameters", "_textParameters"}, false)) {
+      return text_parameters;
+    }
+
+    auto* secondary_ltc = read_il2cpp_reference_field<Il2CppObject>(
+        toast_object, {"<SecondaryTextLocaleTextContext>k__BackingField", "SecondaryTextLocaleTextContext"}, false);
+    if (auto* text_parameters = resolve_ltc_text_parameters(secondary_ltc)) {
+      return text_parameters;
+    }
+  }
+
+  if (ltc) {
+    return resolve_ltc_text_parameters(reinterpret_cast<Il2CppObject*>(ltc));
+  }
+
+  return nullptr;
+}
+
+static std::string resolve_toast_text(void* ltc)
+{
+  if (!ltc) {
     return {};
+  }
 
   auto* langMgr = LanguageManager::Instance();
-  if (!langMgr)
+  if (!langMgr) {
     return {};
+  }
+
+  if (!s_localize_ltc) {
+    return {};
+  }
 
   Il2CppString*    resolved  = nullptr;
   void*            params[2] = {&resolved, ltc};
@@ -345,7 +520,8 @@ static std::string resolve_ltc_param(Il2CppObject* obj)
       }
     }
 
-    auto* identifier = read_il2cpp_reference_field<Il2CppString>(obj, "Identifier", "<Identifier>k__BackingField");
+    auto* identifier =
+        read_il2cpp_reference_field<Il2CppString>(obj, {"_identifier", "Identifier", "<Identifier>k__BackingField"});
     return identifier ? to_string(identifier) : "?";
   }
 
@@ -414,35 +590,68 @@ static std::string resolve_ltc_param(Il2CppObject* obj)
   return fmt::format("<{}>", name);
 }
 
-static std::string resolve_ltc_formatted(void* ltc, std::string_view template_text)
+static std::vector<std::string> resolve_text_parameter_values(Il2CppArray* text_parameters)
 {
-  if (!ltc) {
-    return notification_strip_unity_rich_text(template_text);
-  }
-
-  auto* ltc_object = reinterpret_cast<Il2CppObject*>(ltc);
-  auto* text_parameters =
-      read_il2cpp_reference_field<Il2CppArray>(ltc_object, "TextParameters", "<TextParameters>k__BackingField");
   if (!text_parameters) {
-    return notification_strip_unity_rich_text(template_text);
+    return {};
   }
 
   auto  length   = il2cpp_array_length(text_parameters);
   auto* elements = reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(text_parameters) + sizeof(Il2CppArray));
 
-  auto result = std::string(template_text);
-  for (il2cpp_array_size_t i = 0; i < length && i < 16; ++i) {
-    auto placeholder = fmt::format("{{{}}}", i);
-    auto replacement = resolve_ltc_param(elements[i]);
-
-    size_t position = 0;
-    while ((position = result.find(placeholder, position)) != std::string::npos) {
-      result.replace(position, placeholder.size(), replacement);
-      position += replacement.size();
-    }
+  std::vector<std::string> parameters;
+  parameters.reserve(length < 32 ? length : 32);
+  for (il2cpp_array_size_t i = 0; i < length && i < 32; ++i) {
+    parameters.push_back(resolve_ltc_param(elements[i]));
   }
 
-  return notification_strip_unity_rich_text(result);
+  return parameters;
+}
+
+static std::string resolve_toast_formatted(Toast* toast, void* ltc, std::string_view template_text, int state)
+{
+  if (!ltc) {
+    return notification_strip_unity_rich_text(template_text);
+  }
+
+  auto parameters = resolve_text_parameter_values(resolve_toast_text_parameters(toast, ltc));
+  auto formatted  = notification_strip_unity_rich_text(notification_format_placeholders(template_text, parameters));
+  if (notification_contains_placeholders(formatted)) {
+    if (auto armada_formatted = resolve_armada_created_formatted(toast, state, template_text);
+        !armada_formatted.empty()) {
+      formatted = std::move(armada_formatted);
+    }
+  }
+  return formatted;
+}
+
+static void resolve_language_manager_localize_methods()
+{
+  auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
+  if (!lm_helper.isValidHelper()) {
+    spdlog::warn("[Notify] LanguageManager class helper is invalid");
+    return;
+  }
+
+  auto* cls = lm_helper.get_cls();
+  if (!cls) {
+    spdlog::warn("[Notify] LanguageManager class not found");
+    return;
+  }
+
+  void* iter = nullptr;
+  while (auto* method = il2cpp_class_get_methods(cls, &iter)) {
+    auto name = std::string_view(il2cpp_method_get_name(method));
+    if (name != "Localize") {
+      continue;
+    }
+
+    const auto pc = il2cpp_method_get_param_count(method);
+    if (pc == 2) {
+      s_localize_ltc = method;
+      break;
+    }
+  }
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────────────
@@ -453,24 +662,7 @@ void notification_init()
     return;
   }
 
-  // Resolve LanguageManager::Localize(out string, LocaleTextContext) — the
-  // 2-parameter overload that takes an LTC and returns a localized string.
-  auto lm_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Localization", "LanguageManager");
-  if (lm_helper.isValidHelper()) {
-    auto* cls = lm_helper.get_cls();
-    if (cls) {
-      void* iter = nullptr;
-      while (auto* method = il2cpp_class_get_methods(cls, &iter)) {
-        auto name = std::string_view(il2cpp_method_get_name(method));
-        auto pc   = il2cpp_method_get_param_count(method);
-        if (name == "Localize" && pc == 2) {
-          s_localize_ltc = method;
-          spdlog::debug("[Notify] Resolved LanguageManager::Localize(out, LTC) at {:p}", (const void*)method);
-          break;
-        }
-      }
-    }
-  }
+  resolve_language_manager_localize_methods();
 
   if (!s_localize_ltc) {
     spdlog::warn("[Notify] Could not resolve LanguageManager::Localize — notifications will show titles only");
@@ -577,8 +769,8 @@ void notification_handle_generic_toast(Toast* toast, int state, const char* titl
   std::string localized_body;
   std::string formatted_localized_body;
   if (parsed_body.empty()) {
-    localized_body           = resolve_toast_text(toast);
-    formatted_localized_body = resolve_ltc_formatted(ltc, localized_body);
+    localized_body           = resolve_toast_text(ltc);
+    formatted_localized_body = resolve_toast_formatted(toast, ltc, localized_body, state);
   }
   auto body = notification_choose_body(parsed_body, formatted_localized_body, localized_body);
 

--- a/mods/src/patches/notification_text.cc
+++ b/mods/src/patches/notification_text.cc
@@ -4,6 +4,203 @@
  */
 #include "patches/notification_text.h"
 
+#include <vector>
+
+namespace
+{
+bool ascii_iequals(std::string_view left, std::string_view right)
+{
+  if (left.size() != right.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < left.size(); ++i) {
+    auto lhs = left[i];
+    auto rhs = right[i];
+    if (lhs >= 'A' && lhs <= 'Z') {
+      lhs = static_cast<char>(lhs - 'A' + 'a');
+    }
+    if (rhs >= 'A' && rhs <= 'Z') {
+      rhs = static_cast<char>(rhs - 'A' + 'a');
+    }
+    if (lhs != rhs) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool is_tag_name_char(char ch)
+{ return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '-'; }
+
+size_t find_rich_text_tag_end(std::string_view text, size_t start)
+{
+  char quote = '\0';
+  for (size_t i = start + 1; i < text.size(); ++i) {
+    const auto ch = text[i];
+    if (quote != '\0') {
+      if (ch == quote) {
+        quote = '\0';
+      }
+      continue;
+    }
+
+    if (ch == '"' || ch == '\'') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch == '>') {
+      return i;
+    }
+  }
+
+  return std::string_view::npos;
+}
+
+bool is_unity_rich_text_tag(std::string_view tag)
+{
+  while (!tag.empty() && tag.front() == ' ') {
+    tag.remove_prefix(1);
+  }
+  while (!tag.empty() && tag.back() == ' ') {
+    tag.remove_suffix(1);
+  }
+  if (tag.empty()) {
+    return false;
+  }
+
+  if (tag.front() == '/') {
+    tag.remove_prefix(1);
+  }
+
+  size_t name_length = 0;
+  while (name_length < tag.size() && is_tag_name_char(tag[name_length])) {
+    ++name_length;
+  }
+  if (name_length == 0) {
+    return false;
+  }
+
+  const auto                 name         = tag.substr(0, name_length);
+  constexpr std::string_view known_tags[] = {
+      "align",    "allcaps",   "alpha",     "b",           "br",           "color",
+      "cspace",   "font",      "i",         "indent",      "line-height",  "line-indent",
+      "link",     "lowercase", "margin",    "margin-left", "margin-right", "mark",
+      "material", "mspace",    "nobr",      "page",        "pos",          "rotate",
+      "s",        "size",      "smallcaps", "space",       "sprite",       "style",
+      "sub",      "sup",       "u",         "uppercase",   "voffset",      "width",
+  };
+
+  for (const auto known_tag : known_tags) {
+    if (ascii_iequals(name, known_tag)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool placeholder_suffix_starts(char ch)
+{ return ch == ':' || ch == '.' || ch == ','; }
+
+bool is_zero_padding_suffix(std::string_view suffix)
+{
+  if (suffix.empty()) {
+    return false;
+  }
+
+  for (const auto ch : suffix) {
+    if (ch != '0') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool is_integer_text(std::string_view text)
+{
+  if (text.empty()) {
+    return false;
+  }
+
+  if (text.front() == '-') {
+    text.remove_prefix(1);
+  }
+  if (text.empty()) {
+    return false;
+  }
+
+  for (const auto ch : text) {
+    if (ch < '0' || ch > '9') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::string format_placeholder_value(std::string_view parameter, std::string_view suffix)
+{
+  if (!is_zero_padding_suffix(suffix) || !is_integer_text(parameter)) {
+    return std::string(parameter);
+  }
+
+  const auto negative = parameter.front() == '-';
+  if (negative) {
+    parameter.remove_prefix(1);
+  }
+
+  std::string result;
+  if (negative) {
+    result.push_back('-');
+  }
+  if (parameter.size() < suffix.size()) {
+    result.append(suffix.size() - parameter.size(), '0');
+  }
+  result.append(parameter);
+  return result;
+}
+
+size_t find_placeholder_end(std::string_view text, size_t start, size_t* placeholder_index = nullptr)
+{
+  if (start >= text.size() || text[start] != '{') {
+    return std::string_view::npos;
+  }
+
+  auto       cursor = start + 1;
+  size_t     index  = 0;
+  const auto digits = cursor;
+  while (cursor < text.size() && text[cursor] >= '0' && text[cursor] <= '9') {
+    index = (index * 10) + static_cast<size_t>(text[cursor] - '0');
+    ++cursor;
+  }
+
+  if (cursor == digits) {
+    return std::string_view::npos;
+  }
+
+  size_t end = cursor;
+  if (cursor < text.size() && text[cursor] == '}') {
+    end = cursor;
+  } else if (cursor < text.size() && placeholder_suffix_starts(text[cursor])) {
+    end = text.find('}', cursor + 1);
+    if (end == std::string_view::npos) {
+      return std::string_view::npos;
+    }
+  } else {
+    return std::string_view::npos;
+  }
+
+  if (placeholder_index) {
+    *placeholder_index = index;
+  }
+  return end;
+}
+} // namespace
+
 std::string notification_normalize_body(const char* body)
 {
   if (!body || !*body) {
@@ -99,8 +296,8 @@ std::string notification_strip_unity_rich_text(std::string_view text)
   size_t i = 0;
   while (i < text.size()) {
     if (text[i] == '<') {
-      auto end = text.find('>', i);
-      if (end != std::string_view::npos) {
+      auto end = find_rich_text_tag_end(text, i);
+      if (end != std::string_view::npos && is_unity_rich_text_tag(text.substr(i + 1, end - i - 1))) {
         i = end + 1;
         continue;
       }
@@ -112,10 +309,82 @@ std::string notification_strip_unity_rich_text(std::string_view text)
   return result;
 }
 
-std::string notification_choose_body(std::string_view parsed_body,
-                                     std::string_view formatted_localized_body,
-                                     std::string_view raw_localized_body,
-                                     std::string_view fallback)
+bool notification_contains_placeholders(std::string_view text)
+{
+  size_t position = 0;
+  while ((position = text.find('{', position)) != std::string_view::npos) {
+    if (find_placeholder_end(text, position) != std::string_view::npos) {
+      return true;
+    }
+    ++position;
+  }
+
+  return false;
+}
+
+std::string notification_format_placeholders(std::string_view text, std::span<const std::string> parameters)
+{
+  std::string result;
+  result.reserve(text.size());
+
+  size_t position = 0;
+  while (position < text.size()) {
+    if (text[position] != '{') {
+      result.push_back(text[position++]);
+      continue;
+    }
+
+    if (position + 1 < text.size() && text[position + 1] == '{') {
+      result.append(text.substr(position, 2));
+      position += 2;
+      continue;
+    }
+
+    size_t index = 0;
+    auto   end   = find_placeholder_end(text, position, &index);
+    if (end == std::string_view::npos) {
+      result.push_back(text[position++]);
+      continue;
+    }
+
+    if (index < parameters.size()) {
+      auto cursor = position + 1;
+      while (cursor < end && text[cursor] >= '0' && text[cursor] <= '9') {
+        ++cursor;
+      }
+
+      std::string_view suffix;
+      if (cursor < end && placeholder_suffix_starts(text[cursor])) {
+        suffix = text.substr(cursor + 1, end - cursor - 1);
+      }
+
+      result.append(format_placeholder_value(parameters[index], suffix));
+    } else {
+      result.append(text.substr(position, end - position + 1));
+    }
+    position = end + 1;
+  }
+
+  return result;
+}
+
+std::string notification_format_armada_created_body(std::string_view template_text, std::string_view alliance_color,
+                                                    std::string_view alliance_tag, std::string_view owner_name,
+                                                    std::string_view fleet_capacity,
+                                                    std::string_view target_level_color, std::string_view target_level,
+                                                    std::string_view target_label)
+{
+  const std::vector<std::string> parameters{
+      std::string(alliance_color), std::string(alliance_tag),       std::string(owner_name),
+      std::string(fleet_capacity), std::string(target_level_color), std::string(target_level),
+      std::string(target_label),
+  };
+
+  return notification_strip_unity_rich_text(notification_format_placeholders(template_text, parameters));
+}
+
+std::string notification_choose_body(std::string_view parsed_body, std::string_view formatted_localized_body,
+                                     std::string_view raw_localized_body, std::string_view fallback)
 {
   if (!parsed_body.empty()) {
     return std::string(parsed_body);

--- a/mods/src/patches/notification_text.h
+++ b/mods/src/patches/notification_text.h
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -11,7 +12,13 @@ std::string notification_normalize_body(const char* body);
 std::string notification_flatten_text(std::string_view text);
 std::string notification_escape_text_for_log(std::string_view text);
 std::string notification_strip_unity_rich_text(std::string_view text);
-std::string notification_choose_body(std::string_view parsed_body,
-                                     std::string_view formatted_localized_body,
+bool        notification_contains_placeholders(std::string_view text);
+std::string notification_format_placeholders(std::string_view text, std::span<const std::string> parameters);
+std::string notification_format_armada_created_body(std::string_view template_text, std::string_view alliance_color,
+                                                    std::string_view alliance_tag, std::string_view owner_name,
+                                                    std::string_view fleet_capacity,
+                                                    std::string_view target_level_color, std::string_view target_level,
+                                                    std::string_view target_label);
+std::string notification_choose_body(std::string_view parsed_body, std::string_view formatted_localized_body,
                                      std::string_view raw_localized_body,
                                      std::string_view fallback = "(no details available)");

--- a/tests/src/test_notifications_and_dedupe.cc
+++ b/tests/src/test_notifications_and_dedupe.cc
@@ -94,6 +94,58 @@ TEST_SUITE("notification_text")
   TEST_CASE("strips Unity rich text tags")
   { CHECK(notification_strip_unity_rich_text("<color=#fff>Alpha</color> <b>Beta</b>") == "Alpha Beta"); }
 
+  TEST_CASE("strips Armada toast rich text without losing notification copy")
+  {
+    CHECK(notification_strip_unity_rich_text("<size=28><color=#FF7F7F>ARMADA ALERT!</color></size> "
+                                             "<size=20><color=#40FF60>[ABC] Pike</color> is targeting your "
+                                             "station.</size>")
+          == "ARMADA ALERT! [ABC] Pike is targeting your station.");
+  }
+
+  TEST_CASE("strips quoted TMP link tags and preserves non-tag angle text")
+  {
+    CHECK(notification_strip_unity_rich_text(
+              "Find <link=\"fleetcommand://link/navigation/system?ID=159663443\">Alma</link> now")
+          == "Find Alma now");
+    CHECK(notification_strip_unity_rich_text("Keep values < 10 > 5 visible") == "Keep values < 10 > 5 visible");
+  }
+
+  TEST_CASE("formats localization placeholders before stripping Armada rich text")
+  {
+    const std::vector<std::string> parameters{"#40FF60", "ABC", "Pike", "5", "unused", "120K", "in 5m"};
+    const auto                     formatted = notification_format_placeholders(
+        "<color={0}>[{1}] {2}</color> started an Armada! <size=30>down {3} up {5.000} {6}</size>", parameters);
+
+    CHECK(notification_strip_unity_rich_text(formatted) == "[ABC] Pike started an Armada! down 5 up 120K in 5m");
+  }
+
+  TEST_CASE("zero-pads numeric localization placeholders")
+  {
+    const std::vector<std::string> numeric{"5", "-7", "120K"};
+
+    CHECK(notification_format_placeholders("{0:000}", numeric) == "005");
+    CHECK(notification_format_placeholders("{1:000}", numeric) == "-007");
+    CHECK(notification_format_placeholders("{2:000}", numeric) == "120K");
+  }
+
+  TEST_CASE("formats Armada Created fallback body")
+  {
+    const auto body = notification_format_armada_created_body(
+        "<color={0}>[{1}] {2}</color> started an Armada!\n<size=30>down</size> "
+        "<size=24><b>{3} </b></size><color={4}><size=20> up {5:000} {6}",
+        "#ffffff", "HORD", "xxxpalpainexxx", "6", "#ffffff", "45", "Armada Target");
+
+    CHECK(body == "[HORD] xxxpalpainexxx started an Armada!\ndown 6  up 045 Armada Target");
+  }
+
+  TEST_CASE("detects unresolved localization placeholders")
+  {
+    CHECK(notification_contains_placeholders("[{1}] {2} started an Armada"));
+    CHECK(notification_contains_placeholders("up {5.000} {6}"));
+    CHECK_FALSE(notification_contains_placeholders("Keep values < 10 > 5 visible"));
+    CHECK_FALSE(notification_contains_placeholders("literal {name} text"));
+  }
+
   TEST_CASE("chooses parsed body before localized fallbacks")
   {
     CHECK(notification_choose_body("parsed", "formatted", "raw") == "parsed");


### PR DESCRIPTION
## What changed
- parse Armada start notifications with richer text handling instead of relying on the previous brittle text path
- update notification text/service handling to keep the Armada start message usable in Windows notifications
- add targeted notification parser tests and the investigation SOP note used to validate the format

## Why
Armada start notifications were being parsed incorrectly once the incoming text included richer formatting, which broke or degraded the Windows notification output.

## Impact
Windows Armada start notifications should render the actionable text correctly again without regressing the surrounding notification pipeline.

## Validation
- `ax validate -BuildMode release -Tail 120 -CleanTree`