### PR TITLE
Add release preflight for fork tags

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -2,7 +2,10 @@
 
 Before tagging a release:
 
-1. Validate the exact production/release build candidate, not only a local dev build.
-2. Verify the candidate branch/tag after CI artifacts are produced.
-3. Confirm any science/dormant hooks are either explicitly unsupported or deliberately promoted before release.
-4. Record known risk and test coverage gaps before publishing the tag.
+1. Merge the release candidate to `Guffawaffle/stfc-mod:main`.
+2. Wait for the `Build` workflow on the exact target SHA to complete successfully.
+3. Smoke the exact production artifact from that run, not only a local dev build.
+4. Run `global.stfc-mod-private.release-preflight` in dry-run mode with smoke acknowledged.
+5. Push the proposed tag through the release preflight command only after blockers are clear.
+6. Confirm any science/dormant hooks are either explicitly unsupported or deliberately promoted before release.
+7. Record known risk and test coverage gaps before publishing the tag.

--- a/manifests/capabilities/global.stfc-mod-private.release-preflight.json
+++ b/manifests/capabilities/global.stfc-mod-private.release-preflight.json
@@ -69,7 +69,7 @@
   "outputModes": [
     "json"
   ],
-  "sideEffects": "unknown",
+  "sideEffects": "write",
   "scope": "global",
   "lifecycleState": "active",
   "defaults": {

--- a/manifests/capabilities/global.stfc-mod-private.release-preflight.json
+++ b/manifests/capabilities/global.stfc-mod-private.release-preflight.json
@@ -1,0 +1,106 @@
+{
+  "manifestVersion": "axf/v0",
+  "id": "global.stfc-mod-private.release-preflight",
+  "summary": "Release preflight for Guffawaffle fork tags: repo, target SHA, Build run, artifacts, smoke ack, and optional tag push",
+  "provider": "stfc",
+  "adapterType": "cli",
+  "executionTarget": {
+    "launcher": {
+      "command": "pwsh",
+      "args": [
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File"
+      ]
+    },
+    "target": {
+      "path": "scripts/axf/release-preflight.ps1",
+      "relativeTo": "workspace"
+    }
+  },
+  "argsSchema": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "description": "Expected GitHub repository owner/name. Defaults to Guffawaffle/stfc-mod."
+      },
+      "base-branch": {
+        "type": "string",
+        "description": "Expected release branch. Defaults to main."
+      },
+      "target-ref": {
+        "type": "string",
+        "description": "Git ref to tag. Defaults to origin/<base-branch>."
+      },
+      "tag": {
+        "type": "string",
+        "description": "Explicit release tag. Omit to infer the next stable vX.Y.Z-guffa.N tag."
+      },
+      "run-limit": {
+        "type": "integer",
+        "description": "Number of recent Build runs to inspect."
+      },
+      "smoke-acknowledged": {
+        "type": "boolean",
+        "description": "Required acknowledgement that the exact production artifact was smoked."
+      },
+      "push-tag": {
+        "type": "boolean",
+        "description": "Create and push the proposed tag after all blockers pass."
+      },
+      "allow-dirty": {
+        "type": "boolean",
+        "description": "Allow tag push from a dirty local worktree."
+      },
+      "skip-build-check": {
+        "type": "boolean",
+        "description": "Skip matching Build workflow verification. For debugging only."
+      },
+      "skip-artifact-check": {
+        "type": "boolean",
+        "description": "Skip matching artifact verification. For debugging only."
+      }
+    },
+    "additionalProperties": false
+  },
+  "outputModes": [
+    "json"
+  ],
+  "sideEffects": "unknown",
+  "scope": "global",
+  "lifecycleState": "active",
+  "defaults": {
+    "repo": "Guffawaffle/stfc-mod",
+    "base-branch": "main",
+    "run-limit": 50
+  },
+  "policies": [
+    "require_workspace_binding"
+  ],
+  "owner": "module:stfc",
+  "argMap": {
+    "repo": "-Repo",
+    "base-branch": "-BaseBranch",
+    "target-ref": "-TargetRef",
+    "tag": "-Tag",
+    "run-limit": "-RunLimit",
+    "smoke-acknowledged": "-SmokeAcknowledged",
+    "push-tag": "-PushTag",
+    "allow-dirty": "-AllowDirty",
+    "skip-build-check": "-SkipBuildCheck",
+    "skip-artifact-check": "-SkipArtifactCheck"
+  },
+  "warnings": [
+    "Default mode is dry-run/read-only. With -push-tag this command creates and pushes a release tag.",
+    "-smoke-acknowledged is required for a passing preflight because release tags must be based on a smoked production artifact.",
+    "Release tag pushes require the target SHA to match the freshly fetched origin/main SHA and use a stable vX.Y.Z-guffa.N tag.",
+    "Do not use -skip-build-check or -skip-artifact-check for release tagging; -push-tag refuses those skip flags."
+  ],
+  "details": [
+    "Verifies the current GitHub repo is Guffawaffle/stfc-mod, fetches origin/main, resolves the target SHA, infers or validates the stable fork tag, checks a matching successful Build workflow run from a push to main, and verifies expected artifacts are present.",
+    "The release workflow is still responsible for publishing the GitHub release after the tag is pushed."
+  ]
+}

