### PR TITLE
Define release withdrawal policy

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -9,3 +9,10 @@ Before tagging a release:
 5. Push the proposed tag through the release preflight command only after blockers are clear.
 6. Confirm any science/dormant hooks are either explicitly unsupported or deliberately promoted before release.
 7. Record known risk and test coverage gaps before publishing the tag.
+
+After publishing, if a release is found bad:
+
+1. Follow `docs/RELEASE_WITHDRAWAL_POLICY.md`.
+2. Prefer `superseded` or `known-bad` unless keeping the artifact downloadable is actively harmful.
+3. Use `global.stfc-mod-private.release-withdrawal` in dry-run mode before changing GitHub state.
+4. Do not delete/yank a release or tag without a non-empty reason, a reviewed destructive-action printout, and a durable ledger record.

--- a/docs/RELEASE_WITHDRAWAL_POLICY.md
+++ b/docs/RELEASE_WITHDRAWAL_POLICY.md
@@ -40,6 +40,9 @@ docs/release-withdrawals/release-withdrawals.jsonl
 
 Commit the ledger update after an executed withdrawal.
 
+Release-withdrawal commands accept only stable fork tags shaped like
+`vX.Y.Z-guffa.N` for both the affected tag and replacement tag.
+
 ## Command
 
 Use `global.stfc-mod-private.release-withdrawal`, or run the backing script
