### PR TITLE
Add background-agent orchestration briefs

### DIFF
--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -1,0 +1,137 @@
+# Background Agent Orchestration
+
+This workspace can use background agents as bounded scouts while one main agent
+acts as the bridge/orchestrator. The model is fan out, gather evidence, then
+merge the findings through one accountable operator.
+
+This is local workflow tooling only. It does not belong in mod runtime code, the
+game client, the sidecar, or release artifacts.
+
+## Roles
+
+### Bridge
+
+The bridge is the main agent in the active session. The bridge owns:
+
+- branch selection and branch changes
+- file edits
+- conflict resolution
+- validation
+- commits and pushes
+- PR creation, updates, and merges
+- tags, releases, and release withdrawal actions
+- game/client/sidecar cycling
+- Lex frame logging and durable handoff notes
+
+The bridge may delegate investigation, but the bridge remains accountable for
+every mutation and final claim.
+
+### Background Agent
+
+A background agent is an assigned scout or reviewer. It defaults to read-only.
+It should return evidence and recommendations, not hidden state changes.
+
+Background agents are useful for:
+
+- PR review comment triage
+- branch and feature archaeology
+- public/private reconciliation planning
+- hook-manifest inventory
+- release/readiness audits
+- risk review of a small code area before the bridge edits it
+
+## Default Boundaries
+
+Unless a task brief explicitly says otherwise, a background agent must not:
+
+- create, edit, move, or delete files
+- run `git switch`, `git checkout`, `git rebase`, `git merge`, `git reset`, `git commit`, `git tag`, or `git push`
+- create or mutate GitHub issues, PRs, comments, labels, releases, or tags
+- cycle STFC, the sidecar, or runtime processes
+- edit TOML or game files
+- create sibling clones or worktrees
+- inspect secrets, tokens, or unrelated private files
+
+The bridge can authorize a narrower exception, but the exception must appear in
+the brief.
+
+## Task Brief
+
+Every background-agent task should include:
+
+- objective
+- issue or PR reference
+- current repo, branch, and head SHA
+- allowed scope
+- questions to answer
+- allowed actions
+- forbidden actions
+- expected handoff shape
+
+Use `global.stfc-mod-private.agent-brief` to generate a consistent brief:
+
+```powershell
+.\scripts\axf\agent-brief.ps1 `
+  -Objective "Audit PR #148 for release-policy review risks" `
+  -Mode review `
+  -Issue "#148" `
+  -Scope "docs/RELEASE_WITHDRAWAL_POLICY.md; scripts/axf/release-withdrawal.ps1" `
+  -Questions "Are destructive actions clearly gated?; Are docs and manifest consistent?"
+```
+
+The command emits JSON and a ready-to-paste markdown brief. It can optionally
+write the markdown to a repo-local path with `-OutputPath`, but stdout-only use
+is preferred during normal sessions.
+
+## Handoff Shape
+
+Background-agent handoffs should be concise and structured:
+
+- `summary`: what was inspected and learned
+- `findings`: actionable issues with file/line evidence
+- `risks`: behavior, release, validation, or branch risks
+- `openQuestions`: only material blockers
+- `commandsRun`: commands or API reads used
+- `filesRead`: important files inspected
+- `recommendedNextSteps`: concrete next moves for the bridge
+- `mutationConfirmation`: whether any mutations were made
+
+If a background agent cannot answer without mutation, it should stop and report
+the needed permission instead of guessing.
+
+## Bridge Workflow
+
+1. Confirm the repo and branch are clean enough to delegate from.
+2. Generate a brief with `global.stfc-mod-private.agent-brief`.
+3. Assign one bounded question per background agent when possible.
+4. Keep background agents read-only by default.
+5. Collect handoffs and reconcile conflicts in the main session.
+6. Make any edits directly as the bridge.
+7. Run the relevant AXF validation.
+8. Record the outcome in GitHub, PR notes, or Lex frames as appropriate.
+
+This keeps fanout useful without letting parallel work fragment branch state.
+
+## STFC Examples
+
+### PR Review
+
+Assign one agent to inspect review threads and another to inspect the affected
+files. The bridge decides which comments are actionable and pushes the fix.
+
+### Public/Private Reconciliation
+
+Assign agents to compare branch histories, changed files, and upstream deltas.
+The bridge decides merge order and performs the actual rebase or merge.
+
+### Hook Manifest Inventory
+
+Assign agents by hook family, such as hotkeys, fleet runtime, notifications, or
+Kir'Shara/action queue. Each agent returns tier suggestions and evidence. The
+bridge owns the manifest edit and release validation.
+
+### Release Work
+
+Background agents may audit release workflow state, artifact names, and docs.
+The bridge owns release-preflight, tag pushes, release edits, and withdrawal
+actions.

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -21,7 +21,7 @@ The bridge is the main agent in the active session. The bridge owns:
 - PR creation, updates, and merges
 - tags, releases, and release withdrawal actions
 - game/client/sidecar cycling
-- Lex frame logging and durable handoff notes
+- Lex-frame logging and durable handoff notes
 
 The bridge may delegate investigation, but the bridge remains accountable for
 every mutation and final claim.
@@ -108,7 +108,7 @@ the needed permission instead of guessing.
 5. Collect handoffs and reconcile conflicts in the main session.
 6. Make any edits directly as the bridge.
 7. Run the relevant AXF validation.
-8. Record the outcome in GitHub, PR notes, or Lex frames as appropriate.
+8. Record the outcome in GitHub, PR notes, or Lex-frame entries as appropriate.
 
 This keeps fanout useful without letting parallel work fragment branch state.
 

--- a/manifests/capabilities/global.stfc-mod-private.agent-brief.json
+++ b/manifests/capabilities/global.stfc-mod-private.agent-brief.json
@@ -114,7 +114,7 @@
     "extra-forbidden": "-ExtraForbidden",
     "allow-edits": "-AllowEdits",
     "allow-git-writes": "-AllowGitWrites",
-    "allow-github-writes": "-AllowGithubWrites",
+    "allow-github-writes": "-AllowGitHubWrites",
     "allow-runtime-actions": "-AllowRuntimeActions",
     "output-path": "-OutputPath"
   },

--- a/manifests/capabilities/global.stfc-mod-private.agent-brief.json
+++ b/manifests/capabilities/global.stfc-mod-private.agent-brief.json
@@ -1,0 +1,130 @@
+{
+  "manifestVersion": "axf/v0",
+  "id": "global.stfc-mod-private.agent-brief",
+  "summary": "Generate a structured STFC background-agent task brief for read-only scout/review/fanout work",
+  "provider": "stfc",
+  "adapterType": "cli",
+  "executionTarget": {
+    "launcher": {
+      "command": "pwsh",
+      "args": [
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File"
+      ]
+    },
+    "target": {
+      "path": "scripts/axf/agent-brief.ps1",
+      "relativeTo": "workspace"
+    }
+  },
+  "argsSchema": {
+    "type": "object",
+    "properties": {
+      "objective": {
+        "type": "string",
+        "description": "Concrete objective for the background agent."
+      },
+      "mode": {
+        "type": "string",
+        "enum": [
+          "scout",
+          "review",
+          "implementation",
+          "reconciliation",
+          "release",
+          "triage"
+        ],
+        "description": "Brief type. Defaults to scout."
+      },
+      "issue": {
+        "type": "string",
+        "description": "Related GitHub issue or PR reference."
+      },
+      "agent-name": {
+        "type": "string",
+        "description": "Friendly background-agent name."
+      },
+      "scope": {
+        "type": "string",
+        "description": "Semicolon- or newline-separated scope boundaries."
+      },
+      "questions": {
+        "type": "string",
+        "description": "Semicolon- or newline-separated questions the agent should answer."
+      },
+      "allowed-actions": {
+        "type": "string",
+        "description": "Additional semicolon- or newline-separated allowed actions."
+      },
+      "extra-forbidden": {
+        "type": "string",
+        "description": "Additional semicolon- or newline-separated forbidden actions."
+      },
+      "allow-edits": {
+        "type": "boolean",
+        "description": "Allow the background agent to edit files. Defaults to false."
+      },
+      "allow-git-writes": {
+        "type": "boolean",
+        "description": "Allow git writes such as checkout, rebase, commit, tag, or push. Defaults to false."
+      },
+      "allow-github-writes": {
+        "type": "boolean",
+        "description": "Allow GitHub writes such as comments, labels, releases, or merges. Defaults to false."
+      },
+      "allow-runtime-actions": {
+        "type": "boolean",
+        "description": "Allow game/client/sidecar runtime actions. Defaults to false."
+      },
+      "output-path": {
+        "type": "string",
+        "description": "Optional repo-local path to write the markdown brief."
+      }
+    },
+    "required": [
+      "objective"
+    ],
+    "additionalProperties": false
+  },
+  "outputModes": [
+    "json"
+  ],
+  "sideEffects": "write",
+  "scope": "global",
+  "lifecycleState": "active",
+  "defaults": {
+    "mode": "scout",
+    "agent-name": "background-agent"
+  },
+  "policies": [
+    "require_workspace_binding"
+  ],
+  "owner": "module:stfc",
+  "argMap": {
+    "objective": "-Objective",
+    "mode": "-Mode",
+    "issue": "-Issue",
+    "agent-name": "-AgentName",
+    "scope": "-Scope",
+    "questions": "-Questions",
+    "allowed-actions": "-AllowedActions",
+    "extra-forbidden": "-ExtraForbidden",
+    "allow-edits": "-AllowEdits",
+    "allow-git-writes": "-AllowGitWrites",
+    "allow-github-writes": "-AllowGithubWrites",
+    "allow-runtime-actions": "-AllowRuntimeActions",
+    "output-path": "-OutputPath"
+  },
+  "warnings": [
+    "Briefs default to read-only background-agent work.",
+    "The orchestrator remains responsible for edits, validation, commits, PRs, tags, releases, and Lex-frame logging.",
+    "Side effects are write because -output-path can write a markdown brief."
+  ],
+  "details": [
+    "Emits JSON containing repository context, permission flags, allowed/forbidden actions, expected handoff shape, and a ready-to-paste markdown brief.",
+    "Use this to fan out scout/review/reconciliation tasks while preserving one accountable bridge/orchestrator."
+  ]
+}

--- a/scripts/axf/README.md
+++ b/scripts/axf/README.md
@@ -13,6 +13,7 @@ is present.
 Primary capability IDs include:
 
 ```text
