### PR TITLE
fix fleet runtime sidecar contract

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -968,7 +968,7 @@ action_queue_probe_files = 3
 # mode = "majel"
 # battlelogs = false
 # battlelogs_realtime = true
-# fleet_runtime = true
+# Fleet runtime is sidecar-only. Configure [sidecar.sync].fleet_runtime instead.
 
 #  <[=============================================================================================================]>
 #

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -915,6 +915,12 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
 
     for (const auto& opt : SyncOptions) {
       target.*opt.option = values[opt.option_str].value<bool>().value_or(defaults.*opt.option);
+      if (opt.type == SyncConfig::Type::FleetRuntime && target.*opt.option) {
+        spdlog::warn("Ignoring unsupported {}.fleet_runtime=true. Fleet runtime delivery is sidecar-only; configure "
+                     "[sidecar.sync].fleet_runtime instead.",
+                     target_section);
+        target.*opt.option = false;
+      }
       parsed_target.insert(opt.option_str, target.*opt.option);
     }
 
@@ -1486,6 +1492,12 @@ void Config::Load()
   for (const auto& opt : SyncOptions) {
     sync_defaults.*opt.option = get_config_or_default(config, parsed, "sync", opt.option_str, false, write_config);
   }
+  if (sync_defaults.fleet_runtime) {
+    spdlog::warn("Ignoring unsupported [sync].fleet_runtime=true. Fleet runtime delivery is sidecar-only; configure "
+                 "[sidecar.sync].fleet_runtime instead.");
+    sync_defaults.fleet_runtime = false;
+    parsed["sync"].as_table()->insert_or_assign("fleet_runtime", false);
+  }
 
   spdlog::debug("");
 
@@ -1508,7 +1520,10 @@ void Config::Load()
   auto sync_url   = config["sync"]["url"].value<std::string>();
   auto sync_token = config["sync"]["token"].value<std::string>();
 
-  if (sync_url.has_value() && sync_token.has_value()) {
+  const bool legacy_sync_url_configured   = sync_url.has_value() && !sync_url->empty();
+  const bool legacy_sync_token_configured = sync_token.has_value() && !sync_token->empty();
+
+  if (legacy_sync_url_configured && legacy_sync_token_configured) {
     if (sidecar_config_result.reject_legacy_sync_url) {
       spdlog::error(
           "Ignoring legacy [sync].url / [sync].token loopback sidecar endpoint. Configure [sidecar.sync] instead.");
@@ -1543,6 +1558,9 @@ void Config::Load()
             sync_url.value(), mask_token(sync_token.value()));
       }
     }