@@ -67,9 +70,9 @@ To execute after reviewing the dry-run:
   -Execute
 ```
 
-For a yanked release, the command writes the local ledger record before the
-destructive GitHub action and prints the exact delete command to stderr before
-running it:
+For a yanked release, the command writes a `pre-yank` local ledger record before
+the destructive GitHub action, prints the exact delete command to stderr before
+running it, and then writes a `post-yank` ledger record with the delete outcome:
 
 ```powershell
 .\scripts\axf\release-withdrawal.ps1 `

--- a/docs/RELEASE_WITHDRAWAL_POLICY.md
+++ b/docs/RELEASE_WITHDRAWAL_POLICY.md
@@ -1,0 +1,90 @@
+# Release Withdrawal Policy
+
+This fork defaults to preserving release history. Deleting a release and tag is
+reserved for user-impacting danger, a clearly broken artifact, or an artifact
+that must not remain downloadable.
+
+## Release States
+
+| State | Meaning | Default action |
+| --- | --- | --- |
+| Superseded | The release is safe enough to keep, but a newer release should be preferred. | Leave the release and tag in place, mark the release notes/title, and make the replacement release latest. |
+| Known-bad | The release is useful for audit/history, but users should not install it. | Leave the release and tag in place, mark the title and notes prominently, mark it prerelease, and make the replacement release latest when available. |
+| Yanked | The release artifact is dangerous, clearly broken, or should not remain downloadable. | Delete the GitHub release and remote tag intentionally, after recording the reason and replacement. |
+
+Deletion is not the default cleanup tool. Prefer `superseded` or `known-bad`
+unless keeping the artifact available would create user harm or ongoing support
+confusion.
+
+## Required Record
+
+Every withdrawal action needs a durable record containing:
+
+- affected tag
+- state
+- reason
+- replacement tag, if one exists
+- operator
+- timestamp
+- original release URL/target commit when available
+
+For `superseded` and `known-bad`, the release notes carry the visible warning
+and the repo ledger records the action. For `yanked`, the release notes disappear
+with the release, so the repo ledger is mandatory.
+
+The ledger lives at:
+
+```text
+docs/release-withdrawals/release-withdrawals.jsonl
+```
+
+Commit the ledger update after an executed withdrawal.
+
+## Command
+
+Use `global.stfc-mod-private.release-withdrawal`, or run the backing script
+directly:
+
+```powershell
+.\scripts\axf\release-withdrawal.ps1 `
+  -Tag v2.1.0-guffa.4 `
+  -State known-bad `
+  -Reason "Kir'Shara queue regression in production artifact" `
+  -ReplacementTag v2.1.0-guffa.5
+```
+
+The default mode is dry-run. It prints the planned release edits or destructive
+actions without changing GitHub.
+
+To execute after reviewing the dry-run:
+
+```powershell
+.\scripts\axf\release-withdrawal.ps1 `
+  -Tag v2.1.0-guffa.4 `
+  -State known-bad `
+  -Reason "Kir'Shara queue regression in production artifact" `
+  -ReplacementTag v2.1.0-guffa.5 `
+  -Execute
+```
+
+For a yanked release, the command writes the local ledger record before the
+destructive GitHub action and prints the exact delete command to stderr before
+running it:
+
+```powershell
+.\scripts\axf\release-withdrawal.ps1 `
+  -Tag v2.1.0-guffa.4 `
+  -State yanked `
+  -Reason "Artifact crashes on boot for confirmed users" `
+  -ReplacementTag v2.1.0-guffa.5 `
+  -Execute
+```
+
+That path runs the equivalent of:
+
+```text
+gh release delete <tag> --repo Guffawaffle/stfc-mod --cleanup-tag --yes
+```
+
+Use `yanked` only when preserving the artifact is worse than losing the public
+release/tag history.

--- a/docs/release-withdrawals/README.md
+++ b/docs/release-withdrawals/README.md
@@ -11,3 +11,6 @@ available.
 Use `global.stfc-mod-private.release-withdrawal` or
 `scripts/axf/release-withdrawal.ps1` to create records. Commit ledger updates
 after executing a real withdrawal.
+
+Yanked releases write a `pre-yank` record before deletion and a `post-yank`
+record after the attempted delete, including the delete exit code and outcome.

--- a/docs/release-withdrawals/README.md
+++ b/docs/release-withdrawals/README.md
@@ -1,0 +1,13 @@
+# Release Withdrawal Ledger
+
+`release-withdrawals.jsonl` is the durable repo-local record for fork release
+withdrawal actions.
+
+The file is intentionally JSONL so emergency actions can append a single record
+without rewriting history. Each record should include the affected tag, state,
+reason, replacement tag, operator, timestamp, and original release metadata when
+available.
+
+Use `global.stfc-mod-private.release-withdrawal` or
+`scripts/axf/release-withdrawal.ps1` to create records. Commit ledger updates
+after executing a real withdrawal.

--- a/manifests/capabilities/global.stfc-mod-private.release-withdrawal.json
+++ b/manifests/capabilities/global.stfc-mod-private.release-withdrawal.json
@@ -29,7 +29,7 @@
       },
       "tag": {
         "type": "string",
-        "description": "Release tag to mark, supersede, or yank."
+        "description": "Stable fork release tag to mark, supersede, or yank. Must be shaped like vX.Y.Z-guffa.N."
       },
       "state": {
         "type": "string",
@@ -46,7 +46,7 @@
       },
       "replacement-tag": {
         "type": "string",
-        "description": "Replacement release tag, when one exists."
+        "description": "Replacement stable fork release tag, when one exists. Must be shaped like vX.Y.Z-guffa.N."
       },
       "operator": {
         "type": "string",
@@ -91,11 +91,12 @@
     "Default mode is dry-run/read-only.",
     "The yanked state deletes the GitHub release and remote tag when -execute is set.",
     "Every state requires a non-empty reason.",
-    "Executed actions append a repo-local JSONL record; commit that record when using this command for a real withdrawal."
+    "Affected and replacement tags must be stable fork tags shaped like vX.Y.Z-guffa.N.",
+    "Executed actions append repo-local JSONL records; commit those records when using this command for a real withdrawal."
   ],
   "details": [
     "superseded edits release notes/title and optionally marks the replacement tag latest.",
     "known-bad edits release notes/title, marks the release prerelease, and optionally marks the replacement tag latest.",
-    "yanked writes a repo-local withdrawal record and then runs gh release delete <tag> --cleanup-tag --yes."
+    "yanked writes a pre-yank repo-local withdrawal record, runs gh release delete <tag> --cleanup-tag --yes, then writes a post-yank outcome record."
   ]
 }

--- a/manifests/capabilities/global.stfc-mod-private.release-withdrawal.json
+++ b/manifests/capabilities/global.stfc-mod-private.release-withdrawal.json
@@ -1,0 +1,101 @@
+{
+  "manifestVersion": "axf/v0",
+  "id": "global.stfc-mod-private.release-withdrawal",
+  "summary": "Dry-run-first release withdrawal helper for superseded, known-bad, and yanked fork releases",
+  "provider": "stfc",
+  "adapterType": "cli",
+  "executionTarget": {
+    "launcher": {
+      "command": "pwsh",
+      "args": [
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File"
+      ]
+    },
+    "target": {
+      "path": "scripts/axf/release-withdrawal.ps1",
+      "relativeTo": "workspace"
+    }
+  },
+  "argsSchema": {
+    "type": "object",
+    "properties": {
+      "repo": {
+        "type": "string",
+        "description": "GitHub repository owner/name. Defaults to Guffawaffle/stfc-mod."
+      },
+      "tag": {
+        "type": "string",
+        "description": "Release tag to mark, supersede, or yank."
+      },
+      "state": {
+        "type": "string",
+        "enum": [
+          "superseded",
+          "known-bad",
+          "yanked"
+        ],
+        "description": "Withdrawal state to apply."
+      },
+      "reason": {
+        "type": "string",
+        "description": "Required reason recorded in release notes or the withdrawal ledger."
+      },
+      "replacement-tag": {
+        "type": "string",
+        "description": "Replacement release tag, when one exists."
+      },
+      "operator": {
+        "type": "string",
+        "description": "Operator name to record. Defaults to the authenticated GitHub login."
+      },
+      "execute": {
+        "type": "boolean",
+        "description": "Run the planned action. Omit for dry-run."
+      },
+      "record-path": {
+        "type": "string",
+        "description": "Repo-local JSONL ledger path. Defaults to docs/release-withdrawals/release-withdrawals.jsonl."
+      }
+    },
+    "additionalProperties": false
+  },
+  "outputModes": [
+    "json"
+  ],
+  "sideEffects": "write",
+  "scope": "global",
+  "lifecycleState": "active",
+  "defaults": {
+    "repo": "Guffawaffle/stfc-mod",
+    "record-path": "docs/release-withdrawals/release-withdrawals.jsonl"
+  },
+  "policies": [
+    "require_workspace_binding"
+  ],
+  "owner": "module:stfc",
+  "argMap": {
+    "repo": "-Repo",
+    "tag": "-Tag",
+    "state": "-State",
+    "reason": "-Reason",
+    "replacement-tag": "-ReplacementTag",
+    "operator": "-Operator",
+    "execute": "-Execute",
+    "record-path": "-RecordPath"
+  },
+  "warnings": [
+    "Default mode is dry-run/read-only.",
+    "The yanked state deletes the GitHub release and remote tag when -execute is set.",
+    "Every state requires a non-empty reason.",
+    "Executed actions append a repo-local JSONL record; commit that record when using this command for a real withdrawal."
+  ],
+  "details": [
+    "superseded edits release notes/title and optionally marks the replacement tag latest.",
+    "known-bad edits release notes/title, marks the release prerelease, and optionally marks the replacement tag latest.",
+    "yanked writes a repo-local withdrawal record and then runs gh release delete <tag> --cleanup-tag --yes."
+  ]
+}

--- a/scripts/axf/README.md
+++ b/scripts/axf/README.md
@@ -15,6 +15,7 @@ Primary capability IDs include:
 ```text
 global.stfc-mod-private.review-contract
 global.stfc-mod-private.release-preflight