+global.stfc-mod-private.agent-brief
 global.stfc-mod-private.review-contract
 global.stfc-mod-private.release-preflight
 global.stfc-mod-private.doctor
@@ -24,6 +25,17 @@ global.stfc-mod-private.cycle
 ```
 
 Raw CLI execution is for provider development and manual debugging only.
+
+## Agent Briefs
+
+Use `global.stfc-mod-private.agent-brief` to create scoped task briefs for
+background agents. Briefs default to read-only scout/review work and state the
+repo context, objective, allowed actions, forbidden actions, and expected
+handoff shape.
+
+The bridge/orchestrator remains responsible for mutations: edits, branch moves,
+GitHub writes, releases/tags, runtime actions, final validation, and Lex-frame
+logging. See `docs/AGENT_ORCHESTRATION.md` for the full workflow.
 
 ## Review Contract
 

--- a/scripts/axf/agent-brief.ps1
+++ b/scripts/axf/agent-brief.ps1
@@ -1,0 +1,269 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$Objective,
+  [ValidateSet("scout", "review", "implementation", "reconciliation", "release", "triage")]
+  [string]$Mode = "scout",
+  [string]$Issue = "",
+  [string]$AgentName = "background-agent",
+  [string]$Scope = "",
+  [string]$Questions = "",
+  [string]$AllowedActions = "",
+  [string]$ExtraForbidden = "",
+  [switch]$AllowEdits,
+  [switch]$AllowGitWrites,
+  [switch]$AllowGithubWrites,
+  [switch]$AllowRuntimeActions,
+  [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+
+function Resolve-FirstCommand {
+  param(
+    [string[]]$Names,
+    [switch]$Optional
+  )
+
+  foreach ($name in $Names) {
+    $cmd = Get-Command $name -ErrorAction SilentlyContinue
+    if ($cmd) {
+      return $cmd.Source
+    }
+  }
+
+  if ($Optional) {
+    return $null
+  }
+
+  throw "None of these commands were found: $($Names -join ', ')"
+}
+
+function Invoke-Captured {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  if ([string]::IsNullOrWhiteSpace($FilePath)) {
+    return [ordered]@{
+      exitCode = 127
+      stdout = ""
+      stderr = "command unavailable"
+    }
+  }
+
+  $psi = [System.Diagnostics.ProcessStartInfo]::new()
+  $psi.FileName = $FilePath
+  $psi.WorkingDirectory = $repoRoot.Path
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  foreach ($arg in $Arguments) {
+    [void]$psi.ArgumentList.Add($arg)
+  }
+
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $psi
+  [void]$process.Start()
+  $stdout = $process.StandardOutput.ReadToEnd()
+  $stderr = $process.StandardError.ReadToEnd()
+  $process.WaitForExit()
+
+  return [ordered]@{
+    exitCode = $process.ExitCode
+    stdout = $stdout.Trim()
+    stderr = $stderr.Trim()
+  }
+}
+
+function Split-ListText {
+  param([string]$Text)
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return @()
+  }
+
+  return @($Text -split "`r?`n|;" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+}
+
+function Resolve-OutputPath {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) {
+    return $null
+  }
+
+  $candidate = if ([System.IO.Path]::IsPathRooted($Path)) {
+    $Path
+  } else {
+    Join-Path $repoRoot.Path $Path
+  }
+  $fullPath = [System.IO.Path]::GetFullPath($candidate)
+  $repoFullPath = [System.IO.Path]::GetFullPath($repoRoot.Path).TrimEnd([System.IO.Path]::DirectorySeparatorChar,
+                                                                        [System.IO.Path]::AltDirectorySeparatorChar)
+  $prefix = "$repoFullPath$([System.IO.Path]::DirectorySeparatorChar)"
+  if (-not ($fullPath.Equals($repoFullPath, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $fullPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase))) {
+    throw "OutputPath must stay within the repository workspace: $Path"
+  }
+
+  return $fullPath
+}
+
+function ConvertTo-BulletList {
+  param([object[]]$Items)
+
+  if (-not $Items -or $Items.Count -eq 0) {
+    return "- none specified"
+  }
+
+  return ($Items | ForEach-Object { "- $_" }) -join "`n"
+}
+
+$git = Resolve-FirstCommand @("git")
+$gh = Resolve-FirstCommand @("gh") -Optional
+
+$branch = Invoke-Captured $git @("branch", "--show-current")
+$head = Invoke-Captured $git @("rev-parse", "HEAD")
+$status = Invoke-Captured $git @("status", "--short", "--branch")
+$remote = Invoke-Captured $git @("remote", "get-url", "origin")
+
+$prUrl = $null
+if ($gh) {
+  $prView = Invoke-Captured $gh @("pr", "view", "--json", "url", "--jq", ".url")
+  if ($prView.exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($prView.stdout)) {
+    $prUrl = $prView.stdout
+  }
+}
+
+$scopeItems = Split-ListText $Scope
+$questionItems = Split-ListText $Questions
+$allowedItems = Split-ListText $AllowedActions
+$extraForbiddenItems = Split-ListText $ExtraForbidden
+
+$defaultAllowed = @(
+  "Read files and command output needed to answer the objective.",
+  "Use fast local discovery commands such as rg, git diff, git show, and gh view/list when relevant.",
+  "Return a concise structured handoff to the orchestrator."
+)
+$defaultForbidden = @()
+if (-not $AllowEdits) {
+  $defaultForbidden += "Do not create, edit, move, or delete files."
+}
+if (-not $AllowGitWrites) {
+  $defaultForbidden += "Do not run git switch, checkout, rebase, merge, reset, commit, tag, or push."
+}
+if (-not $AllowGithubWrites) {
+  $defaultForbidden += "Do not create, edit, close, merge, label, or comment on GitHub issues, PRs, releases, or tags."
+}
+if (-not $AllowRuntimeActions) {
+  $defaultForbidden += "Do not cycle STFC, sidecar, or modify game/runtime files."
+}
+$defaultForbidden += @(
+  "Do not create sibling clones or worktrees.",
+  "Do not inspect secrets, tokens, or unrelated private files.",
+  "Do not treat findings as final; the orchestrator owns edits, validation, and publishing."
+)
+$forbiddenItems = @($defaultForbidden + $extraForbiddenItems)
+$allowed = @($defaultAllowed + $allowedItems)
+
+$expectedOutput = @(
+  "summary: 3-6 bullets of what was inspected and learned",
+  "findings: actionable items with file/line evidence when available",
+  "risks: behavior, release, validation, or branch risks",
+  "openQuestions: only questions that materially block the orchestrator",
+  "commandsRun: commands or API reads used",
+  "filesRead: important local or remote files inspected",
+  "recommendedNextSteps: concrete next moves for the orchestrator",
+  "mutationConfirmation: state whether any mutations were made; default should be none"
+)
+
+$fence = '```'
+$briefMarkdown = @"
+# Background Agent Brief
+
+Agent: $AgentName
+Mode: $Mode
+Issue: $(if ([string]::IsNullOrWhiteSpace($Issue)) { "none" } else { $Issue })
+Repository: $($remote.stdout)
+Branch: $($branch.stdout)
+Head: $($head.stdout)
+Pull Request: $(if ($prUrl) { $prUrl } else { "none detected" })
+
+## Objective
+
+$Objective
+
+## Scope
+
+$(ConvertTo-BulletList $scopeItems)
+
+## Questions To Answer
+
+$(ConvertTo-BulletList $questionItems)
+
+## Allowed Actions
+
+$(ConvertTo-BulletList $allowed)
+
+## Forbidden Actions
+
+$(ConvertTo-BulletList $forbiddenItems)
+
+## Expected Handoff
+
+$(ConvertTo-BulletList $expectedOutput)
+
+## Current Worktree
+
+${fence}text
+$($status.stdout)
+${fence}
+"@
+
+$writtenPath = $null
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+  $writtenPath = Resolve-OutputPath $OutputPath
+  $directory = Split-Path -Parent $writtenPath
+  if (-not [string]::IsNullOrWhiteSpace($directory)) {
+    [void][System.IO.Directory]::CreateDirectory($directory)
+  }
+  [System.IO.File]::WriteAllText($writtenPath, $briefMarkdown, [System.Text.UTF8Encoding]::new($false))
+}
+
+$payload = [ordered]@{
+  ok = $true
+  command = "agent-brief"
+  repoRoot = $repoRoot.Path
+  mode = $Mode
+  agentName = $AgentName
+  issue = if ([string]::IsNullOrWhiteSpace($Issue)) { $null } else { $Issue }
+  objective = $Objective
+  context = [ordered]@{
+    origin = $remote.stdout
+    branch = $branch.stdout
+    head = $head.stdout
+    pullRequest = $prUrl
+    status = $status.stdout
+  }
+  permissions = [ordered]@{
+    editsAllowed = [bool]$AllowEdits
+    gitWritesAllowed = [bool]$AllowGitWrites
+    githubWritesAllowed = [bool]$AllowGithubWrites
+    runtimeActionsAllowed = [bool]$AllowRuntimeActions
+  }
+  scope = $scopeItems
+  questions = $questionItems
+  allowedActions = $allowed
+  forbiddenActions = $forbiddenItems
+  expectedOutput = $expectedOutput
+  briefMarkdown = $briefMarkdown
+  writtenPath = $writtenPath
+}
+
+$payload | ConvertTo-Json -Depth 30
+exit 0