+  } else if (legacy_sync_url_configured || legacy_sync_token_configured) {
+    spdlog::warn("Ignoring incomplete legacy [sync].url / [sync].token configuration. Both values must be non-empty "
+                 "to create sync.targets.default.");
   }
 
   if (auto sync_file = config["sync"]["file"].value<std::string>();

--- a/mods/src/patches/fleet_runtime_sync.cc
+++ b/mods/src/patches/fleet_runtime_sync.cc
@@ -8,7 +8,6 @@
 #include "patches/fleet_runtime_diagnostics.h"
 #include "patches/live_debug_fleet_runtime_observers.h"
 #include "patches/sidecar_local_ingest.h"
-#include "patches/sync_scheduler.h"
 
 #include <nlohmann/json.hpp>
 
@@ -78,8 +77,7 @@ int64_t current_time_millis_utc()
 
 bool fleet_runtime_sync_enabled()
 {
-  return Config::Get().installSyncPatches
-         && (Config::Get().sync_options.fleet_runtime || sidecar_local_ingest::FleetRuntimeEnabled());
+  return Config::Get().installSyncPatches && sidecar_local_ingest::FleetRuntimeEnabled();
 }
 
 int cargo_fill_percent_bucket(int basis_points, int percent)
@@ -362,9 +360,6 @@ void fleet_runtime_sync_capture(const GameplayDispatchContext& dispatch)
   const auto trace = fleet_runtime_diagnostics_make_trace(dispatch, snapshot.fleet, snapshot.slots, observed_at_ms,
                                                           capture_duration_ms);
   const auto payload = build_snapshot_payload(dispatch.source, observed_at_ms, snapshot.fleet, snapshot.slots);
-  if (Config::Get().sync_options.fleet_runtime) {
-    queue_data(SyncConfig::Type::FleetRuntime, payload, false, trace);
-  }
   if (sidecar_local_ingest::FleetRuntimeEnabled()) {
     if (sidecar_local_ingest::FleetRuntimeSnapshotOnlyMode()) {
       spdlog::info("[FleetRuntimeSync] stage=sidecar-publish source={} owner={} seam={} reason={} effect={} "

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -225,8 +225,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
   spdlog::info("");
 
   spdlog::info("Initializing code hooks:");
-  auto             install_deployment_runtime_observers =
-      cfg.installSyncPatches && cfg.sync_options.fleet_runtime;
+  auto             install_deployment_runtime_observers = false;
   if (sidecar_local_ingest::FleetRuntimeEnabled()) {
     spdlog::info("[FleetRuntimeSync] sidecar fleet_runtime uses fleet-bar transition requests; deployment event "
                  "observers disabled");

--- a/mods/src/patches/sync_capability_snapshot.cc
+++ b/mods/src/patches/sync_capability_snapshot.cc
@@ -29,12 +29,12 @@ const char* current_platform_name()
 #endif
 }
 
-std::vector<std::string> enabled_sync_type_names(const SyncConfig& config)
+std::vector<std::string> enabled_sync_type_names(const SyncTargetConfig& config)
 {
   std::vector<std::string> names;
   names.reserve(SyncOptions.size());
   for (const auto& option : SyncOptions) {
-    if (config.enabled(option.type)) {
+    if (http::SyncTargetAcceptsType(config, option.type)) {
       names.push_back(std::string(option.type_str));
     }
   }
@@ -76,7 +76,6 @@ void queue_mod_capability_snapshot()
               "stfc.mod.capability_snapshot.v1",
               "stfc.sync.delta_batch.v1",
               "stfc.fleet.assignment_snapshot.v1",
-              "stfc.fleet.runtime_snapshot.v1",
               "stfc.battle.summary.v1",
           },
   });

--- a/mods/src/patches/sync_transport_policy.cc
+++ b/mods/src/patches/sync_transport_policy.cc
@@ -88,6 +88,9 @@ bool SyncTargetAcceptsType(const SyncTargetConfig& target_config, const SyncConf
   if (type == SyncConfig::Type::FleetAssignments) {
     return SyncTargetUsesMajelEnvelope(target_config.mode) && target_config.slots;
   }
+  if (type == SyncConfig::Type::FleetRuntime) {
+    return false;
+  }
 
   for (const auto& option : SyncOptions) {
     if (option.type == type) {

--- a/tests/src/test_sidecar_config.cc
+++ b/tests/src/test_sidecar_config.cc
@@ -46,6 +46,21 @@ bool has_rejected_target(const std::vector<SidecarRejectedSyncTarget>& rejected_
 
 TEST_SUITE("sidecar_config")
 {
+  TEST_CASE("sidecar sync producers default off")
+  {
+    auto config = toml::parse(R"(
+[sidecar.sync]
+)");
+
+    const auto result = ParseSidecarConfig(config);
+
+    CHECK_FALSE(result.config.sync.enabled);
+    CHECK_FALSE(result.config.sync.battlelogs_realtime);
+    CHECK_FALSE(result.config.sync.battlelog_enrichment);
+    CHECK_FALSE(result.config.sync.fleet_runtime);
+    CHECK(result.config.sync.fleet_runtime_mode == "normal");
+  }
+
   TEST_CASE("omitting advanced namespaces keeps normal config parsing backward compatible")
   {
     auto config = toml::parse(R"(

--- a/tests/src/test_sync_transport_policy.cc
+++ b/tests/src/test_sync_transport_policy.cc
@@ -79,14 +79,17 @@ TEST_SUITE("sync_transport_policy")
     SyncTargetConfig target;
     target.ships = true;
     target.slots = true;
+    target.fleet_runtime = true;
 
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::Ships));
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetRuntime));
 
     target.mode = SyncTargetConfig::Mode::Majel;
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetRuntime));
 
     target.slots = false;
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
@@ -102,7 +105,7 @@ TEST_SUITE("sync_transport_policy")
                 {
                     .name = "majel",
                     .mode = SyncTargetConfig::Mode::Majel,
-                    .enabled_sync_types = {"ship", "slot", "fleet_runtime"},
+                    .enabled_sync_types = {"ship", "slot"},
                 },
             },
         .supported_schemas = {"stfc.mod.capability_snapshot.v1", "stfc.sync.delta_batch.v1"},
@@ -113,7 +116,7 @@ TEST_SUITE("sync_transport_policy")
     CHECK(snapshot["platform"] == "windows");
     CHECK(snapshot["targets"][0]["name"] == "majel");
     CHECK(snapshot["targets"][0]["mode"] == "majel");
-    CHECK(snapshot["targets"][0]["enabledSyncTypes"][2] == "fleet_runtime");
+    CHECK(snapshot["targets"][0]["enabledSyncTypes"][1] == "slot");
     CHECK(snapshot["privacy"]["tokenRedacted"] == true);
     CHECK(snapshot["privacy"]["containsEndpointUrls"] == false);
     CHECK(snapshot.dump().find("secret-token") == std::string::npos);


### PR DESCRIPTION
## Summary

- make fleet runtime sidecar-only and ignore legacy `[sync]` / `[sync.targets.*]` fleet_runtime opt-ins
- prevent empty legacy `[sync].url` / `[sync].token` from creating a bad `sync.targets.default`
- remove external fleet runtime capability advertising and update the example config
- add tests for sidecar sync defaults and external target fleet runtime rejection

## Root Cause

`[sync].fleet_runtime = true` enabled the frame-driven fleet runtime capture path even when `[sidecar.sync].fleet_runtime` was disabled. Target-level `fleet_runtime = false` only affected delivery, not hook/capture activation. Empty legacy `[sync].url = ""` and `token = ""` could also materialize an unusable `default` target inheriting top-level settings.

## Behavior

Fleet runtime capture/publish now requires sidecar readiness through `[sidecar.sync].fleet_runtime`. Legacy and Majel external sync targets no longer accept `FleetRuntime` payloads from `[sync]` or `[sync.targets.*]`.

Closes #157

## Validation

- `git diff --check`
- `xmake run stfc-mod-tests` 280/280 passed
- `xmake build mods`
- deployed/cycled with saved repro TOML; boot logged both bad fleet_runtime settings as ignored, `fleet_runtime_sync enabled=false`, and `DeploymentRuntimeObservers` skipped