+global.stfc-mod-private.release-withdrawal
 global.stfc-mod-private.doctor
 global.stfc-mod-private.windows-interop
 global.stfc-mod-private.status
@@ -50,6 +51,17 @@ release artifacts, and explicit smoke-test acknowledgement.
 Only pass `-PushTag` after the dry run is clean and the exact production
 artifact has been smoked. The release GitHub Actions workflow remains
 responsible for publishing release assets after the tag is pushed.
+
+## Release Withdrawal
+
+Use `global.stfc-mod-private.release-withdrawal` when a published fork release
+needs to be superseded, marked known-bad, or yanked. The default mode is a dry
+run. Executed actions require a reason and append a repo-local JSONL record under
+`docs/release-withdrawals/`.
+
+The `yanked` state deletes the GitHub release and remote tag. Use it only after
+reviewing the dry-run output and confirming that preserving the artifact is worse
+than losing public release/tag history.
 
 For AXF 1.0.0 and later, this repo owns its STFC family manifests locally.
 Run `axf scout --write` from the repo root to regenerate

--- a/scripts/axf/README.md
+++ b/scripts/axf/README.md
@@ -56,8 +56,8 @@ responsible for publishing release assets after the tag is pushed.
 
 Use `global.stfc-mod-private.release-withdrawal` when a published fork release
 needs to be superseded, marked known-bad, or yanked. The default mode is a dry
-run. Executed actions require a reason and append a repo-local JSONL record under
-`docs/release-withdrawals/`.
+run. Dry runs and executed actions require a reason. Executed actions append a
+repo-local JSONL record under `docs/release-withdrawals/`.
 
 The `yanked` state deletes the GitHub release and remote tag. Use it only after
 reviewing the dry-run output and confirming that preserving the artifact is worse

--- a/scripts/axf/release-withdrawal.ps1
+++ b/scripts/axf/release-withdrawal.ps1
@@ -14,6 +14,7 @@ $ErrorActionPreference = "Stop"
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
 $validStates = @("superseded", "known-bad", "yanked")
