### PR TITLE
[codex] fix: correct section change trigger signature

### DIFF
--- a/mods/src/patches/section_change_router.cc
+++ b/mods/src/patches/section_change_router.cc
@@ -38,7 +38,7 @@ void notify_observer(const SectionChangeObserver& observer,
   }
 }
 
-void SectionManager_TriggerSectionChange_Router_Hook(auto            original,
+bool SectionManager_TriggerSectionChange_Router_Hook(auto            original,
                                                      SectionManager* self,
                                                      SectionID       nextSectionID,
                                                      void*           args,
@@ -46,7 +46,7 @@ void SectionManager_TriggerSectionChange_Router_Hook(auto            original,
                                                      bool            isGoBackStep,
                                                      bool            allowSameSection)
 {
-  const SectionChangeContext context{
+  SectionChangeContext context{
       .manager               = self,
       .next_section          = nextSectionID,
       .args                  = args,
@@ -59,11 +59,14 @@ void SectionManager_TriggerSectionChange_Router_Hook(auto            original,
     notify_observer(observer, context, observer.before_original);
   }
 
-  original(self, nextSectionID, args, forcedSectionChange, isGoBackStep, allowSameSection);
+  const auto changed = original(self, nextSectionID, args, forcedSectionChange, isGoBackStep, allowSameSection);
+  context.changed    = changed;
 
   for (const auto& observer : observers()) {
     notify_observer(observer, context, observer.after_original);
   }
+
+  return changed;
 }
 } // namespace
 
@@ -105,7 +108,7 @@ void InstallSectionChangeRouterHooks()
     return;
   }
 
-  auto trigger_section_change = section_manager.GetMethod("TriggerSectionChange");
+  auto trigger_section_change = section_manager.GetMethod("TriggerSectionChange", 5);
   if (trigger_section_change == nullptr) {
     hooks.record_missing_method(kSectionManagerTriggerSectionChangeHook);
     hooks.log_summary();

--- a/mods/src/patches/section_change_router.h
+++ b/mods/src/patches/section_change_router.h
@@ -11,6 +11,7 @@ struct SectionChangeContext {
   bool            forced_section_change = false;
   bool            is_go_back_step = false;
   bool            allow_same_section = false;
+  bool            changed = false;
 };
 
 struct SectionChangeObserver {

--- a/mods/src/prime/Hub.h
+++ b/mods/src/prime/Hub.h
@@ -215,20 +215,22 @@ public:
   __declspec(property(get = __get__sectionStorage)) SectionStorage* _sectionStorage;
   __declspec(property(get = __get__history)) SectionNavHistory* _history;
 
-  void TriggerSectionChange(SectionID nextSectionID, void* args, bool forcedSectionChange = false,
+  bool TriggerSectionChange(SectionID nextSectionID, void* args, bool forcedSectionChange = false,
                             bool isGoBackStep = false, bool allowSameSection = false)
   {
     static auto triggerWarn = true;
     static auto triggerMethod =
-        get_class_helper().GetMethod<void(void*, SectionID, void*, bool, bool isGoBackStep, bool allowSameSection)>(
-            "TriggerSectionChange");
+        get_class_helper().GetMethod<bool(void*, SectionID, void*, bool, bool isGoBackStep, bool allowSameSection)>(
+            "TriggerSectionChange", 5);
 
     if (triggerMethod) {
-      triggerMethod(this, nextSectionID, args, forcedSectionChange, isGoBackStep, allowSameSection);
+      return triggerMethod(this, nextSectionID, args, forcedSectionChange, isGoBackStep, allowSameSection);
     } else if (triggerWarn) {
       triggerWarn = false;
       ErrorMsg::MissingMethod("SectionManager", "TriggerSectionChange");
     }
+
+    return false;
   }
 
 private:


### PR DESCRIPTION
## What changed
- corrected the `SectionManager::TriggerSectionChange` wrapper to use the bool-returning overload with explicit arg count `5`
- updated the section change router detour to hook the same bool-returning overload and return the original result
- recorded the original return value on `SectionChangeContext` for after-original observers

## Why
Private main already has the working Claim All flyout behavior, but the section-change seam still used a stale void/unqualified `TriggerSectionChange` signature. That left the router and `Hub` wrapper out of sync with the current runtime method shape.

## Impact
This keeps the existing flyout behavior while cleaning up the underlying section-change hook and wrapper so later work in this area is built on the correct method contract.

## Validation
- `ax validate -BuildMode release -Tail 120`
- `ax cycle -BuildMode release -Tail 120 -ErrorLast 20`