--- a/scripts/axf/agent-brief.ps1
+++ b/scripts/axf/agent-brief.ps1
@@ -12,7 +12,7 @@ param(
   [string]$ExtraForbidden = "",
   [switch]$AllowEdits,
   [switch]$AllowGitWrites,
-  [switch]$AllowGithubWrites,
+  [switch]$AllowGitHubWrites,
   [switch]$AllowRuntimeActions,
   [string]$OutputPath = ""
 )
@@ -90,6 +90,28 @@ function Split-ListText {
   return @($Text -split "`r?`n|;" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
 }
 
+function Add-Problem {
+  param(
+    [System.Collections.ArrayList]$Target,
+    [string]$Code,
+    [string]$Message
+  )
+
+  [void]$Target.Add([ordered]@{
+    code = $Code
+    message = $Message
+  })
+}
+
+function Get-WorkspacePathComparison {
+  if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+      [System.Runtime.InteropServices.OSPlatform]::Windows)) {
+    return [System.StringComparison]::OrdinalIgnoreCase
+  }
+
+  return [System.StringComparison]::Ordinal
+}
+
 function Resolve-OutputPath {
   param([string]$Path)
 
@@ -106,8 +128,8 @@ function Resolve-OutputPath {
   $repoFullPath = [System.IO.Path]::GetFullPath($repoRoot.Path).TrimEnd([System.IO.Path]::DirectorySeparatorChar,
                                                                         [System.IO.Path]::AltDirectorySeparatorChar)
   $prefix = "$repoFullPath$([System.IO.Path]::DirectorySeparatorChar)"
-  if (-not ($fullPath.Equals($repoFullPath, [System.StringComparison]::OrdinalIgnoreCase) -or
-            $fullPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase))) {
+  $comparison = Get-WorkspacePathComparison
+  if (-not ($fullPath.Equals($repoFullPath, $comparison) -or $fullPath.StartsWith($prefix, $comparison))) {
     throw "OutputPath must stay within the repository workspace: $Path"
   }
 
@@ -126,17 +148,42 @@ function ConvertTo-BulletList {
 
 $git = Resolve-FirstCommand @("git")
 $gh = Resolve-FirstCommand @("gh") -Optional
+$blockers = [System.Collections.ArrayList]::new()
+$warnings = [System.Collections.ArrayList]::new()
+$steps = [ordered]@{}
 
 $branch = Invoke-Captured $git @("branch", "--show-current")
 $head = Invoke-Captured $git @("rev-parse", "HEAD")
 $status = Invoke-Captured $git @("status", "--short", "--branch")
 $remote = Invoke-Captured $git @("remote", "get-url", "origin")
+$steps.git = [ordered]@{
+  branch = $branch
+  head = $head
+  status = $status
+  origin = $remote
+}
+
+if ($branch.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($branch.stdout)) {
+  Add-Problem $blockers "branch-unresolved" "Could not resolve the current branch."
+}
+if ($head.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($head.stdout)) {
+  Add-Problem $blockers "head-unresolved" "Could not resolve HEAD."
+}
+if ($status.exitCode -ne 0) {
+  Add-Problem $blockers "status-unresolved" "Could not read worktree status."
+}
+if ($remote.exitCode -ne 0 -or [string]::IsNullOrWhiteSpace($remote.stdout)) {
+  Add-Problem $blockers "origin-unresolved" "Could not resolve origin remote URL."
+}
 
 $prUrl = $null
 if ($gh) {
   $prView = Invoke-Captured $gh @("pr", "view", "--json", "url", "--jq", ".url")
+  $steps.githubPullRequest = $prView
   if ($prView.exitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($prView.stdout)) {
     $prUrl = $prView.stdout
+  } else {
+    Add-Problem $warnings "pull-request-unresolved" "Could not resolve an associated GitHub pull request."
   }
 }
 
@@ -157,7 +204,7 @@ if (-not $AllowEdits) {
 if (-not $AllowGitWrites) {
   $defaultForbidden += "Do not run git switch, checkout, rebase, merge, reset, commit, tag, or push."
 }
-if (-not $AllowGithubWrites) {
+if (-not $AllowGitHubWrites) {
   $defaultForbidden += "Do not create, edit, close, merge, label, or comment on GitHub issues, PRs, releases, or tags."
 }
 if (-not $AllowRuntimeActions) {
@@ -226,7 +273,7 @@ ${fence}
 "@
 
 $writtenPath = $null
-if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+if ($blockers.Count -eq 0 -and -not [string]::IsNullOrWhiteSpace($OutputPath)) {
   $writtenPath = Resolve-OutputPath $OutputPath
   $directory = Split-Path -Parent $writtenPath
   if (-not [string]::IsNullOrWhiteSpace($directory)) {
@@ -236,7 +283,7 @@ if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
 }
 
 $payload = [ordered]@{
-  ok = $true
+  ok = $blockers.Count -eq 0
   command = "agent-brief"
   repoRoot = $repoRoot.Path
   mode = $Mode
@@ -253,9 +300,11 @@ $payload = [ordered]@{
   permissions = [ordered]@{
     editsAllowed = [bool]$AllowEdits
     gitWritesAllowed = [bool]$AllowGitWrites
-    githubWritesAllowed = [bool]$AllowGithubWrites
+    githubWritesAllowed = [bool]$AllowGitHubWrites
     runtimeActionsAllowed = [bool]$AllowRuntimeActions
   }
+  blockers = @($blockers)
+  warnings = @($warnings)
   scope = $scopeItems
   questions = $questionItems
   allowedActions = $allowed
@@ -263,7 +312,11 @@ $payload = [ordered]@{
   expectedOutput = $expectedOutput
   briefMarkdown = $briefMarkdown
   writtenPath = $writtenPath
+  steps = $steps
 }
 
 $payload | ConvertTo-Json -Depth 30
-exit 0
+if ($blockers.Count -eq 0) {
+  exit 0
+}
+exit 1


### PR DESCRIPTION
## Summary

Adds STFC-local background-agent orchestration guidance and an AXF helper for generating scoped task briefs.

This adapts the LexRunner-style fanout concept to this workspace without adding runtime/app code. The bridge/orchestrator remains accountable for edits, validation, commits, PRs, releases, tags, runtime actions, and Lex-frame logging. Background agents default to read-only scout/review work and return structured handoff notes.

Closes #149.

## Changes

- Adds `docs/AGENT_ORCHESTRATION.md` with the bridge/background-agent workflow and safety boundaries.
- Adds `scripts/axf/agent-brief.ps1` to emit JSON plus ready-to-paste markdown briefs.
- Adds `global.stfc-mod-private.agent-brief` capability manifest.
- Updates `scripts/axf/README.md` so agents can discover the helper.

## Validation

- Raw `scripts/axf/agent-brief.ps1` sample run with issue/scope/questions
- Outside-workspace `-OutputPath` attempt blocks before creating a file
- AXF inspect for `global.stfc-mod-private.agent-brief`
- AXF run for `global.stfc-mod-private.agent-brief`
- `git diff --check`
- `scripts/axf/review-contract.ps1 -Tail 120`