### PR TITLE
Add background-agent worktree broker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ mods/.xmake
 !.ax/
 !.ax/**
 .ax-priv/
+
+# Local background-agent worktree lease state and per-worktree briefs.
+.agent-worktrees/
+.agent-worktree/

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ mods/.xmake
 # Public AX facade is tracked; the private AX repo stays local-only.
 !.ax/
 !.ax/**
+.ax/agent-worktrees/
 .ax-priv/
 
-# Local background-agent worktree lease state and per-worktree briefs.
-.agent-worktrees/
+# Local background-agent per-worktree briefs.
 .agent-worktree/

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -55,6 +55,19 @@ Unless a task brief explicitly says otherwise, a background agent must not:
 The bridge can authorize a narrower exception, but the exception must appear in
 the brief.
 
+## Mutation Worktrees
+
+If a background agent needs to mutate files, the bridge should create a worktree
+lease with `global.stfc-mod-private.agent-worktree`. Worktree leases isolate the
+agent's files, index, and branch checkout from the main checkout.
+
+Worktrees do not isolate GitHub writes, release/tag writes, STFC runtime state,
+sidecar state, game files, TOML runtime configuration, or global build caches.
+Those lanes remain bridge-owned unless the lease explicitly says otherwise.
+
+See `docs/AGENT_WORKTREE_BROKER.md` for the lifecycle command and cleanup
+policy.
+
 ## Task Brief
 
 Every background-agent task should include:
@@ -103,12 +116,14 @@ the needed permission instead of guessing.
 
 1. Confirm the repo and branch are clean enough to delegate from.
 2. Generate a brief with `global.stfc-mod-private.agent-brief`.
-3. Assign one bounded question per background agent when possible.
-4. Keep background agents read-only by default.
-5. Collect handoffs and reconcile conflicts in the main session.
-6. Make any edits directly as the bridge.
-7. Run the relevant AXF validation.
-8. Record the outcome in GitHub, PR notes, or Lex frames as appropriate.
+3. For mutation-capable work, create a bridge-owned worktree lease.
+4. Assign one bounded question per background agent when possible.
+5. Keep background agents read-only by default.
+6. Collect handoffs and reconcile conflicts in the main session.
+7. Make final edits directly as the bridge or deliberately integrate lease output.
+8. Run the relevant AXF validation.
+9. Clean up any worktree leases.
+10. Record the outcome in GitHub, PR notes, or Lex frames as appropriate.
 
 This keeps fanout useful without letting parallel work fragment branch state.
 

--- a/docs/AGENT_WORKTREE_BROKER.md
+++ b/docs/AGENT_WORKTREE_BROKER.md
@@ -1,0 +1,134 @@
+# Background Agent Worktree Broker
+
+Worktrees are the mutation lane for background agents. The bridge creates a
+lease, hands the worktree path to a background agent, collects the handoff, and
+then cleans the lease up.
+
+Background agents should not create their own worktrees. They should work inside
+a lease created by the bridge.
+
+## What Worktrees Isolate
+
+Git worktrees isolate:
+
+- working files
+- the Git index
+- untracked files inside that worktree
+- branch checkout state
+
+They do not isolate:
+
+- GitHub writes
+- tags and releases
+- shared remotes and refs
+- the game install
+- STFC or sidecar processes
+- TOML runtime configuration
+- global build caches or external tools
+
+Runtime, release, and GitHub mutation lanes remain bridge-owned unless the lease
+explicitly says otherwise.
+
+## Command
+
+Use `global.stfc-mod-private.agent-worktree`, or run:
+
+```powershell
+.\scripts\axf\agent-worktree.ps1 -Action list
+```
+
+The default worktree root is a sibling directory:
+
+```text
+D:\dev\stfc-mod-agent-worktrees
+```
+
+Lease state is local-only and ignored by Git:
+
+```text
+.agent-worktrees/leases.jsonl
+```
+
+## Create A Lease
+
+Dry-run first:
+
+```powershell
+.\scripts\axf\agent-worktree.ps1 `
+  -Action create `
+  -LeaseId hook-tier-scout `
+  -AgentName HookTierScout `
+  -Objective "Prototype hook support-tier manifest changes" `
+  -Issue "#145" `
+  -BaseRef HEAD `
+  -AllowedScope "manifests; docs; scripts/axf" `
+  -AllowEdits
+```
+
+Execute only after the planned path, branch, and scope look right:
+
+```powershell
+.\scripts\axf\agent-worktree.ps1 `
+  -Action create `
+  -LeaseId hook-tier-scout `
+  -AgentName HookTierScout `
+  -Objective "Prototype hook support-tier manifest changes" `
+  -Issue "#145" `
+  -BaseRef HEAD `
+  -AllowedScope "manifests; docs; scripts/axf" `
+  -AllowEdits `
+  -Execute
+```
+
+The broker creates the worktree and writes `.agent-worktree/AGENT_LEASE.md`
+inside it.
+
+## Inspect A Lease
+
+```powershell
+.\scripts\axf\agent-worktree.ps1 -Action status -LeaseId hook-tier-scout
+```
+
+Use status before cleanup. If the worktree is dirty, collect the handoff or diff
+before removing it.
+
+## Cleanup
+
+Dry-run cleanup first:
+
+```powershell
+.\scripts\axf\agent-worktree.ps1 -Action cleanup -LeaseId hook-tier-scout
+```
+
+Execute cleanup after collecting the handoff:
+
+```powershell
+.\scripts\axf\agent-worktree.ps1 `
+  -Action cleanup `
+  -LeaseId hook-tier-scout `
+  -Execute
+```
+
+Dirty worktrees block cleanup, including tracked, untracked, and ignored files
+outside the broker-owned lease brief. Use `-Force` only after the bridge has
+collected or intentionally discarded the worktree handoff:
+
+```powershell
+.\scripts\axf\agent-worktree.ps1 `
+  -Action cleanup `
+  -LeaseId hook-tier-scout `
+  -Force `
+  -Execute
+```
+
+Cleanup first verifies the recorded path is still a registered worktree for this
+repository and still on the recorded lease branch. It then removes only
+broker-owned lease files, removes the worktree, and records a cleanup event. It
+does not delete the local branch by default; the bridge keeps that branch
+available for review, cherry-pick, or manual deletion after integration.
+
+## Bridge Rule
+
+The bridge owns final integration. A background agent may leave a diff or a
+commit in a leased worktree only when the lease allows it. The bridge decides
+whether to copy, cherry-pick, reimplement, or discard that work.

--- a/docs/AGENT_WORKTREE_BROKER.md
+++ b/docs/AGENT_WORKTREE_BROKER.md
@@ -46,7 +46,7 @@ D:\dev\stfc-mod-agent-worktrees
 Lease state is local-only and ignored by Git:
 
 ```text
-.agent-worktrees/leases.jsonl
+.ax/agent-worktrees/leases.jsonl
 ```
 
 ## Create A Lease

--- a/manifests/capabilities/global.stfc-mod-private.agent-worktree.json
+++ b/manifests/capabilities/global.stfc-mod-private.agent-worktree.json
@@ -91,7 +91,7 @@
       },
       "lease-state-path": {
         "type": "string",
-        "description": "Repo-local lease ledger path under .agent-worktrees."
+        "description": "Repo-local lease ledger path under .ax/agent-worktrees."
       }
     },
     "additionalProperties": false
@@ -106,7 +106,7 @@
     "action": "list",
     "agent-name": "background-agent",
     "base-ref": "HEAD",
-    "lease-state-path": ".agent-worktrees/leases.jsonl"
+    "lease-state-path": ".ax/agent-worktrees/leases.jsonl"
   },
   "policies": [
     "require_workspace_binding"
@@ -137,7 +137,7 @@
     "The bridge/orchestrator owns lease creation, cleanup, final validation, and publishing."
   ],
   "details": [
-    "Creates worktrees under a known local worktree root and records lease events under .agent-worktrees/leases.jsonl.",
+    "Creates worktrees under a known local worktree root and records lease events under .ax/agent-worktrees/leases.jsonl.",
     "Writes .agent-worktree/AGENT_LEASE.md inside created worktrees so background agents can see objective, scope, and permissions.",
     "Cleanup verifies that the recorded path is registered as this repository's worktree and still on the recorded lease branch before deleting broker-owned lease files."
   ]

--- a/manifests/capabilities/global.stfc-mod-private.agent-worktree.json
+++ b/manifests/capabilities/global.stfc-mod-private.agent-worktree.json
@@ -1,0 +1,144 @@
+{
+  "manifestVersion": "axf/v0",
+  "id": "global.stfc-mod-private.agent-worktree",
+  "summary": "Bridge-owned worktree lease broker for mutation-capable background-agent tasks",
+  "provider": "stfc",
+  "adapterType": "cli",
+  "executionTarget": {
+    "launcher": {
+      "command": "pwsh",
+      "args": [
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File"
+      ]
+    },
+    "target": {
+      "path": "scripts/axf/agent-worktree.ps1",
+      "relativeTo": "workspace"
+    }
+  },
+  "argsSchema": {
+    "type": "object",
+    "properties": {
+      "action": {
+        "type": "string",
+        "enum": [
+          "list",
+          "status",
+          "create",
+          "cleanup"
+        ],
+        "description": "Lifecycle action. Defaults to list."
+      },
+      "lease-id": {
+        "type": "string",
+        "description": "Lease id. Auto-generated for create when omitted."
+      },
+      "agent-name": {
+        "type": "string",
+        "description": "Friendly background-agent name."
+      },
+      "objective": {
+        "type": "string",
+        "description": "Objective for the leased worktree. Required for create."
+      },
+      "issue": {
+        "type": "string",
+        "description": "Related issue or PR reference."
+      },
+      "base-ref": {
+        "type": "string",
+        "description": "Git ref to create the worktree from. Defaults to HEAD."
+      },
+      "branch-name": {
+        "type": "string",
+        "description": "Branch name for the worktree. Defaults to agent/<lease-id>."
+      },
+      "allowed-scope": {
+        "type": "string",
+        "description": "Semicolon- or newline-separated mutation scope for the leased agent."
+      },
+      "allow-edits": {
+        "type": "boolean",
+        "description": "Record that edits are allowed in the leased worktree."
+      },
+      "allow-git-writes": {
+        "type": "boolean",
+        "description": "Record that git writes are allowed in the leased worktree."
+      },
+      "allow-github-writes": {
+        "type": "boolean",
+        "description": "Record that GitHub writes are allowed."
+      },
+      "allow-runtime-actions": {
+        "type": "boolean",
+        "description": "Record that runtime/game/sidecar actions are allowed."
+      },
+      "execute": {
+        "type": "boolean",
+        "description": "Execute create or cleanup. Omit for dry-run."
+      },
+      "force": {
+        "type": "boolean",
+        "description": "Allow cleanup of a dirty worktree after collecting the handoff."
+      },
+      "worktree-root": {
+        "type": "string",
+        "description": "Optional worktree root. Defaults to a sibling stfc-mod-agent-worktrees directory."
+      },
+      "lease-state-path": {
+        "type": "string",
+        "description": "Repo-local lease ledger path under .agent-worktrees."
+      }
+    },
+    "additionalProperties": false
+  },
+  "outputModes": [
+    "json"
+  ],
+  "sideEffects": "write",
+  "scope": "global",
+  "lifecycleState": "active",
+  "defaults": {
+    "action": "list",
+    "agent-name": "background-agent",
+    "base-ref": "HEAD",
+    "lease-state-path": ".agent-worktrees/leases.jsonl"
+  },
+  "policies": [
+    "require_workspace_binding"
+  ],
+  "owner": "module:stfc",
+  "argMap": {
+    "action": "-Action",
+    "lease-id": "-LeaseId",
+    "agent-name": "-AgentName",
+    "objective": "-Objective",
+    "issue": "-Issue",
+    "base-ref": "-BaseRef",
+    "branch-name": "-BranchName",
+    "allowed-scope": "-AllowedScope",
+    "allow-edits": "-AllowEdits",
+    "allow-git-writes": "-AllowGitWrites",
+    "allow-github-writes": "-AllowGithubWrites",
+    "allow-runtime-actions": "-AllowRuntimeActions",
+    "execute": "-Execute",
+    "force": "-Force",
+    "worktree-root": "-WorktreeRoot",
+    "lease-state-path": "-LeaseStatePath"
+  },
+  "warnings": [
+    "Create and cleanup are dry-run unless -execute is set.",
+    "Cleanup is destructive and refuses dirty worktrees unless -force is set. Dirty includes tracked, untracked, and ignored files outside the broker-owned lease brief.",
+    "Worktrees isolate files and indexes, not GitHub writes, release/tag writes, game runtime state, sidecar state, or global build caches.",
+    "The bridge/orchestrator owns lease creation, cleanup, final validation, and publishing."
+  ],
+  "details": [
+    "Creates worktrees under a known local worktree root and records lease events under .agent-worktrees/leases.jsonl.",
+    "Writes .agent-worktree/AGENT_LEASE.md inside created worktrees so background agents can see objective, scope, and permissions.",
+    "Cleanup verifies that the recorded path is registered as this repository's worktree and still on the recorded lease branch before deleting broker-owned lease files."
+  ]
+}

--- a/scripts/axf/README.md
+++ b/scripts/axf/README.md
@@ -14,6 +14,7 @@ Primary capability IDs include:
 
 ```text
 global.stfc-mod-private.agent-brief
+global.stfc-mod-private.agent-worktree
 global.stfc-mod-private.review-contract
 global.stfc-mod-private.release-preflight
 global.stfc-mod-private.doctor
@@ -36,6 +37,11 @@ handoff shape.
 The bridge/orchestrator remains responsible for mutations: edits, branch moves,
 GitHub writes, releases/tags, runtime actions, final validation, and Lex-frame
 logging. See `docs/AGENT_ORCHESTRATION.md` for the full workflow.
+
+Use `global.stfc-mod-private.agent-worktree` when a background agent needs an
+isolated mutation lane. The bridge creates the lease, the agent works inside the
+leased worktree, and the bridge collects the handoff before cleanup. See
+`docs/AGENT_WORKTREE_BROKER.md`.
 
 ## Review Contract
 

--- a/scripts/axf/agent-worktree.ps1
+++ b/scripts/axf/agent-worktree.ps1
@@ -16,7 +16,7 @@ param(
   [switch]$Execute,
   [switch]$Force,
   [string]$WorktreeRoot = "",
-  [string]$LeaseStatePath = ".agent-worktrees/leases.jsonl"
+  [string]$LeaseStatePath = ".ax/agent-worktrees/leases.jsonl"
 )
 
 $ErrorActionPreference = "Stop"
@@ -202,15 +202,15 @@ function Resolve-LeaseStatePath {
     Join-Path $repoRoot.Path $Path
   }
   $fullPath = [System.IO.Path]::GetFullPath($candidate)
-  $stateRoot = [System.IO.Path]::GetFullPath((Join-Path $repoRoot.Path ".agent-worktrees")).TrimEnd(
+  $stateRoot = [System.IO.Path]::GetFullPath((Join-Path $repoRoot.Path ".ax/agent-worktrees")).TrimEnd(
     [System.IO.Path]::DirectorySeparatorChar,
     [System.IO.Path]::AltDirectorySeparatorChar)
   $prefix = "$stateRoot$([System.IO.Path]::DirectorySeparatorChar)"
   if ($fullPath.Equals($stateRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-    throw "LeaseStatePath must be a file under .agent-worktrees: $Path"
+    throw "LeaseStatePath must be a file under .ax/agent-worktrees: $Path"
   }
   if (-not $fullPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
-    throw "LeaseStatePath must stay under .agent-worktrees: $Path"
+    throw "LeaseStatePath must stay under .ax/agent-worktrees: $Path"
   }
 
   return $fullPath

--- a/scripts/axf/agent-worktree.ps1
+++ b/scripts/axf/agent-worktree.ps1
@@ -1,0 +1,849 @@
+[CmdletBinding()]
+param(
+  [ValidateSet("list", "status", "create", "cleanup")]
+  [string]$Action = "list",
+  [string]$LeaseId = "",
+  [string]$AgentName = "background-agent",
+  [string]$Objective = "",
+  [string]$Issue = "",
+  [string]$BaseRef = "HEAD",
+  [string]$BranchName = "",
+  [string]$AllowedScope = "",
+  [switch]$AllowEdits,
+  [switch]$AllowGitWrites,
+  [switch]$AllowGithubWrites,
+  [switch]$AllowRuntimeActions,
+  [switch]$Execute,
+  [switch]$Force,
+  [string]$WorktreeRoot = "",
+  [string]$LeaseStatePath = ".agent-worktrees/leases.jsonl"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$repoParent = Split-Path -Parent $repoRoot.Path
+$defaultWorktreeRoot = Join-Path $repoParent "stfc-mod-agent-worktrees"
+
+function Resolve-FirstCommand {
+  param([string[]]$Names)
+
+  foreach ($name in $Names) {
+    $cmd = Get-Command $name -ErrorAction SilentlyContinue
+    if ($cmd) {
+      return $cmd.Source
+    }
+  }
+
+  throw "None of these commands were found: $($Names -join ', ')"
+}
+
+function ConvertTo-LineTail {
+  param(
+    [string]$Text,
+    [int]$Count = 40
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return @()
+  }
+
+  $lines = $Text -split "`r?`n" | Where-Object { $_ -ne "" }
+  if ($lines.Count -le $Count) {
+    return @($lines)
+  }
+
+  return @($lines | Select-Object -Last $Count)
+}
+
+function Split-StatusText {
+  param([string]$Text)
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return @()
+  }
+
+  return @($Text -split "`r?`n" | Where-Object { $_ -ne "" })
+}
+
+function Test-IsBrokerOwnedStatusLine {
+  param([string]$Line)
+
+  return $Line -match '^(?:\?\?|!!) AGENT_LEASE\.md$' -or
+         $Line -match '^(?:\?\?|!!) \.agent-worktree/AGENT_LEASE\.md$' -or
+         $Line -match '^(?:\?\?|!!) \.agent-worktree/?$'
+}
+
+function Remove-BrokerOwnedStatusLines {
+  param([string[]]$Lines)
+
+  return @($Lines | Where-Object { -not (Test-IsBrokerOwnedStatusLine $_) })
+}
+
+function Select-BrokerOwnedStatusLines {
+  param([string[]]$Lines)
+
+  return @($Lines | Where-Object { Test-IsBrokerOwnedStatusLine $_ })
+}
+
+function Invoke-Captured {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments,
+    [string]$WorkingDirectory = $repoRoot.Path
+  )
+
+  $psi = [System.Diagnostics.ProcessStartInfo]::new()
+  $psi.FileName = $FilePath
+  $psi.WorkingDirectory = $WorkingDirectory
+  $psi.UseShellExecute = $false
+  $psi.RedirectStandardOutput = $true
+  $psi.RedirectStandardError = $true
+
+  foreach ($arg in $Arguments) {
+    [void]$psi.ArgumentList.Add($arg)
+  }
+
+  $process = [System.Diagnostics.Process]::new()
+  $process.StartInfo = $psi
+  [void]$process.Start()
+  $stdout = $process.StandardOutput.ReadToEnd()
+  $stderr = $process.StandardError.ReadToEnd()
+  $process.WaitForExit()
+
+  return [ordered]@{
+    exitCode = $process.ExitCode
+    stdout = $stdout.Trim()
+    stderr = $stderr.Trim()
+    stdoutTail = ConvertTo-LineTail $stdout
+    stderrTail = ConvertTo-LineTail $stderr
+  }
+}
+
+function Add-Problem {
+  param(
+    [System.Collections.ArrayList]$Target,
+    [string]$Code,
+    [string]$Message
+  )
+
+  [void]$Target.Add([ordered]@{
+    code = $Code
+    message = $Message
+  })
+}
+
+function ConvertTo-Slug {
+  param([string]$Text)
+
+  $slug = $Text.ToLowerInvariant() -replace '[^a-z0-9]+', '-'
+  $slug = $slug.Trim('-')
+  if ([string]::IsNullOrWhiteSpace($slug)) {
+    return "agent"
+  }
+  if ($slug.Length -gt 40) {
+    return $slug.Substring(0, 40).Trim('-')
+  }
+  return $slug
+}
+
+function Resolve-UnderRoot {
+  param(
+    [string]$Path,
+    [string]$Root,
+    [string]$Label
+  )
+
+  $rootFull = [System.IO.Path]::GetFullPath($Root).TrimEnd([System.IO.Path]::DirectorySeparatorChar,
+                                                          [System.IO.Path]::AltDirectorySeparatorChar)
+  $candidate = if ([System.IO.Path]::IsPathRooted($Path)) {
+    $Path
+  } else {
+    Join-Path $rootFull $Path
+  }
+  $fullPath = [System.IO.Path]::GetFullPath($candidate)
+  $prefix = "$rootFull$([System.IO.Path]::DirectorySeparatorChar)"
+  if (-not ($fullPath.Equals($rootFull, [System.StringComparison]::OrdinalIgnoreCase) -or
+            $fullPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase))) {
+    throw "$Label must stay within $rootFull`: $Path"
+  }
+
+  return $fullPath
+}
+
+function Test-IsSameOrUnder {
+  param(
+    [string]$Path,
+    [string]$Root
+  )
+
+  $rootFull = [System.IO.Path]::GetFullPath($Root).TrimEnd([System.IO.Path]::DirectorySeparatorChar,
+                                                          [System.IO.Path]::AltDirectorySeparatorChar)
+  $pathFull = [System.IO.Path]::GetFullPath($Path).TrimEnd([System.IO.Path]::DirectorySeparatorChar,
+                                                          [System.IO.Path]::AltDirectorySeparatorChar)
+  $prefix = "$rootFull$([System.IO.Path]::DirectorySeparatorChar)"
+  return $pathFull.Equals($rootFull, [System.StringComparison]::OrdinalIgnoreCase) -or
+         $pathFull.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function ConvertTo-ComparablePath {
+  param([string]$Path)
+
+  return [System.IO.Path]::GetFullPath($Path).TrimEnd([System.IO.Path]::DirectorySeparatorChar,
+                                                      [System.IO.Path]::AltDirectorySeparatorChar)
+}
+
+function Resolve-LeaseStatePath {
+  param([string]$Path)
+
+  $candidate = if ([System.IO.Path]::IsPathRooted($Path)) {
+    $Path
+  } else {
+    Join-Path $repoRoot.Path $Path
+  }
+  $fullPath = [System.IO.Path]::GetFullPath($candidate)
+  $stateRoot = [System.IO.Path]::GetFullPath((Join-Path $repoRoot.Path ".agent-worktrees")).TrimEnd(
+    [System.IO.Path]::DirectorySeparatorChar,
+    [System.IO.Path]::AltDirectorySeparatorChar)
+  $prefix = "$stateRoot$([System.IO.Path]::DirectorySeparatorChar)"
+  if ($fullPath.Equals($stateRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "LeaseStatePath must be a file under .agent-worktrees: $Path"
+  }
+  if (-not $fullPath.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "LeaseStatePath must stay under .agent-worktrees: $Path"
+  }
+
+  return $fullPath
+}
+
+function Resolve-LeaseRoot {
+  param([object]$Lease)
+
+  $root = if ($Lease.worktreeRoot) {
+    $Lease.worktreeRoot
+  } else {
+    $worktreeRootFullPath
+  }
+  $rootFull = [System.IO.Path]::GetFullPath($root).TrimEnd([System.IO.Path]::DirectorySeparatorChar,
+                                                           [System.IO.Path]::AltDirectorySeparatorChar)
+  if (Test-IsSameOrUnder $rootFull $repoRoot.Path) {
+    throw "Recorded worktree root must not be inside the primary repository checkout: $rootFull"
+  }
+
+  return $rootFull
+}
+
+function Remove-BrokerOwnedLeaseFiles {
+  param([string]$Path)
+
+  $leaseRootFull = [System.IO.Path]::GetFullPath($Path)
+  $removed = @()
+
+  $legacyBrief = Resolve-UnderRoot "AGENT_LEASE.md" $leaseRootFull "Broker lease brief"
+  if (Test-Path -LiteralPath $legacyBrief) {
+    Remove-Item -LiteralPath $legacyBrief -Force
+    $removed += "AGENT_LEASE.md"
+  }
+
+  $leaseBrief = Resolve-UnderRoot ".agent-worktree/AGENT_LEASE.md" $leaseRootFull "Broker lease brief"
+  if (Test-Path -LiteralPath $leaseBrief) {
+    Remove-Item -LiteralPath $leaseBrief -Force
+    $removed += ".agent-worktree/AGENT_LEASE.md"
+  }
+
+  $leaseBriefDirectory = Resolve-UnderRoot ".agent-worktree" $leaseRootFull "Broker lease brief directory"
+  if (Test-Path -LiteralPath $leaseBriefDirectory) {
+    $remainingItems = @(Get-ChildItem -LiteralPath $leaseBriefDirectory -Force)
+    if ($remainingItems.Count -eq 0) {
+      Remove-Item -LiteralPath $leaseBriefDirectory -Force
+      $removed += ".agent-worktree/"
+    }
+  }
+
+  return @($removed)
+}
+
+function Get-BrokerLeaseDirectoryExtraItems {
+  param([string]$Path)
+
+  $leaseRootFull = [System.IO.Path]::GetFullPath($Path)
+  $leaseBriefDirectory = Resolve-UnderRoot ".agent-worktree" $leaseRootFull "Broker lease brief directory"
+  if (-not (Test-Path -LiteralPath $leaseBriefDirectory)) {
+    return @()
+  }
+
+  $extras = @()
+  foreach ($item in @(Get-ChildItem -LiteralPath $leaseBriefDirectory -Force -Recurse)) {
+    $relative = [System.IO.Path]::GetRelativePath($leaseBriefDirectory, $item.FullName).Replace("\", "/")
+    if ($relative -ne "AGENT_LEASE.md") {
+      $extras += ".agent-worktree/$relative"
+    }
+  }
+
+  return @($extras)
+}
+
+function Split-ListText {
+  param([string]$Text)
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return @()
+  }
+
+  return @($Text -split "`r?`n|;" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+}
+
+function Read-LeaseRecords {
+  param([string]$Path)
+
+  if (-not (Test-Path -LiteralPath $Path)) {
+    return @()
+  }
+
+  $records = @()
+  foreach ($line in [System.IO.File]::ReadLines($Path)) {
+    if ([string]::IsNullOrWhiteSpace($line)) {
+      continue
+    }
+    try {
+      $records += ($line | ConvertFrom-Json -Depth 30)
+    } catch {
+      $records += [pscustomobject]@{
+        event = "parse-error"
+        raw = $line
+      }
+    }
+  }
+  return @($records)
+}
+
+function Write-LeaseRecord {
+  param(
+    [System.Collections.IDictionary]$Record,
+    [string]$Path
+  )
+
+  $directory = Split-Path -Parent $Path
+  if (-not [string]::IsNullOrWhiteSpace($directory)) {
+    [void][System.IO.Directory]::CreateDirectory($directory)
+  }
+
+  $line = $Record | ConvertTo-Json -Depth 30 -Compress
+  [System.IO.File]::AppendAllText($Path, "$line`n", [System.Text.UTF8Encoding]::new($false))
+}
+
+function Format-DisplayCommand {
+  param(
+    [string]$FilePath,
+    [string[]]$Arguments
+  )
+
+  $parts = @($FilePath) + $Arguments
+  return ($parts | ForEach-Object {
+    if ($_ -match '^[A-Za-z0-9_./:@=+\-\\]+$') {
+      $_
+    } else {
+      '"' + ($_.Replace('"', '\"')) + '"'
+    }
+  }) -join " "
+}
+
+function Get-LatestLease {
+  param(
+    [object[]]$Records,
+    [string]$Id
+  )
+
+  $matches = @($Records | Where-Object { $_.leaseId -eq $Id })
+  if ($matches.Count -eq 0) {
+    return $null
+  }
+
+  return $matches | Select-Object -Last 1
+}
+
+function ConvertTo-LeaseSummary {
+  param([object[]]$Records)
+
+  $summaries = [ordered]@{}
+  foreach ($record in $Records) {
+    if ([string]::IsNullOrWhiteSpace($record.leaseId)) {
+      continue
+    }
+    $summaries[$record.leaseId] = $record
+  }
+
+  return @($summaries.GetEnumerator() | ForEach-Object {
+    $record = $_.Value
+    [ordered]@{
+      leaseId = $record.leaseId
+      event = $record.event
+      agentName = $record.agentName
+      branchName = $record.branchName
+      worktreePath = $record.worktreePath
+      baseRef = $record.baseRef
+      baseSha = $record.baseSha
+      updatedAt = $record.recordedAt
+      objective = $record.objective
+    }
+  })
+}
+
+function ConvertFrom-WorktreePorcelain {
+  param([string]$Text)
+
+  $items = @()
+  $current = [ordered]@{}
+  foreach ($line in ($Text -split "`r?`n")) {
+    if ([string]::IsNullOrWhiteSpace($line)) {
+      if ($current.Count -gt 0) {
+        $items += [pscustomobject]$current
+        $current = [ordered]@{}
+      }
+      continue
+    }
+
+    $parts = $line -split " ", 2
+    $key = $parts[0]
+    $value = if ($parts.Count -gt 1) { $parts[1] } else { $true }
+    $current[$key] = $value
+  }
+
+  if ($current.Count -gt 0) {
+    $items += [pscustomobject]$current
+  }
+
+  return @($items)
+}
+
+function Find-RegisteredWorktree {
+  param(
+    [object[]]$Worktrees,
+    [string]$Path
+  )
+
+  $target = ConvertTo-ComparablePath $Path
+  foreach ($worktree in $Worktrees) {
+    if (-not $worktree.worktree) {
+      continue
+    }
+    $candidate = ConvertTo-ComparablePath ([string]$worktree.worktree)
+    if ($candidate.Equals($target, [System.StringComparison]::OrdinalIgnoreCase)) {
+      return $worktree
+    }
+  }
+
+  return $null
+}
+
+function ConvertTo-WorktreeBranchName {
+  param([object]$Worktree)
+
+  if ($null -eq $Worktree -or -not $Worktree.branch) {
+    return ""
+  }
+
+  $branch = [string]$Worktree.branch
+  if ($branch.StartsWith("refs/heads/", [System.StringComparison]::OrdinalIgnoreCase)) {
+    return $branch.Substring("refs/heads/".Length)
+  }
+
+  return $branch
+}
+
+function Test-RegisteredLeaseWorktree {
+  param(
+    [string]$Path,
+    [string]$BranchName
+  )
+
+  $worktreeList = Invoke-Captured $git @("worktree", "list", "--porcelain")
+  $worktrees = if ($worktreeList.exitCode -eq 0) {
+    ConvertFrom-WorktreePorcelain $worktreeList.stdout
+  } else {
+    @()
+  }
+  $registered = Find-RegisteredWorktree $worktrees $Path
+  $actualBranch = ConvertTo-WorktreeBranchName $registered
+  $expectedBranch = [string]$BranchName
+  $branchOk = ($null -ne $registered) -and
+              ([string]::IsNullOrWhiteSpace($expectedBranch) -or $actualBranch -eq $expectedBranch)
+
+  return [ordered]@{
+    ok = ($worktreeList.exitCode -eq 0) -and ($null -ne $registered) -and $branchOk
+    exitCode = $worktreeList.exitCode
+    registered = $null -ne $registered
+    path = $Path
+    registeredPath = if ($registered) { $registered.worktree } else { $null }
+    expectedBranch = if ($expectedBranch) { $expectedBranch } else { $null }
+    actualBranch = if ($actualBranch) { $actualBranch } else { $null }
+    branchOk = $branchOk
+    stderrTail = $worktreeList.stderrTail
+  }
+}
+
+function Write-LeaseBrief {
+  param(
+    [string]$Path,
+    [System.Collections.IDictionary]$Record
+  )
+
+  $scopeText = if ($Record.allowedScope.Count -eq 0) {
+    "- none specified"
+  } else {
+    ($Record.allowedScope | ForEach-Object { "- $_" }) -join "`n"
+  }
+  $fence = '```'
+  $content = @"
+# Background Agent Worktree Lease
+
+Lease: $($Record.leaseId)
+Agent: $($Record.agentName)
+Issue: $($Record.issue)
+Branch: $($Record.branchName)
+Base: $($Record.baseRef) / $($Record.baseSha)
+
+## Objective
+
+$($Record.objective)
+
+## Allowed Scope
+
+$scopeText
+
+## Permissions
+
+${fence}json
+$($Record.permissions | ConvertTo-Json -Depth 10)
+${fence}
+
+## Rules
+
+- Keep all work inside this worktree.
+- Do not push, tag, release, or mutate GitHub unless the lease explicitly permits it.
+- Do not cycle STFC, sidecar, or game/runtime state unless the lease explicitly permits it.
+- Leave a concise handoff for the bridge before cleanup.
+"@
+  $leaseBriefDirectory = Join-Path $Path ".agent-worktree"
+  [void][System.IO.Directory]::CreateDirectory($leaseBriefDirectory)
+  [System.IO.File]::WriteAllText((Join-Path $leaseBriefDirectory "AGENT_LEASE.md"),
+                                 $content,
+                                 [System.Text.UTF8Encoding]::new($false))
+}
+
+$blockers = [System.Collections.ArrayList]::new()
+$warnings = [System.Collections.ArrayList]::new()
+$steps = [ordered]@{}
+$planned = [System.Collections.ArrayList]::new()
+$executed = [System.Collections.ArrayList]::new()
+try {
+  $git = Resolve-FirstCommand @("git")
+  $leaseStateFullPath = Resolve-LeaseStatePath $LeaseStatePath
+  $worktreeRootFullPath = [System.IO.Path]::GetFullPath($(if ([string]::IsNullOrWhiteSpace($WorktreeRoot)) {
+        $defaultWorktreeRoot
+      } elseif ([System.IO.Path]::IsPathRooted($WorktreeRoot)) {
+        $WorktreeRoot
+      } else {
+        Join-Path $repoParent $WorktreeRoot
+      })).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+
+  if (Test-IsSameOrUnder $worktreeRootFullPath $repoRoot.Path) {
+    Add-Problem $blockers "worktree-root-inside-repo" "WorktreeRoot must not be inside the primary repository checkout."
+  }
+
+  $records = Read-LeaseRecords $leaseStateFullPath
+  $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+  $effectiveWorktreeRoot = $worktreeRootFullPath
+  $leaseIdResolved = if ([string]::IsNullOrWhiteSpace($LeaseId)) {
+    "run-$((Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmss'))-$(ConvertTo-Slug $AgentName)"
+  } else {
+    ConvertTo-Slug $LeaseId
+  }
+  $branchNameResolved = if ([string]::IsNullOrWhiteSpace($BranchName)) {
+    "agent/$leaseIdResolved"
+  } else {
+    $BranchName
+  }
+  $leasePath = Resolve-UnderRoot $leaseIdResolved $worktreeRootFullPath "Lease path"
+} catch {
+  $payload = [ordered]@{
+    ok = $false
+    command = "agent-worktree"
+    action = $Action
+    dryRun = -not $Execute
+    repoRoot = $repoRoot.Path
+    error = $_.Exception.Message
+    blockers = @($blockers)
+    warnings = @($warnings)
+    plannedActions = @($planned)
+    executedActions = @($executed)
+    steps = $steps
+  }
+  $payload | ConvertTo-Json -Depth 40
+  exit 1
+}
+
+try {
+  if ($Action -eq "list") {
+    $worktreeList = Invoke-Captured $git @("worktree", "list", "--porcelain")
+    $steps.gitWorktrees = [ordered]@{
+      ok = $worktreeList.exitCode -eq 0
+      exitCode = $worktreeList.exitCode
+      worktrees = ConvertFrom-WorktreePorcelain $worktreeList.stdout
+      stdoutTail = $worktreeList.stdoutTail
+      stderrTail = $worktreeList.stderrTail
+    }
+    if (-not $steps.gitWorktrees.ok) {
+      Add-Problem $warnings "git-worktree-list-failed" "Could not read git worktree list."
+    }
+  } elseif ($Action -eq "status") {
+    $lease = Get-LatestLease $records $leaseIdResolved
+    if ($null -eq $lease) {
+      Add-Problem $blockers "lease-not-found" "Lease $leaseIdResolved was not found in $LeaseStatePath."
+    } elseif ($lease.event -eq "cleanup") {
+      Add-Problem $warnings "lease-cleaned" "Lease $leaseIdResolved is already recorded as cleaned."
+    } elseif ($lease.worktreePath) {
+      $leaseRoot = Resolve-LeaseRoot $lease
+      $effectiveWorktreeRoot = $leaseRoot
+      $leasePath = Resolve-UnderRoot $lease.worktreePath $leaseRoot "Lease path"
+      $registration = Test-RegisteredLeaseWorktree $leasePath $lease.branchName
+      $steps.registeredWorktree = $registration
+      if ($registration.exitCode -ne 0) {
+        Add-Problem $blockers "worktree-list-failed" "Could not verify registered git worktrees."
+      } elseif (-not $registration.registered) {
+        Add-Problem $blockers "worktree-not-registered" "Lease path is not registered as a worktree for this repository."
+      } elseif (-not $registration.branchOk) {
+        Add-Problem $blockers "worktree-branch-mismatch" "Lease worktree is not on the recorded lease branch."
+      } elseif (Test-Path -LiteralPath $leasePath) {
+        $status = Invoke-Captured $git @("-C", $leasePath, "status", "--short", "--branch")
+        $steps.worktreeStatus = [ordered]@{
+          ok = $status.exitCode -eq 0
+          exitCode = $status.exitCode
+          stdoutTail = $status.stdoutTail
+          stderrTail = $status.stderrTail
+        }
+      } else {
+        Add-Problem $warnings "worktree-path-missing" "Lease path is not present on disk."
+      }
+    } else {
+      Add-Problem $warnings "worktree-path-missing" "Lease record does not contain a worktree path."
+    }
+  } elseif ($Action -eq "create") {
+    if ([string]::IsNullOrWhiteSpace($Objective)) {
+      Add-Problem $blockers "objective-required" "Create requires -Objective."
+    }
+    if (Test-Path -LiteralPath $leasePath) {
+      Add-Problem $blockers "lease-path-exists" "Lease path already exists: $leasePath"
+    }
+    $existingLease = Get-LatestLease $records $leaseIdResolved
+    if ($existingLease -and $existingLease.event -ne "cleanup") {
+      Add-Problem $blockers "lease-id-active" "Lease id $leaseIdResolved already has an active record."
+    }
+
+    $base = Invoke-Captured $git @("rev-parse", "$BaseRef^{commit}")
+    $baseSha = $base.stdout.Trim()
+    $steps.base = [ordered]@{
+      ok = ($base.exitCode -eq 0) -and ($baseSha -match '^[0-9a-f]{40}$')
+      baseRef = $BaseRef
+      baseSha = if ($baseSha) { $baseSha } else { $null }
+      exitCode = $base.exitCode
+      stderrTail = $base.stderrTail
+    }
+    if (-not $steps.base.ok) {
+      Add-Problem $blockers "base-ref-unresolved" "Could not resolve base ref $BaseRef."
+    }
+
+    $branchExists = Invoke-Captured $git @("rev-parse", "--verify", "--quiet", $branchNameResolved)
+    if ($branchExists.exitCode -eq 0) {
+      Add-Problem $blockers "branch-exists" "Branch $branchNameResolved already exists."
+    }
+
+    $args = @("worktree", "add", "-b", $branchNameResolved, $leasePath, $baseSha)
+    [void]$planned.Add([ordered]@{
+      kind = "create-worktree"
+      display = Format-DisplayCommand $git $args
+      args = $args
+      destructive = $false
+    })
+
+    if ($Execute -and $blockers.Count -eq 0) {
+      [void][System.IO.Directory]::CreateDirectory($worktreeRootFullPath)
+      $create = Invoke-Captured $git $args
+      [void]$executed.Add([ordered]@{
+        kind = "create-worktree"
+        exitCode = $create.exitCode
+        stdoutTail = $create.stdoutTail
+        stderrTail = $create.stderrTail
+      })
+      if ($create.exitCode -ne 0) {
+        Add-Problem $blockers "worktree-create-failed" "git worktree add failed."
+      } else {
+        $record = [ordered]@{
+          event = "create"
+          recordedAt = $timestamp
+          leaseId = $leaseIdResolved
+          agentName = $AgentName
+          objective = $Objective
+          issue = $Issue
+          baseRef = $BaseRef
+          baseSha = $baseSha
+          branchName = $branchNameResolved
+          worktreeRoot = $worktreeRootFullPath
+          worktreePath = $leasePath
+          allowedScope = Split-ListText $AllowedScope
+          permissions = [ordered]@{
+            editsAllowed = [bool]$AllowEdits
+            gitWritesAllowed = [bool]$AllowGitWrites
+            githubWritesAllowed = [bool]$AllowGithubWrites
+            runtimeActionsAllowed = [bool]$AllowRuntimeActions
+          }
+        }
+        Write-LeaseRecord $record $leaseStateFullPath
+        Write-LeaseBrief $leasePath $record
+      }
+    }
+  } elseif ($Action -eq "cleanup") {
+    $lease = Get-LatestLease $records $leaseIdResolved
+    if ($null -eq $lease) {
+      Add-Problem $blockers "lease-not-found" "Lease $leaseIdResolved was not found in $LeaseStatePath."
+    } elseif ($lease.event -eq "cleanup") {
+      Add-Problem $warnings "lease-already-cleaned" "Lease $leaseIdResolved is already recorded as cleaned."
+    } else {
+      $leaseRoot = Resolve-LeaseRoot $lease
+      $effectiveWorktreeRoot = $leaseRoot
+      $leasePath = Resolve-UnderRoot $lease.worktreePath $leaseRoot "Lease path"
+      $registration = Test-RegisteredLeaseWorktree $leasePath $lease.branchName
+      $steps.registeredWorktree = $registration
+      if ($registration.exitCode -ne 0) {
+        Add-Problem $blockers "worktree-list-failed" "Could not verify registered git worktrees."
+      } elseif (-not $registration.registered) {
+        Add-Problem $blockers "worktree-not-registered" "Lease path is not registered as a worktree for this repository."
+      } elseif (-not $registration.branchOk) {
+        Add-Problem $blockers "worktree-branch-mismatch" "Lease worktree is not on the recorded lease branch."
+      }
+      if (-not (Test-Path -LiteralPath $leasePath)) {
+        Add-Problem $warnings "worktree-path-missing" "Lease path is not present on disk: $leasePath"
+      } elseif ($blockers.Count -eq 0) {
+        $status = Invoke-Captured $git @("-C", $leasePath, "status", "--porcelain", "--ignored=matching")
+        $statusLines = Split-StatusText $status.stdout
+        $brokerOwnedStatusLines = @(
+          Select-BrokerOwnedStatusLines $statusLines |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
+        $brokerExtraItems = Get-BrokerLeaseDirectoryExtraItems $leasePath
+        $userStatusLines = @(
+          @((Remove-BrokerOwnedStatusLines $statusLines) + $brokerExtraItems) |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+        )
+        $dirty = $userStatusLines.Count -gt 0
+        $steps.worktreeStatus = [ordered]@{
+          ok = $status.exitCode -eq 0
+          exitCode = $status.exitCode
+          dirty = $dirty
+          stdoutTail = @($userStatusLines | Select-Object -Last 40)
+          brokerOwnedTail = @($brokerOwnedStatusLines | Select-Object -Last 40)
+          brokerExtraTail = @($brokerExtraItems | Select-Object -Last 40)
+          stderrTail = $status.stderrTail
+        }
+        if ($status.exitCode -ne 0) {
+          Add-Problem $blockers "worktree-status-failed" "Could not inspect worktree status."
+        } elseif ($dirty -and -not $Force) {
+          Add-Problem $blockers "worktree-dirty" "Worktree has local changes; use -Force only after collecting the handoff."
+        }
+      }
+
+      [void]$planned.Add([ordered]@{
+        kind = "remove-broker-lease-files"
+        paths = @("AGENT_LEASE.md", ".agent-worktree/")
+        destructive = $true
+      })
+      $args = if ($Force) {
+        @("worktree", "remove", "--force", $leasePath)
+      } else {
+        @("worktree", "remove", $leasePath)
+      }
+      [void]$planned.Add([ordered]@{
+        kind = "cleanup-worktree"
+        display = Format-DisplayCommand $git $args
+        args = $args
+        destructive = $true
+      })
+
+      if ($Execute -and $blockers.Count -eq 0) {
+        $removedBrokerFiles = Remove-BrokerOwnedLeaseFiles $leasePath
+        [void]$executed.Add([ordered]@{
+          kind = "remove-broker-lease-files"
+          removed = @($removedBrokerFiles)
+        })
+        $cleanup = Invoke-Captured $git $args
+        [void]$executed.Add([ordered]@{
+          kind = "cleanup-worktree"
+          exitCode = $cleanup.exitCode
+          stdoutTail = $cleanup.stdoutTail
+          stderrTail = $cleanup.stderrTail
+        })
+        if ($cleanup.exitCode -ne 0) {
+          Add-Problem $blockers "worktree-cleanup-failed" "git worktree remove failed."
+        } else {
+          $record = [ordered]@{
+            event = "cleanup"
+            recordedAt = $timestamp
+            leaseId = $leaseIdResolved
+            agentName = $lease.agentName
+            objective = $lease.objective
+            issue = $lease.issue
+            baseRef = $lease.baseRef
+            baseSha = $lease.baseSha
+            branchName = $lease.branchName
+            worktreeRoot = $lease.worktreeRoot
+            worktreePath = $leasePath
+            force = [bool]$Force
+          }
+          Write-LeaseRecord $record $leaseStateFullPath
+        }
+      }
+    }
+  }
+
+  $ok = $blockers.Count -eq 0
+  $payload = [ordered]@{
+    ok = $ok
+    command = "agent-worktree"
+    action = $Action
+    dryRun = -not $Execute
+    repoRoot = $repoRoot.Path
+    worktreeRoot = $effectiveWorktreeRoot
+    leaseStatePath = $leaseStateFullPath
+    leaseId = $leaseIdResolved
+    branchName = $branchNameResolved
+    leasePath = $leasePath
+    blockers = @($blockers)
+    warnings = @($warnings)
+    leases = ConvertTo-LeaseSummary $records
+    plannedActions = @($planned)
+    executedActions = @($executed)
+    steps = $steps
+  }
+
+  $payload | ConvertTo-Json -Depth 40
+  if ($ok) {
+    exit 0
+  }
+  exit 1
+} catch {
+  $payload = [ordered]@{
+    ok = $false
+    command = "agent-worktree"
+    action = $Action
+    dryRun = -not $Execute
+    repoRoot = $repoRoot.Path
+    error = $_.Exception.Message
+    blockers = @($blockers)
+    warnings = @($warnings)
+    plannedActions = @($planned)
+    executedActions = @($executed)
+    steps = $steps
+  }
+  $payload | ConvertTo-Json -Depth 40
+  exit 1
+}


### PR DESCRIPTION
## Summary

Adds a bridge-owned background-agent worktree broker as the mutation lane for delegated agent work.

This is stacked on #150 and closes #151 when the stack lands.

## What changed

- Added `global.stfc-mod-private.agent-worktree` and `scripts/axf/agent-worktree.ps1`.
- Added create/status/list/cleanup lease flows with dry-run-by-default behavior.
- Writes `.agent-worktree/AGENT_LEASE.md` into leased worktrees for objective, scope, and permission context.
- Cleanup verifies the lease path is a registered worktree for this repo and still on the recorded branch before deleting broker-owned files.
- Dirty cleanup checks tracked, untracked, and ignored files outside the broker lease brief.
- Documented the worktree broker lifecycle and updated orchestration docs/AXF README.

## Validation

- `git diff --check`
- JSON parse for `global.stfc-mod-private.agent-worktree`
- raw `agent-worktree.ps1` dry-run create
- raw `agent-worktree.ps1` missing-lease status failure
- execute-path clean lease create/status/cleanup smoke
- execute-path ignored-extra-file cleanup block plus forced cleanup smoke
- AXF inspect/run for `global.stfc-mod-private.agent-worktree`
- `scripts/axf/review-contract.ps1 -Tail 120`

## Notes

The branch is intentionally stacked on `tooling/background-agent-orchestration` so this can review as the next tooling slice after #150.