--- a/scripts/axf/README.md
+++ b/scripts/axf/README.md
@@ -14,6 +14,7 @@ Primary capability IDs include:
 
 ```text
 global.stfc-mod-private.review-contract
+global.stfc-mod-private.release-preflight
 global.stfc-mod-private.doctor
 global.stfc-mod-private.windows-interop
 global.stfc-mod-private.status
@@ -37,6 +38,18 @@ for code and hook-adjacent branches. It runs:
 The gameplay seam scanner is blocking in this contract. The standalone scanner
 command remains useful for focused local checks, but review-ready branches should
 use the AXF review contract so the scanner is not skipped.
+
+## Release Preflight
+
+Use `global.stfc-mod-private.release-preflight` before pushing a fork release
+tag. The default mode is a dry run. It verifies the local GitHub repo target,
+the freshly fetched `origin/main` target SHA, the proposed `vX.Y.Z-guffa.N`
+tag, a successful matching `Build` workflow run from a push to `main`, expected
+release artifacts, and explicit smoke-test acknowledgement.
+
+Only pass `-PushTag` after the dry run is clean and the exact production
+artifact has been smoked. The release GitHub Actions workflow remains
+responsible for publishing release assets after the tag is pushed.
 
 For AXF 1.0.0 and later, this repo owns its STFC family manifests locally.
 Run `axf scout --write` from the repo root to regenerate

--- a/scripts/axf/release-preflight.ps1
+++ b/scripts/axf/release-preflight.ps1
@@ -1,0 +1,508 @@
+[CmdletBinding()]
+param(
+  [string]$Repo = "Guffawaffle/stfc-mod",
+  [string]$BaseBranch = "main",
+  [string]$TargetRef = "",
+  [string]$Tag = "",
+  [int]$RunLimit = 50,
+  [switch]$SmokeAcknowledged,
+  [switch]$PushTag,
+  [switch]$AllowDirty,
+  [switch]$SkipBuildCheck,
+  [switch]$SkipArtifactCheck
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$stableForkTagPattern = '^v\d+\.\d+\.\d+-guffa\.\d+$'
+$expectedArtifacts = @(
+  "stfc-community-mod",
+  "stfc-community-mod-macos-universal",
+  "stfc-community-mod-installer"
+)
+
+function Resolve-FirstCommand {
+  param([string[]]$Names)
+
+  foreach ($name in $Names) {
+    $cmd = Get-Command $name -ErrorAction SilentlyContinue
+    if ($cmd) {
+      return $cmd.Source
+    }
+  }
+
+  throw "None of these commands were found: $($Names -join ', ')"
+}
+
+function ConvertTo-LineTail {
+  param(
+    [string]$Text,
+    [int]$Count = 40,
+    [int]$MaxLineLength = 1200
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return @()
+  }
+
+  $lines = $Text -split "`r?`n" | Where-Object { $_ -ne "" } | ForEach-Object {
+    if ($_.Length -gt $MaxLineLength) {
+      "$($_.Substring(0, $MaxLineLength))...[truncated]"
+    } else {
+      $_
+    }
+  }
+  if ($lines.Count -le $Count) {
+    return @($lines)
+  }
+
+  return @($lines | Select-Object -Last $Count)
+}
+
+function Invoke-Captured {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  $psi = [System.Diagnostics.ProcessStartInfo]::new()
+  $psi.FileName = $FilePath
+  $psi.WorkingDirectory = $repoRoot.Path
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  foreach ($arg in $Arguments) {
+    [void]$psi.ArgumentList.Add($arg)
+  }
+
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $psi
+  [void]$process.Start()
+  $stdout = $process.StandardOutput.ReadToEnd()
+  $stderr = $process.StandardError.ReadToEnd()
+  $process.WaitForExit()
+
+  return [ordered]@{
+    exitCode = $process.ExitCode
+    stdout = $stdout
+    stderr = $stderr
+    stdoutTail = ConvertTo-LineTail $stdout
+    stderrTail = ConvertTo-LineTail $stderr
+  }
+}
+
+function ConvertFrom-JsonOrNull {
+  param([string]$Text)
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return $null
+  }
+
+  try {
+    return $Text | ConvertFrom-Json -Depth 40
+  } catch {
+    return $null
+  }
+}
+
+function Add-Problem {
+  param(
+    [System.Collections.ArrayList]$Target,
+    [string]$Code,
+    [string]$Message
+  )
+
+  [void]$Target.Add([ordered]@{
+    code = $Code
+    message = $Message
+  })
+}
+
+function Get-RemoteForkTags {
+  param(
+    [string]$Git,
+    [string]$Remote = "origin"
+  )
+
+  $result = Invoke-Captured $Git @("ls-remote", "--tags", $Remote, "v*-guffa.*")
+  if ($result.exitCode -ne 0) {
+    throw "git ls-remote failed: $($result.stderr)"
+  }
+
+  $tags = New-Object System.Collections.Generic.HashSet[string]
+  foreach ($line in ($result.stdout -split "`r?`n")) {
+    if ([string]::IsNullOrWhiteSpace($line)) {
+      continue
+    }
+
+    $parts = $line -split "\s+"
+    if ($parts.Count -lt 2) {
+      continue
+    }
+
+    $ref = $parts[1]
+    if (-not $ref.StartsWith("refs/tags/")) {
+      continue
+    }
+
+    $name = $ref.Substring("refs/tags/".Length)
+    if ($name.EndsWith("^{}")) {
+      $name = $name.Substring(0, $name.Length - 3)
+    }
+
+    [void]$tags.Add($name)
+  }
+
+  return @($tags)
+}
+
+function Resolve-NextForkTag {
+  param(
+    [string[]]$Tags
+  )
+
+  $stable = @()
+  foreach ($candidate in $Tags) {
+    if ($candidate -match '^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-guffa\.(?<fork>\d+)$') {
+      $stable += [pscustomobject]@{
+        tag = $candidate
+        major = [int]$Matches.major
+        minor = [int]$Matches.minor
+        patch = [int]$Matches.patch
+        fork = [int]$Matches.fork
+      }
+    }
+  }
+
+  if (-not $stable) {
+    throw "No stable vX.Y.Z-guffa.N tags found on origin."
+  }
+
+  $latest = $stable | Sort-Object major, minor, patch, fork | Select-Object -Last 1
+  return [ordered]@{
+    previousTag = $latest.tag
+    nextTag = "v$($latest.major).$($latest.minor).$($latest.patch)-guffa.$($latest.fork + 1)"
+    baseVersion = "$($latest.major).$($latest.minor).$($latest.patch)"
+  }
+}
+
+$blockers = [System.Collections.ArrayList]::new()
+$warnings = [System.Collections.ArrayList]::new()
+$steps = [ordered]@{}
+$commands = [ordered]@{}
+$tagAction = [ordered]@{
+  attempted = $false
+  createdLocalTag = $false
+  pushedTag = $false
+}
+
+try {
+  $git = Resolve-FirstCommand @("git")
+  $gh = Resolve-FirstCommand @("gh")
+  $commands.git = $git
+  $commands.gh = $gh
+
+  if ([string]::IsNullOrWhiteSpace($TargetRef)) {
+    $TargetRef = "origin/$BaseBranch"
+  }
+
+  $fetchBase = Invoke-Captured $git @(
+    "fetch",
+    "origin",
+    "+refs/heads/$($BaseBranch):refs/remotes/origin/$($BaseBranch)",
+    "--prune"
+  )
+  $steps.fetchBase = [ordered]@{
+    ok = ($fetchBase.exitCode -eq 0)
+    command = "git fetch origin +refs/heads/$($BaseBranch):refs/remotes/origin/$($BaseBranch) --prune"
+    exitCode = $fetchBase.exitCode
+    stdoutTail = $fetchBase.stdoutTail
+    stderrTail = $fetchBase.stderrTail
+  }
+  if (-not $steps.fetchBase.ok) {
+    Add-Problem $blockers "fetch-base-failed" "Could not fetch origin/$BaseBranch before resolving the release target."
+  }
+
+  $repoView = Invoke-Captured $gh @("repo", "view", "--json", "nameWithOwner,defaultBranchRef")
+  $repoData = ConvertFrom-JsonOrNull $repoView.stdout
+  $steps.repository = [ordered]@{
+    ok = ($repoView.exitCode -eq 0) -and ($repoData -ne $null)
+    command = "gh repo view --json nameWithOwner,defaultBranchRef"
+    exitCode = $repoView.exitCode
+    data = $repoData
+    stdoutTail = $repoView.stdoutTail
+    stderrTail = $repoView.stderrTail
+  }
+
+  if (-not $steps.repository.ok) {
+    Add-Problem $blockers "repo-view-failed" "Could not resolve GitHub repository metadata."
+  } else {
+    if ($repoData.nameWithOwner -ne $Repo) {
+      Add-Problem $blockers "wrong-repository" "Expected $Repo but current GitHub repo is $($repoData.nameWithOwner)."
+    }
+    if ($repoData.defaultBranchRef.name -ne $BaseBranch) {
+      Add-Problem $warnings "unexpected-default-branch" "Expected default branch $BaseBranch but repo default is $($repoData.defaultBranchRef.name)."
+    }
+  }
+
+  $targetResolve = Invoke-Captured $git @("rev-parse", "$TargetRef^{commit}")
+  $targetSha = $targetResolve.stdout.Trim()
+  $steps.target = [ordered]@{
+    ok = ($targetResolve.exitCode -eq 0) -and ($targetSha -match '^[0-9a-f]{40}$')
+    targetRef = $TargetRef
+    targetSha = if ($targetSha) { $targetSha } else { $null }
+    command = "git rev-parse $TargetRef^{commit}"
+    exitCode = $targetResolve.exitCode
+    stdoutTail = $targetResolve.stdoutTail
+    stderrTail = $targetResolve.stderrTail
+  }
+
+  if (-not $steps.target.ok) {
+    Add-Problem $blockers "target-ref-unresolved" "Could not resolve target ref $TargetRef."
+  }
+
+  if ($TargetRef -ne "origin/$BaseBranch") {
+    Add-Problem $warnings "target-override" "Target ref is $TargetRef, not origin/$BaseBranch."
+  }
+
+  $baseResolve = Invoke-Captured $git @("rev-parse", "origin/$BaseBranch^{commit}")
+  $baseSha = $baseResolve.stdout.Trim()
+  $steps.base = [ordered]@{
+    ok = ($baseResolve.exitCode -eq 0) -and ($baseSha -match '^[0-9a-f]{40}$')
+    baseRef = "origin/$BaseBranch"
+    baseSha = if ($baseSha) { $baseSha } else { $null }
+    exitCode = $baseResolve.exitCode
+    stderrTail = $baseResolve.stderrTail
+  }
+
+  if (-not $steps.base.ok) {
+    Add-Problem $blockers "base-ref-unresolved" "Could not resolve origin/$BaseBranch."
+  } elseif ($targetSha -and $targetSha -ne $baseSha) {
+    if ($PushTag) {
+      Add-Problem $blockers "target-not-base-head" "Refusing to push a release tag for $targetSha because origin/$BaseBranch is $baseSha."
+    } else {
+      Add-Problem $warnings "target-not-base-head" "Target SHA $targetSha does not match origin/$BaseBranch $baseSha."
+    }
+  }
+
+  $status = Invoke-Captured $git @("status", "--porcelain")
+  $dirtyLines = @()
+  if (-not [string]::IsNullOrWhiteSpace($status.stdout)) {
+    $dirtyLines = @($status.stdout -split "`r?`n" | Where-Object { $_ -ne "" })
+  }
+  $steps.worktree = [ordered]@{
+    ok = ($status.exitCode -eq 0)
+    dirty = ($dirtyLines.Count -gt 0)
+    dirtyCount = $dirtyLines.Count
+    dirtyFiles = $dirtyLines
+  }
+  if ($dirtyLines.Count -gt 0) {
+    if ($PushTag -and -not $AllowDirty) {
+      Add-Problem $blockers "dirty-worktree" "Working tree is dirty; use -AllowDirty only if this is intentional."
+    } else {
+      Add-Problem $warnings "dirty-worktree" "Working tree is dirty; dry-run can continue, but tag push should use a clean tree."
+    }
+  }
+
+  $remoteTags = Get-RemoteForkTags $git
+  $tagPlan = Resolve-NextForkTag $remoteTags
+  if ([string]::IsNullOrWhiteSpace($Tag)) {
+    $Tag = $tagPlan.nextTag
+  }
+
+  $tagShapeOk = $Tag -match $stableForkTagPattern
+  $localTag = Invoke-Captured $git @("tag", "--list", $Tag)
+  $localTagExists = -not [string]::IsNullOrWhiteSpace($localTag.stdout)
+  $remoteTagExists = $remoteTags -contains $Tag
+  $steps.tag = [ordered]@{
+    ok = $tagShapeOk -and -not $remoteTagExists -and -not $localTagExists
+    proposedTag = $Tag
+    previousStableForkTag = $tagPlan.previousTag
+    inferredBaseVersion = $tagPlan.baseVersion
+    expectedPattern = $stableForkTagPattern
+    shapeOk = $tagShapeOk
+    localTagExists = $localTagExists
+    remoteTagExists = $remoteTagExists
+  }
+  if (-not $tagShapeOk) {
+    Add-Problem $blockers "tag-shape-invalid" "Tag $Tag is not a stable fork tag shaped like vX.Y.Z-guffa.N."
+  }
+  if ($localTagExists -or $remoteTagExists) {
+    Add-Problem $blockers "tag-exists" "Tag $Tag already exists locally or remotely."
+  }
+
+  if (-not $SmokeAcknowledged) {
+    Add-Problem $blockers "smoke-not-acknowledged" "Production artifact smoke has not been acknowledged."
+  }
+  if ($PushTag -and $SkipBuildCheck) {
+    Add-Problem $blockers "push-tag-skip-build-check" "Refusing to push a release tag while -SkipBuildCheck is set."
+  }
+  if ($PushTag -and $SkipArtifactCheck) {
+    Add-Problem $blockers "push-tag-skip-artifact-check" "Refusing to push a release tag while -SkipArtifactCheck is set."
+  }
+
+  $matchingBuild = $null
+  if ($SkipBuildCheck) {
+    $steps.buildRun = [ordered]@{
+      ok = $true
+      skipped = $true
+      reason = "SkipBuildCheck requested"
+    }
+  } else {
+    $runs = Invoke-Captured $gh @(
+      "run",
+      "list",
+      "--repo",
+      $Repo,
+      "--workflow",
+      "Build",
+      "--limit",
+      [string]$RunLimit,
+      "--json",
+      "databaseId,headSha,headBranch,status,conclusion,createdAt,url,workflowName,event"
+    )
+    $runsData = ConvertFrom-JsonOrNull $runs.stdout
+    $runRows = @()
+    if ($runsData) {
+      $runRows = @($runsData)
+    }
+    $matchingBuild = $runRows | Where-Object {
+      $_.headSha -eq $targetSha -and $_.status -eq "completed" -and $_.conclusion -eq "success"
+    } | Select-Object -First 1
+    $matchingBuildIsReleaseBuild = ($matchingBuild -ne $null) -and
+      ($matchingBuild.event -eq "push") -and
+      ($matchingBuild.headBranch -eq $BaseBranch)
+
+    $steps.buildRun = [ordered]@{
+      ok = ($runs.exitCode -eq 0) -and $matchingBuildIsReleaseBuild
+      command = "gh run list --repo $Repo --workflow Build --limit $RunLimit"
+      exitCode = $runs.exitCode
+      inspectedRunCount = $runRows.Count
+      matchingRun = $matchingBuild
+      expectedEvent = "push"
+      expectedHeadBranch = $BaseBranch
+      stdoutTail = $runs.stdoutTail
+      stderrTail = $runs.stderrTail
+    }
+
+    if (($runs.exitCode -eq 0) -and ($matchingBuild -ne $null) -and (-not $matchingBuildIsReleaseBuild)) {
+      Add-Problem $blockers "matching-build-not-main-push" "Matching Build run $($matchingBuild.databaseId) is not a push build for $BaseBranch."
+    } elseif (-not $steps.buildRun.ok) {
+      Add-Problem $blockers "matching-build-missing" "No successful Build workflow run found for target SHA $targetSha."
+    }
+  }
+
+  if ($SkipArtifactCheck) {
+    $steps.artifacts = [ordered]@{
+      ok = $true
+      skipped = $true
+      reason = "SkipArtifactCheck requested"
+    }
+  } elseif ($matchingBuild -ne $null) {
+    $artifacts = Invoke-Captured $gh @(
+      "api",
+      "/repos/$Repo/actions/runs/$($matchingBuild.databaseId)/artifacts"
+    )
+    $artifactData = ConvertFrom-JsonOrNull $artifacts.stdout
+    $artifactRows = @()
+    if ($artifactData -and $artifactData.artifacts) {
+      $artifactRows = @($artifactData.artifacts)
+    }
+
+    $artifactNames = @($artifactRows | ForEach-Object { $_.name })
+    $missingArtifacts = @($expectedArtifacts | Where-Object { $artifactNames -notcontains $_ })
+    $expiredArtifacts = @($artifactRows | Where-Object { $_.expired -eq $true } | ForEach-Object { $_.name })
+    $artifactsOk = ($artifacts.exitCode -eq 0) -and ($missingArtifacts.Count -eq 0) -and ($expiredArtifacts.Count -eq 0)
+    $steps.artifacts = [ordered]@{
+      ok = $artifactsOk
+      command = "gh api /repos/$Repo/actions/runs/$($matchingBuild.databaseId)/artifacts"
+      exitCode = $artifacts.exitCode
+      expected = $expectedArtifacts
+      found = $artifactNames
+      missing = $missingArtifacts
+      expired = $expiredArtifacts
+      stderrTail = $artifacts.stderrTail
+    }
+
+    foreach ($missing in $missingArtifacts) {
+      Add-Problem $blockers "artifact-missing" "Build run $($matchingBuild.databaseId) is missing artifact $missing."
+    }
+    foreach ($expired in $expiredArtifacts) {
+      Add-Problem $blockers "artifact-expired" "Build run $($matchingBuild.databaseId) artifact $expired is expired."
+    }
+  } else {
+    $steps.artifacts = [ordered]@{
+      ok = $false
+      skipped = $true
+      reason = "No matching build run available for artifact lookup"
+    }
+    Add-Problem $blockers "artifact-check-unavailable" "Could not verify artifacts because no matching Build workflow run was available."
+  }
+
+  $readyToTag = ($blockers.Count -eq 0)
+
+  if ($PushTag) {
+    $tagAction.attempted = $true
+    if (-not $readyToTag) {
+      $tagAction.skippedReason = "preflight blockers present"
+    } else {
+      $createTag = Invoke-Captured $git @("tag", "-a", $Tag, $targetSha, "-m", $Tag)
+      $tagAction.createTag = $createTag
+      if ($createTag.exitCode -eq 0) {
+        $tagAction.createdLocalTag = $true
+        $push = Invoke-Captured $git @("push", "origin", $Tag)
+        $tagAction.push = $push
+        if ($push.exitCode -eq 0) {
+          $tagAction.pushedTag = $true
+        } else {
+          Add-Problem $blockers "tag-push-failed" "Created local tag $Tag but failed to push it."
+        }
+      } else {
+        Add-Problem $blockers "tag-create-failed" "Failed to create local tag $Tag."
+      }
+    }
+  }
+
+  $ok = ($blockers.Count -eq 0)
+  $payload = [ordered]@{
+    ok = $ok
+    command = "release-preflight"
+    repoRoot = $repoRoot.Path
+    repo = $Repo
+    baseBranch = $BaseBranch
+    targetRef = $TargetRef
+    targetSha = if ($targetSha) { $targetSha } else { $null }
+    proposedTag = $Tag
+    dryRun = -not $PushTag
+    smokeAcknowledged = [bool]$SmokeAcknowledged
+    readyToTag = $readyToTag
+    blockers = @($blockers)
+    warnings = @($warnings)
+    steps = $steps
+    tagAction = $tagAction
+    commands = $commands
+  }
+
+  $payload | ConvertTo-Json -Depth 40
+  if ($ok) {
+    exit 0
+  }
+  exit 1
+} catch {
+  $payload = [ordered]@{
+    ok = $false
+    command = "release-preflight"
+    repoRoot = $repoRoot.Path
+    repo = $Repo
+    error = $_.Exception.Message
+    blockers = @($blockers)
+    warnings = @($warnings)
+    steps = $steps
+    tagAction = $tagAction
+    commands = $commands
+  }
+  $payload | ConvertTo-Json -Depth 40
+  exit 1
+}

--- a/scripts/axf/release-preflight.ps1
+++ b/scripts/axf/release-preflight.ps1
@@ -363,9 +363,18 @@ try {
       "--json",
       "databaseId,headSha,headBranch,status,conclusion,createdAt,url,workflowName,event"
     )
-    $runsData = ConvertFrom-JsonOrNull $runs.stdout
+    $runsData = $null
+    $runsJsonOk = $false
+    if ($runs.exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($runs.stdout)) {
+      try {
+        $runsData = $runs.stdout | ConvertFrom-Json -Depth 40
+        $runsJsonOk = $true
+      } catch {
+        $runsJsonOk = $false
+      }
+    }
     $runRows = @()
-    if ($runsData) {
+    if ($runsJsonOk -and $runsData) {
       $runRows = @($runsData)
     }
     $matchingBuild = $runRows | Where-Object {
@@ -376,9 +385,10 @@ try {
       ($matchingBuild.headBranch -eq $BaseBranch)
 
     $steps.buildRun = [ordered]@{
-      ok = ($runs.exitCode -eq 0) -and $matchingBuildIsReleaseBuild
+      ok = ($runs.exitCode -eq 0) -and $runsJsonOk -and $matchingBuildIsReleaseBuild
       command = "gh run list --repo $Repo --workflow Build --limit $RunLimit"
       exitCode = $runs.exitCode
+      jsonOk = $runsJsonOk
       inspectedRunCount = $runRows.Count
       matchingRun = $matchingBuild
       expectedEvent = "push"
@@ -387,7 +397,11 @@ try {
       stderrTail = $runs.stderrTail
     }
 
-    if (($runs.exitCode -eq 0) -and ($matchingBuild -ne $null) -and (-not $matchingBuildIsReleaseBuild)) {
+    if ($runs.exitCode -ne 0) {
+      Add-Problem $blockers "build-run-list-failed" "Could not list Build workflow runs for $Repo."
+    } elseif (-not $runsJsonOk) {
+      Add-Problem $blockers "build-run-list-json-failed" "Build workflow run list output was empty or not valid JSON."
+    } elseif (($matchingBuild -ne $null) -and (-not $matchingBuildIsReleaseBuild)) {
       Add-Problem $blockers "matching-build-not-main-push" "Matching Build run $($matchingBuild.databaseId) is not a push build for $BaseBranch."
     } elseif (-not $steps.buildRun.ok) {
       Add-Problem $blockers "matching-build-missing" "No successful Build workflow run found for target SHA $targetSha."
@@ -405,20 +419,30 @@ try {
       "api",
       "/repos/$Repo/actions/runs/$($matchingBuild.databaseId)/artifacts"
     )
-    $artifactData = ConvertFrom-JsonOrNull $artifacts.stdout
+    $artifactData = $null
+    $artifactsJsonOk = $false
+    if ($artifacts.exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($artifacts.stdout)) {
+      try {
+        $artifactData = $artifacts.stdout | ConvertFrom-Json -Depth 40
+        $artifactsJsonOk = $true
+      } catch {
+        $artifactsJsonOk = $false
+      }
+    }
     $artifactRows = @()
-    if ($artifactData -and $artifactData.artifacts) {
+    if ($artifactsJsonOk -and $artifactData -and $artifactData.artifacts) {
       $artifactRows = @($artifactData.artifacts)
     }
 
     $artifactNames = @($artifactRows | ForEach-Object { $_.name })
     $missingArtifacts = @($expectedArtifacts | Where-Object { $artifactNames -notcontains $_ })
     $expiredArtifacts = @($artifactRows | Where-Object { $_.expired -eq $true } | ForEach-Object { $_.name })
-    $artifactsOk = ($artifacts.exitCode -eq 0) -and ($missingArtifacts.Count -eq 0) -and ($expiredArtifacts.Count -eq 0)
+    $artifactsOk = ($artifacts.exitCode -eq 0) -and $artifactsJsonOk -and ($missingArtifacts.Count -eq 0) -and ($expiredArtifacts.Count -eq 0)
     $steps.artifacts = [ordered]@{
       ok = $artifactsOk
       command = "gh api /repos/$Repo/actions/runs/$($matchingBuild.databaseId)/artifacts"
       exitCode = $artifacts.exitCode
+      jsonOk = $artifactsJsonOk
       expected = $expectedArtifacts
       found = $artifactNames
       missing = $missingArtifacts
@@ -426,11 +450,17 @@ try {
       stderrTail = $artifacts.stderrTail
     }
 
-    foreach ($missing in $missingArtifacts) {
-      Add-Problem $blockers "artifact-missing" "Build run $($matchingBuild.databaseId) is missing artifact $missing."
-    }
-    foreach ($expired in $expiredArtifacts) {
-      Add-Problem $blockers "artifact-expired" "Build run $($matchingBuild.databaseId) artifact $expired is expired."
+    if ($artifacts.exitCode -ne 0) {
+      Add-Problem $blockers "artifact-api-failed" "Could not list artifacts for Build run $($matchingBuild.databaseId)."
+    } elseif (-not $artifactsJsonOk) {
+      Add-Problem $blockers "artifact-api-json-failed" "Artifact API output for Build run $($matchingBuild.databaseId) was empty or not valid JSON."
+    } else {
+      foreach ($missing in $missingArtifacts) {
+        Add-Problem $blockers "artifact-missing" "Build run $($matchingBuild.databaseId) is missing artifact $missing."
+      }
+      foreach ($expired in $expiredArtifacts) {
+        Add-Problem $blockers "artifact-expired" "Build run $($matchingBuild.databaseId) artifact $expired is expired."
+      }
     }
   } else {
     $steps.artifacts = [ordered]@{


### PR DESCRIPTION
## Summary

Adds a tracked AXF release preflight capability for Guffawaffle fork tags.

This gives us a repeatable gate before pushing `vX.Y.Z-guffa.N` tags. It verifies the repo target, fetches and resolves `origin/main`, infers or validates the stable fork tag, requires explicit production-artifact smoke acknowledgement, checks for a successful `Build` workflow from a push to `main`, verifies the expected release artifacts are present and not expired, and can optionally create/push the tag only after blockers clear.

Also updates the AXF README and release checklist so the workflow is not tribal memory.

Closes #143.

## Validation

- `global.stfc-mod-private.release-preflight` inspected through AXF
- `global.stfc-mod-private.release-preflight` dry-run through AXF with `smoke-acknowledged=true` passes for `origin/main` SHA `f0166986ef3e4318db0ce2483579f143eb5845bb`, proposing `v2.1.0-guffa.5`
- Raw script negative checks:
  - missing smoke acknowledgement blocks with `smoke-not-acknowledged`
  - invalid RC-style tag blocks with `tag-shape-invalid`
  - `-PushTag` with skip flags refuses to push
- `git diff --check`
- `scripts/axf/review-contract.ps1 -Tail 120`