+$stableForkTagPattern = '^v\d+\.\d+\.\d+-guffa\.\d+$'
 
 function Resolve-FirstCommand {
   param([string[]]$Names)
@@ -161,7 +162,7 @@ function Resolve-RecordPath {
 
 function Write-WithdrawalRecord {
   param(
-    [hashtable]$Record,
+    [System.Collections.IDictionary]$Record,
     [string]$Path
   )
 
@@ -174,6 +175,79 @@ function Write-WithdrawalRecord {
   $line = ($Record | ConvertTo-Json -Depth 20 -Compress)
   [System.IO.File]::AppendAllText($fullPath, "$line`n", [System.Text.UTF8Encoding]::new($false))
   return $fullPath
+}
+
+function Copy-WithdrawalRecord {
+  param([System.Collections.IDictionary]$Record)
+
+  $copy = [ordered]@{}
+  foreach ($key in $Record.Keys) {
+    $copy[$key] = $Record[$key]
+  }
+
+  return $copy
+}
+
+function Remove-LeadingReleaseWithdrawalNotice {
+  param([string]$Body)
+
+  if ([string]::IsNullOrWhiteSpace($Body)) {
+    return ""
+  }
+
+  $lines = @($Body -split "`r?`n")
+  if ($lines.Count -lt 6) {
+    return $Body
+  }
+
+  $hasExistingNotice = ($lines[0] -eq "> [!WARNING]") -and
+                       $lines[1].StartsWith("> Fork release state: **", [System.StringComparison]::Ordinal)
+  if (-not $hasExistingNotice) {
+    return $Body
+  }
+
+  $requiredPrefixes = @("> Reason: ", "> Replacement: ", "> Operator: ", "> Recorded: ")
+  for ($i = 0; $i -lt $requiredPrefixes.Count; $i++) {
+    if (-not $lines[$i + 2].StartsWith($requiredPrefixes[$i], [System.StringComparison]::Ordinal)) {
+      return $Body
+    }
+  }
+
+  $dropCount = 6
+  if ($lines.Count -gt $dropCount -and $lines[$dropCount] -eq "") {
+    $dropCount++
+  }
+  if ($lines.Count -le $dropCount) {
+    return ""
+  }
+
+  return ($lines[$dropCount..($lines.Count - 1)] -join "`r`n")
+}
+
+function New-WithdrawalExecutionRecord {
+  param(
+    [System.Collections.IDictionary]$BaseRecord,
+    [string]$Event,
+    [System.Collections.ArrayList]$ExecutedActions,
+    [System.Collections.ArrayList]$Blockers
+  )
+
+  $copy = Copy-WithdrawalRecord $BaseRecord
+  $copy.event = $Event
+  $copy.recordedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  $copy.ok = $Blockers.Count -eq 0
+  $deleteAction = @($ExecutedActions | Where-Object { $_.kind -eq "delete-release-and-tag" } | Select-Object -First 1)
+  if ($deleteAction.Count -gt 0) {
+    $copy.deleteExitCode = $deleteAction[0].exitCode
+    $copy.deleteSucceeded = $deleteAction[0].exitCode -eq 0
+  } else {
+    $copy.deleteExitCode = $null
+    $copy.deleteSucceeded = $false
+  }
+  $copy.executedActions = @($ExecutedActions)
+  $copy.blockers = @($Blockers)
+
+  return $copy
 }
 
 function Build-ReleaseNotice {
@@ -206,6 +280,7 @@ $blockers = [System.Collections.ArrayList]::new()
 $warnings = [System.Collections.ArrayList]::new()
 $plannedActions = [System.Collections.ArrayList]::new()
 $executedActions = [System.Collections.ArrayList]::new()
+$recordEventsWritten = [System.Collections.ArrayList]::new()
 $commands = [ordered]@{}
 $steps = [ordered]@{}
 $record = $null
@@ -223,6 +298,25 @@ try {
 
   if ([string]::IsNullOrWhiteSpace($normalizedTag)) {
     Add-Problem $blockers "tag-required" "A release tag is required."
+  }
+  $tagShapeOk = (-not [string]::IsNullOrWhiteSpace($normalizedTag)) -and ($normalizedTag -match $stableForkTagPattern)
+  if (-not [string]::IsNullOrWhiteSpace($normalizedTag) -and -not $tagShapeOk) {
+    Add-Problem $blockers "tag-shape-invalid" "Tag $normalizedTag is not a stable fork tag shaped like vX.Y.Z-guffa.N."
+  }
+  $replacementShapeOk = $true
+  if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement)) {
+    $replacementShapeOk = $normalizedReplacement -match $stableForkTagPattern
+    if (-not $replacementShapeOk) {
+      Add-Problem $blockers "replacement-tag-shape-invalid" "Replacement tag $normalizedReplacement is not a stable fork tag shaped like vX.Y.Z-guffa.N."
+    }
+  }
+  $steps.tag = [ordered]@{
+    ok = $tagShapeOk
+    tag = if ($normalizedTag) { $normalizedTag } else { $null }
+    replacementTag = if ($normalizedReplacement) { $normalizedReplacement } else { $null }
+    expectedPattern = $stableForkTagPattern
+    shapeOk = $tagShapeOk
+    replacementShapeOk = $replacementShapeOk
   }
   if ($validStates -notcontains $normalizedState) {
     Add-Problem $blockers "state-required" "State must be one of: $($validStates -join ', ')."
@@ -248,7 +342,7 @@ try {
   $normalizedOperator = $Operator.Trim()
 
   $releaseData = $null
-  if (-not [string]::IsNullOrWhiteSpace($normalizedTag)) {
+  if ($tagShapeOk) {
     $releaseView = Invoke-Captured $gh @(
       "release",
       "view",
@@ -280,7 +374,11 @@ try {
       command = "gh release view $normalizedTag --repo $Repo"
       exitCode = $releaseView.exitCode
       data = $releaseSummary
-      stdoutTail = if ($releaseView.exitCode -eq 0) { $null } else { $releaseView.stdoutTail }
+      stdoutTail = if (($releaseView.exitCode -eq 0) -and ($releaseData -ne $null)) {
+        $null
+      } else {
+        $releaseView.stdoutTail
+      }
       stderrTail = $releaseView.stderrTail
     }
     if (-not $steps.release.ok) {
@@ -295,7 +393,7 @@ try {
     Add-Problem $blockers "replacement-same-as-tag" "Replacement tag must differ from the affected tag."
   }
 
-  if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement)) {
+  if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement) -and $replacementShapeOk) {
     $replacementView = Invoke-Captured $gh @(
       "release",
       "view",
@@ -311,7 +409,11 @@ try {
       command = "gh release view $normalizedReplacement --repo $Repo"
       exitCode = $replacementView.exitCode
       data = $replacementData
-      stdoutTail = if ($replacementView.exitCode -eq 0) { $null } else { $replacementView.stdoutTail }
+      stdoutTail = if (($replacementView.exitCode -eq 0) -and ($replacementData -ne $null)) {
+        $null
+      } else {
+        $replacementView.stdoutTail
+      }
       stderrTail = $replacementView.stderrTail
     }
     if (-not $steps.replacement.ok) {
@@ -407,16 +509,30 @@ try {
 
   if ($Execute -and $blockers.Count -eq 0) {
     $body = if ($null -eq $releaseData.body) { "" } else { [string]$releaseData.body }
+    $bodyWithoutExistingNotice = Remove-LeadingReleaseWithdrawalNotice $body
     $notesPath = $null
     if ($normalizedState -eq "superseded" -or $normalizedState -eq "known-bad") {
       $notesPath = [System.IO.Path]::GetTempFileName()
-      $notesBody = "$notice`r`n`r`n$body"
+      $notesBody = if ([string]::IsNullOrWhiteSpace($bodyWithoutExistingNotice)) {
+        $notice
+      } else {
+        "$notice`r`n`r`n$bodyWithoutExistingNotice"
+      }
       [System.IO.File]::WriteAllText($notesPath, $notesBody, [System.Text.UTF8Encoding]::new($false))
+      $steps.releaseNotice = [ordered]@{
+        existingNoticeRemoved = $bodyWithoutExistingNotice -ne $body
+        originalBodyLength = $body.Length
+        updatedBodyLength = $notesBody.Length
+      }
     }
 
     try {
       if ($normalizedState -eq "yanked") {
-        $recordWrittenPath = Write-WithdrawalRecord ([hashtable]$record) $RecordPath
+        $preActionRecord = Copy-WithdrawalRecord $record
+        $preActionRecord.event = "pre-yank"
+        $preActionRecord.auditNote = "Recorded before destructive release and tag deletion."
+        $recordWrittenPath = Write-WithdrawalRecord $preActionRecord $RecordPath
+        [void]$recordEventsWritten.Add("pre-yank")
       }
 
       foreach ($action in $plannedActions) {
@@ -451,7 +567,14 @@ try {
       }
 
       if ($normalizedState -ne "yanked" -and $blockers.Count -eq 0) {
-        $recordWrittenPath = Write-WithdrawalRecord ([hashtable]$record) $RecordPath
+        $appliedRecord = Copy-WithdrawalRecord $record
+        $appliedRecord.event = "applied"
+        $recordWrittenPath = Write-WithdrawalRecord $appliedRecord $RecordPath
+        [void]$recordEventsWritten.Add("applied")
+      } elseif ($normalizedState -eq "yanked") {
+        $outcomeRecord = New-WithdrawalExecutionRecord $record "post-yank" $executedActions $blockers
+        $recordWrittenPath = Write-WithdrawalRecord $outcomeRecord $RecordPath
+        [void]$recordEventsWritten.Add("post-yank")
       }
     } finally {
       if ($notesPath -and (Test-Path -LiteralPath $notesPath)) {
@@ -474,6 +597,7 @@ try {
     operator = if ($normalizedOperator) { $normalizedOperator } else { $null }
     recordPath = $RecordPath
     recordWrittenPath = $recordWrittenPath
+    recordEventsWritten = @($recordEventsWritten)
     blockers = @($blockers)
     warnings = @($warnings)
     plannedActions = @($plannedActions)
@@ -500,6 +624,7 @@ try {
     warnings = @($warnings)
     plannedActions = @($plannedActions)
     executedActions = @($executedActions)
+    recordEventsWritten = @($recordEventsWritten)
     record = $record
     steps = $steps
     commands = $commands

--- a/scripts/axf/release-withdrawal.ps1
+++ b/scripts/axf/release-withdrawal.ps1
@@ -1,0 +1,509 @@
+[CmdletBinding()]
+param(
+  [string]$Repo = "Guffawaffle/stfc-mod",
+  [string]$Tag = "",
+  [string]$State = "",
+  [string]$Reason = "",
+  [string]$ReplacementTag = "",
+  [string]$Operator = "",
+  [switch]$Execute,
+  [string]$RecordPath = "docs/release-withdrawals/release-withdrawals.jsonl"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$validStates = @("superseded", "known-bad", "yanked")
+
+function Resolve-FirstCommand {
+  param([string[]]$Names)
+
+  foreach ($name in $Names) {
+    $cmd = Get-Command $name -ErrorAction SilentlyContinue
+    if ($cmd) {
+      return $cmd.Source
+    }
+  }
+
+  throw "None of these commands were found: $($Names -join ', ')"
+}
+
+function ConvertTo-LineTail {
+  param(
+    [string]$Text,
+    [int]$Count = 40,
+    [int]$MaxLineLength = 1200
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return @()
+  }
+
+  $lines = $Text -split "`r?`n" | Where-Object { $_ -ne "" } | ForEach-Object {
+    if ($_.Length -gt $MaxLineLength) {
+      "$($_.Substring(0, $MaxLineLength))...[truncated]"
+    } else {
+      $_
+    }
+  }
+  if ($lines.Count -le $Count) {
+    return @($lines)
+  }
+
+  return @($lines | Select-Object -Last $Count)
+}
+
+function Invoke-Captured {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  $psi = [System.Diagnostics.ProcessStartInfo]::new()
+  $psi.FileName = $FilePath
+  $psi.WorkingDirectory = $repoRoot.Path
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  foreach ($arg in $Arguments) {
+    [void]$psi.ArgumentList.Add($arg)
+  }
+
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $psi
+  [void]$process.Start()
+  $stdout = $process.StandardOutput.ReadToEnd()
+  $stderr = $process.StandardError.ReadToEnd()
+  $process.WaitForExit()
+
+  return [ordered]@{
+    exitCode = $process.ExitCode
+    stdout = $stdout
+    stderr = $stderr
+    stdoutTail = ConvertTo-LineTail $stdout
+    stderrTail = ConvertTo-LineTail $stderr
+  }
+}
+
+function ConvertFrom-JsonOrNull {
+  param([string]$Text)
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return $null
+  }
+
+  try {
+    return $Text | ConvertFrom-Json -Depth 40
+  } catch {
+    return $null
+  }
+}
+
+function Add-Problem {
+  param(
+    [System.Collections.ArrayList]$Target,
+    [string]$Code,
+    [string]$Message
+  )
+
+  [void]$Target.Add([ordered]@{
+    code = $Code
+    message = $Message
+  })
+}
+
+function Format-DisplayCommand {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  $parts = @($FilePath) + $Arguments
+  return ($parts | ForEach-Object {
+    if ($_ -match '^[A-Za-z0-9_./:@=+\-]+$') {
+      $_
+    } else {
+      '"' + ($_.Replace('"', '\"')) + '"'
+    }
+  }) -join " "
+}
+
+function Add-Action {
+  param(
+    [System.Collections.ArrayList]$Target,
+    [string]$Kind,
+    [string]$Description,
+    [string]$FilePath,
+    [string[]]$Arguments,
+    [bool]$Destructive = $false
+  )
+
+  [void]$Target.Add([ordered]@{
+    kind = $Kind
+    description = $Description
+    destructive = $Destructive
+    file = $FilePath
+    args = $Arguments
+    display = Format-DisplayCommand $FilePath $Arguments
+  })
+}
+
+function Resolve-RecordPath {
+  param([string]$Path)
+
+  if ([System.IO.Path]::IsPathRooted($Path)) {
+    return $Path
+  }
+
+  return Join-Path $repoRoot.Path $Path
+}
+
+function Write-WithdrawalRecord {
+  param(
+    [hashtable]$Record,
+    [string]$Path
+  )
+
+  $fullPath = Resolve-RecordPath $Path
+  $directory = Split-Path -Parent $fullPath
+  if (-not [string]::IsNullOrWhiteSpace($directory)) {
+    [void][System.IO.Directory]::CreateDirectory($directory)
+  }
+
+  $line = ($Record | ConvertTo-Json -Depth 20 -Compress)
+  [System.IO.File]::AppendAllText($fullPath, "$line`n", [System.Text.UTF8Encoding]::new($false))
+  return $fullPath
+}
+
+function Build-ReleaseNotice {
+  param(
+    [string]$State,
+    [string]$Reason,
+    [string]$ReplacementTag,
+    [string]$Operator,
+    [string]$Timestamp
+  )
+
+  $replacement = if ([string]::IsNullOrWhiteSpace($ReplacementTag)) { "none recorded" } else { $ReplacementTag }
+  $label = switch ($State) {
+    "superseded" { "Superseded" }
+    "known-bad" { "Known bad" }
+    "yanked" { "Yanked" }
+  }
+
+  return @"
+> [!WARNING]
+> Fork release state: **$label**
+> Reason: $Reason
+> Replacement: $replacement
+> Operator: $Operator
+> Recorded: $Timestamp
+"@
+}
+
+$blockers = [System.Collections.ArrayList]::new()
+$warnings = [System.Collections.ArrayList]::new()
+$plannedActions = [System.Collections.ArrayList]::new()
+$executedActions = [System.Collections.ArrayList]::new()
+$commands = [ordered]@{}
+$steps = [ordered]@{}
+$record = $null
+$recordWrittenPath = $null
+
+try {
+  $gh = Resolve-FirstCommand @("gh")
+  $commands.gh = $gh
+
+  $normalizedState = $State.Trim().ToLowerInvariant()
+  $normalizedTag = $Tag.Trim()
+  $normalizedReason = $Reason.Trim()
+  $normalizedReplacement = $ReplacementTag.Trim()
+  $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+  if ([string]::IsNullOrWhiteSpace($normalizedTag)) {
+    Add-Problem $blockers "tag-required" "A release tag is required."
+  }
+  if ($validStates -notcontains $normalizedState) {
+    Add-Problem $blockers "state-required" "State must be one of: $($validStates -join ', ')."
+  }
+  if ([string]::IsNullOrWhiteSpace($normalizedReason)) {
+    Add-Problem $blockers "reason-required" "A non-empty reason is required for every release withdrawal action."
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Operator)) {
+    $user = Invoke-Captured $gh @("api", "user", "--jq", ".login")
+    $steps.operator = [ordered]@{
+      ok = ($user.exitCode -eq 0) -and (-not [string]::IsNullOrWhiteSpace($user.stdout))
+      exitCode = $user.exitCode
+      stdoutTail = $user.stdoutTail
+      stderrTail = $user.stderrTail
+    }
+    if ($steps.operator.ok) {
+      $Operator = $user.stdout.Trim()
+    } else {
+      Add-Problem $blockers "operator-unresolved" "Could not resolve the GitHub operator. Pass -Operator explicitly."
+    }
+  }
+  $normalizedOperator = $Operator.Trim()
+
+  $releaseData = $null
+  if (-not [string]::IsNullOrWhiteSpace($normalizedTag)) {
+    $releaseView = Invoke-Captured $gh @(
+      "release",
+      "view",
+      $normalizedTag,
+      "--repo",
+      $Repo,
+      "--json",
+      "tagName,name,isDraft,isPrerelease,body,url,createdAt,publishedAt,targetCommitish,databaseId"
+    )
+    $releaseData = ConvertFrom-JsonOrNull $releaseView.stdout
+    $releaseSummary = $null
+    if ($releaseData) {
+      $releaseBody = if ($null -eq $releaseData.body) { "" } else { [string]$releaseData.body }
+      $releaseSummary = [ordered]@{
+        tagName = $releaseData.tagName
+        name = $releaseData.name
+        isDraft = $releaseData.isDraft
+        isPrerelease = $releaseData.isPrerelease
+        url = $releaseData.url
+        createdAt = $releaseData.createdAt
+        publishedAt = $releaseData.publishedAt
+        targetCommitish = $releaseData.targetCommitish
+        databaseId = $releaseData.databaseId
+        bodyLength = $releaseBody.Length
+      }
+    }
+    $steps.release = [ordered]@{
+      ok = ($releaseView.exitCode -eq 0) -and ($releaseData -ne $null)
+      command = "gh release view $normalizedTag --repo $Repo"
+      exitCode = $releaseView.exitCode
+      data = $releaseSummary
+      stdoutTail = if ($releaseView.exitCode -eq 0) { $null } else { $releaseView.stdoutTail }
+      stderrTail = $releaseView.stderrTail
+    }
+    if (-not $steps.release.ok) {
+      Add-Problem $blockers "release-not-found" "Could not load release $normalizedTag from $Repo."
+    }
+  }
+
+  if ($normalizedState -eq "yanked" -and [string]::IsNullOrWhiteSpace($normalizedReplacement)) {
+    Add-Problem $warnings "replacement-missing" "No replacement tag was recorded for a yanked release."
+  }
+  if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement) -and $normalizedReplacement -eq $normalizedTag) {
+    Add-Problem $blockers "replacement-same-as-tag" "Replacement tag must differ from the affected tag."
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement)) {
+    $replacementView = Invoke-Captured $gh @(
+      "release",
+      "view",
+      $normalizedReplacement,
+      "--repo",
+      $Repo,
+      "--json",
+      "tagName,name,isDraft,isPrerelease,url,targetCommitish,databaseId"
+    )
+    $replacementData = ConvertFrom-JsonOrNull $replacementView.stdout
+    $steps.replacement = [ordered]@{
+      ok = ($replacementView.exitCode -eq 0) -and ($replacementData -ne $null)
+      command = "gh release view $normalizedReplacement --repo $Repo"
+      exitCode = $replacementView.exitCode
+      data = $replacementData
+      stdoutTail = if ($replacementView.exitCode -eq 0) { $null } else { $replacementView.stdoutTail }
+      stderrTail = $replacementView.stderrTail
+    }
+    if (-not $steps.replacement.ok) {
+      Add-Problem $blockers "replacement-release-not-found" "Could not load replacement release $normalizedReplacement from $Repo."
+    }
+  }
+
+  if ($blockers.Count -eq 0) {
+    $releaseName = if ([string]::IsNullOrWhiteSpace($releaseData.name)) { $normalizedTag } else { $releaseData.name }
+    $notice = Build-ReleaseNotice $normalizedState $normalizedReason $normalizedReplacement $normalizedOperator $timestamp
+    $record = [ordered]@{
+      recordedAt = $timestamp
+      repo = $Repo
+      tag = $normalizedTag
+      state = $normalizedState
+      reason = $normalizedReason
+      replacementTag = if ([string]::IsNullOrWhiteSpace($normalizedReplacement)) { $null } else { $normalizedReplacement }
+      operator = $normalizedOperator
+      releaseUrl = $releaseData.url
+      releaseDatabaseId = $releaseData.databaseId
+      targetCommitish = $releaseData.targetCommitish
+    }
+
+    if ($normalizedState -eq "superseded") {
+      $title = if ($releaseName.StartsWith("[SUPERSEDED] ")) { $releaseName } else { "[SUPERSEDED] $releaseName" }
+      Add-Action $plannedActions "edit-release" "Mark the release as superseded and prepend the release-state notice." $gh @(
+        "release",
+        "edit",
+        $normalizedTag,
+        "--repo",
+        $Repo,
+        "--title",
+        $title,
+        "--notes-file",
+        "<generated-notes-file>"
+      )
+      if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement)) {
+        Add-Action $plannedActions "mark-replacement-latest" "Mark the replacement release as latest." $gh @(
+          "release",
+          "edit",
+          $normalizedReplacement,
+          "--repo",
+          $Repo,
+          "--latest"
+        )
+      }
+    } elseif ($normalizedState -eq "known-bad") {
+      $title = if ($releaseName.StartsWith("[KNOWN BAD] ")) { $releaseName } else { "[KNOWN BAD] $releaseName" }
+      Add-Action $plannedActions "edit-release" "Mark the release known-bad, mark it prerelease, and prepend the release-state notice." $gh @(
+        "release",
+        "edit",
+        $normalizedTag,
+        "--repo",
+        $Repo,
+        "--title",
+        $title,
+        "--prerelease",
+        "--notes-file",
+        "<generated-notes-file>"
+      )
+      if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement)) {
+        Add-Action $plannedActions "mark-replacement-latest" "Mark the replacement release as latest." $gh @(
+          "release",
+          "edit",
+          $normalizedReplacement,
+          "--repo",
+          $Repo,
+          "--latest"
+        )
+      }
+    } elseif ($normalizedState -eq "yanked") {
+      Add-Action $plannedActions "delete-release-and-tag" "Delete the GitHub release and remote tag." $gh @(
+        "release",
+        "delete",
+        $normalizedTag,
+        "--repo",
+        $Repo,
+        "--cleanup-tag",
+        "--yes"
+      ) $true
+      if (-not [string]::IsNullOrWhiteSpace($normalizedReplacement)) {
+        Add-Action $plannedActions "mark-replacement-latest" "Mark the replacement release as latest." $gh @(
+          "release",
+          "edit",
+          $normalizedReplacement,
+          "--repo",
+          $Repo,
+          "--latest"
+        )
+      }
+    }
+  }
+
+  if ($Execute -and $blockers.Count -eq 0) {
+    $body = if ($null -eq $releaseData.body) { "" } else { [string]$releaseData.body }
+    $notesPath = $null
+    if ($normalizedState -eq "superseded" -or $normalizedState -eq "known-bad") {
+      $notesPath = [System.IO.Path]::GetTempFileName()
+      $notesBody = "$notice`r`n`r`n$body"
+      [System.IO.File]::WriteAllText($notesPath, $notesBody, [System.Text.UTF8Encoding]::new($false))
+    }
+
+    try {
+      if ($normalizedState -eq "yanked") {
+        $recordWrittenPath = Write-WithdrawalRecord ([hashtable]$record) $RecordPath
+      }
+
+      foreach ($action in $plannedActions) {
+        $args = @($action.args)
+        if ($notesPath) {
+          $args = @($args | ForEach-Object {
+            if ($_ -eq "<generated-notes-file>") {
+              $notesPath
+            } else {
+              $_
+            }
+          })
+        }
+
+        if ($action.destructive) {
+          [Console]::Error.WriteLine("DESTRUCTIVE ACTION: $(Format-DisplayCommand $action.file $args)")
+        }
+
+        $result = Invoke-Captured $action.file $args
+        [void]$executedActions.Add([ordered]@{
+          kind = $action.kind
+          destructive = $action.destructive
+          display = Format-DisplayCommand $action.file $args
+          exitCode = $result.exitCode
+          stdoutTail = $result.stdoutTail
+          stderrTail = $result.stderrTail
+        })
+        if ($result.exitCode -ne 0) {
+          Add-Problem $blockers "action-failed" "Action $($action.kind) failed with exit code $($result.exitCode)."
+          break
+        }
+      }
+
+      if ($normalizedState -ne "yanked" -and $blockers.Count -eq 0) {
+        $recordWrittenPath = Write-WithdrawalRecord ([hashtable]$record) $RecordPath
+      }
+    } finally {
+      if ($notesPath -and (Test-Path -LiteralPath $notesPath)) {
+        Remove-Item -LiteralPath $notesPath -Force
+      }
+    }
+  }
+
+  $ok = ($blockers.Count -eq 0)
+  $payload = [ordered]@{
+    ok = $ok
+    command = "release-withdrawal"
+    dryRun = -not $Execute
+    repoRoot = $repoRoot.Path
+    repo = $Repo
+    tag = if ($normalizedTag) { $normalizedTag } else { $null }
+    state = if ($normalizedState) { $normalizedState } else { $null }
+    reason = if ($normalizedReason) { $normalizedReason } else { $null }
+    replacementTag = if ($normalizedReplacement) { $normalizedReplacement } else { $null }
+    operator = if ($normalizedOperator) { $normalizedOperator } else { $null }
+    recordPath = $RecordPath
+    recordWrittenPath = $recordWrittenPath
+    blockers = @($blockers)
+    warnings = @($warnings)
+    plannedActions = @($plannedActions)
+    executedActions = @($executedActions)
+    record = $record
+    steps = $steps
+    commands = $commands
+  }
+
+  $payload | ConvertTo-Json -Depth 40
+  if ($ok) {
+    exit 0
+  }
+  exit 1
+} catch {
+  $payload = [ordered]@{
+    ok = $false
+    command = "release-withdrawal"
+    dryRun = -not $Execute
+    repoRoot = $repoRoot.Path
+    repo = $Repo
+    error = $_.Exception.Message
+    blockers = @($blockers)
+    warnings = @($warnings)
+    plannedActions = @($plannedActions)
+    executedActions = @($executedActions)
+    record = $record
+    steps = $steps
+    commands = $commands
+  }
+  $payload | ConvertTo-Json -Depth 40
+  exit 1
+}


### PR DESCRIPTION
## Summary

Defines the fork policy for bad published releases and adds a dry-run-first withdrawal helper.

The policy distinguishes `superseded`, `known-bad`, and `yanked` releases. It makes deletion/yank the exception, requires a non-empty reason, and records withdrawal metadata in a repo-local JSONL ledger when actions are executed.

The new AXF capability is `global.stfc-mod-private.release-withdrawal`. In dry-run it reports the planned release edits or destructive delete command. In execute mode, the `yanked` path writes the local ledger record before running `gh release delete <tag> --cleanup-tag --yes`, and prints the exact destructive command to stderr before invoking it.

Closes #144.

## Validation

- `global.stfc-mod-private.release-withdrawal` inspected through AXF
- AXF dry-run yanked plan for `v2.1.0-guffa.4` shows the exact delete command and does not execute it
- Raw script dry-runs:
  - `known-bad` plans release-note/title edits
  - `yanked` plans `gh release delete ... --cleanup-tag --yes`
  - missing reason blocks with `reason-required`
  - nonexistent replacement tag blocks with `replacement-release-not-found`
- `git diff --cached --check`
- `scripts/axf/review-contract.ps1 -Tail 120`

## Note

This branch is based on `origin/main`. It may have a small mechanical conflict with PR #147 in `RELEASE_CHECKLIST.md` / `scripts/axf/README.md` depending on merge order.