### PR TITLE
[codex] Generate release notes from PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: write
       actions: read
+      pull-requests: read
+      issues: read
     name: Create Release
 
     steps:
@@ -26,11 +28,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Fetch upstream main
-        run: |
-          git remote add upstream https://github.com/netniV/stfc-mod.git
-          git fetch --no-tags --depth=1 upstream main
 
       # ✅ Step 1 — Check if Build succeeded for this same commit
       - name: Wait for matching Build success
@@ -117,40 +114,13 @@ jobs:
 
       - name: Generate release body
         run: |
-          compare_url="https://github.com/netniV/stfc-mod/compare/main...Guffawaffle:${{ github.ref_name }}"
-          readme_url="https://github.com/Guffawaffle/stfc-mod/blob/${{ github.ref_name }}/README.md#whats-different-in-this-fork"
-
-          cat > release-body.md <<'EOF'
-          > **⚠️ UNOFFICIAL FORK — This is NOT the official STFC Community Mod.**
-          >
-          > This build comes from [Guffawaffle's personal fork](https://github.com/Guffawaffle/stfc-mod) and contains experimental features not yet accepted upstream.
-          > **For the official mod, go to [netniV/stfc-mod](https://github.com/netniV/stfc-mod/releases/latest).**
-          > **To support the project, [sponsor netniV](https://github.com/sponsors/netniV)** — he built this.
-
-          ---
-
-          ### Release Assets
-          - `stfc-community-mod.zip` — recommended Windows download
-          - `stfc-community-mod-__TAG__.zip` — versioned Windows archive
-          - `stfc-community-mod-windows-x64.tar.zst` — Windows archive for launcher/update tooling
-          - `stfc-community-mod-macos-universal.tar.zst` — macOS dylib archive for launcher/update tooling
-          - `version.dll` — direct drop-in update for existing installs
-          - `SHA256SUMS.txt` — optional hash verification for release assets
-
-          ### What's different in this fork?
-          See the [fork README](__README_URL__) for a list of experimental features.
-
-          ### Full Fork Delta From Upstream Main
-          This section compares this release against `netniV/stfc-mod` `main`, not just the previous fork tag.
-
-          Full compare: __COMPARE_URL__
-
-          EOF
-
-          sed -i "s|__COMPARE_URL__|${compare_url}|" release-body.md
-          sed -i "s|__README_URL__|${readme_url}|" release-body.md
-          sed -i "s|__TAG__|${{ github.ref_name }}|" release-body.md
-          git log --reverse --no-merges --format='- %s' upstream/main..${{ github.sha }} | awk '!seen[$0]++' >> release-body.md
+          python3 scripts/generate_release_notes.py \
+            --tag "${{ github.ref_name }}" \
+            --target "${{ github.sha }}" \
+            --repo "${{ github.repository }}" \
+            --output release-body.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ✅ Step 5 — Create Release
       - name: Create Release

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -10,7 +10,9 @@ Before tagging a release:
 6. Run the hook support-tier gate through the review contract and confirm any
    science/dormant hooks are either explicitly unsupported in
    `manifests/hook_support_tiers.json` or deliberately promoted before release.
-7. Record known risk and test coverage gaps before publishing the tag.
+7. Review the generated release notes. They should highlight merged PRs and
+   fixed issues since the previous fork tag, not raw commit-title dumps.
+8. Record known risk and test coverage gaps before publishing the tag.
 
 After publishing, if a release is found bad:
 

--- a/docs/release-notes/v2.1.0-guffa.5.md
+++ b/docs/release-notes/v2.1.0-guffa.5.md
@@ -1,0 +1,44 @@
+# v2.1.0-guffa.5
+
+> **UNOFFICIAL FORK - This is NOT the official STFC Community Mod.**
+>
+> This build comes from [Guffawaffle's personal fork](https://github.com/Guffawaffle/stfc-mod) and contains experimental features not yet accepted upstream.
+> **For the official mod, go to [netniV/stfc-mod](https://github.com/netniV/stfc-mod/releases/latest).**
+> **To support the project, [sponsor netniV](https://github.com/sponsors/netniV)** - he built this.
+
+---
+
+### Release Assets
+- `stfc-community-mod.zip` - recommended Windows download
+- `stfc-community-mod-v2.1.0-guffa.5.zip` - versioned Windows archive
+- `stfc-community-mod-windows-x64.tar.zst` - Windows archive for launcher/update tooling
+- `stfc-community-mod-macos-universal.tar.zst` - macOS dylib archive for launcher/update tooling
+- `version.dll` - direct drop-in update for existing installs
+- `SHA256SUMS.txt` - optional hash verification for release assets
+
+### Included Changes
+Compared with [v2.1.0-guffa.4](https://github.com/Guffawaffle/stfc-mod/releases/tag/v2.1.0-guffa.4).
+
+#### Merged PRs
+- [#147](https://github.com/Guffawaffle/stfc-mod/pull/147) Add release preflight for fork tags (fixes #143)
+- [#148](https://github.com/Guffawaffle/stfc-mod/pull/148) Define release withdrawal policy (fixes #144)
+- [#150](https://github.com/Guffawaffle/stfc-mod/pull/150) Add background-agent orchestration briefs (fixes #149)
+- [#153](https://github.com/Guffawaffle/stfc-mod/pull/153) Add background-agent worktree broker
+- [#155](https://github.com/Guffawaffle/stfc-mod/pull/155) [codex] fix loading transition hang
+- [#158](https://github.com/Guffawaffle/stfc-mod/pull/158) fix fleet runtime sidecar contract (fixes #157)
+- [#159](https://github.com/Guffawaffle/stfc-mod/pull/159) [codex] Expose fork runtime release identity (fixes #156)
+- [#154](https://github.com/Guffawaffle/stfc-mod/pull/154) Add hook support-tier manifest gate (fixes #145)
+
+#### Issues Fixed
+- [#143](https://github.com/Guffawaffle/stfc-mod/issues/143) Add executable release preflight for fork tags (via #147)
+- [#144](https://github.com/Guffawaffle/stfc-mod/issues/144) Define policy for broken fork releases and tag withdrawal (via #148)
+- [#145](https://github.com/Guffawaffle/stfc-mod/issues/145) Build hook support-tier manifest and release enforcement (via #154)
+- [#149](https://github.com/Guffawaffle/stfc-mod/issues/149) Define background-agent orchestration workflow (via #150)
+- [#156](https://github.com/Guffawaffle/stfc-mod/issues/156) Align runtime version logging with fork release tag (via #159)
+- [#157](https://github.com/Guffawaffle/stfc-mod/issues/157) Make fleet_runtime sidecar-only and noop for legacy sync targets (via #158)
+
+### What's Different In This Fork?
+See the [fork README](https://github.com/Guffawaffle/stfc-mod/blob/v2.1.0-guffa.5/README.md#whats-different-in-this-fork) for a list of experimental features.
+
+### Compare
+Full compare: https://github.com/Guffawaffle/stfc-mod/compare/v2.1.0-guffa.4...v2.1.0-guffa.5

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Generate fork release notes from merged PRs instead of raw commit titles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+STABLE_FORK_TAG_PATTERN = re.compile(r"^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)-guffa\.(?P<fork>\d+)$")
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    number: int
+    title: str
+    url: str
+    merge_commit: str
+    issues: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    title: str
+    url: str
+    prs: tuple[int, ...]
+
+
+def run(command: list[str]) -> str:
+    result = subprocess.run(command, check=False, capture_output=True, text=True, encoding="utf-8")
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({result.returncode}): {' '.join(command)}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def git(*args: str) -> str:
+    return run(["git", *args]).strip()
+
+
+def gh_json(*args: str) -> Any:
+    output = run(["gh", *args])
+    return json.loads(output)
+
+
+def parse_stable_fork_tag(tag: str) -> tuple[int, int, int, int] | None:
+    match = STABLE_FORK_TAG_PATTERN.match(tag)
+    if not match:
+        return None
+    return tuple(int(match.group(name)) for name in ("major", "minor", "patch", "fork"))
+
+
+def resolve_previous_tag(current_tag: str, override: str | None) -> str:
+    if override:
+        return override
+
+    current_version = parse_stable_fork_tag(current_tag)
+    tags = git("tag", "--list", "v*-guffa.*").splitlines()
+    stable_tags = [(parsed, tag) for tag in tags if (parsed := parse_stable_fork_tag(tag)) is not None]
+    if not stable_tags:
+        raise RuntimeError("no stable vX.Y.Z-guffa.N tags found")
+
+    if current_version is not None:
+        candidates = [(version, tag) for version, tag in stable_tags if version < current_version]
+    else:
+        candidates = [(version, tag) for version, tag in stable_tags if tag != current_tag]
+
+    if not candidates:
+        raise RuntimeError(f"could not infer a previous stable fork tag for {current_tag}")
+
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def resolve_repository(explicit_repo: str | None) -> str:
+    if explicit_repo:
+        return explicit_repo
+    if os.environ.get("GITHUB_REPOSITORY"):
+        return os.environ["GITHUB_REPOSITORY"]
+    data = gh_json("repo", "view", "--json", "nameWithOwner")
+    return str(data["nameWithOwner"])
+
+
+def commits_in_range(previous_tag: str, target: str) -> list[str]:
+    return git("rev-list", "--reverse", f"{previous_tag}..{target}").splitlines()
+
+
+def merged_prs_for_commits(repo: str, commit_order: dict[str, int], pr_limit: int) -> list[PullRequest]:
+    data = gh_json(
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "merged",
+        "--base",
+        "main",
+        "--limit",
+        str(pr_limit),
+        "--json",
+        "number,title,url,mergeCommit,closingIssuesReferences",
+    )
+
+    prs: list[PullRequest] = []
+    for entry in data:
+        merge_commit = ((entry.get("mergeCommit") or {}).get("oid") or "").lower()
+        if merge_commit not in commit_order:
+            continue
+        issue_numbers = tuple(
+            sorted(
+                {
+                    int(issue["number"])
+                    for issue in entry.get("closingIssuesReferences") or []
+                    if isinstance(issue.get("number"), int)
+                }
+            )
+        )
+        prs.append(
+            PullRequest(
+                number=int(entry["number"]),
+                title=str(entry["title"]),
+                url=str(entry["url"]),
+                merge_commit=merge_commit,
+                issues=issue_numbers,
+            )
+        )
+
+    return sorted(prs, key=lambda pr: commit_order[pr.merge_commit])
+
+
+def issues_for_prs(repo: str, prs: list[PullRequest]) -> list[Issue]:
+    pr_by_issue: dict[int, list[int]] = {}
+    for pr in prs:
+        for issue_number in pr.issues:
+            pr_by_issue.setdefault(issue_number, []).append(pr.number)
+
+    issues: list[Issue] = []
+    for issue_number in sorted(pr_by_issue):
+        data = gh_json("issue", "view", str(issue_number), "--repo", repo, "--json", "number,title,url")
+        issues.append(
+            Issue(
+                number=int(data["number"]),
+                title=str(data["title"]),
+                url=str(data["url"]),
+                prs=tuple(pr_by_issue[issue_number]),
+            )
+        )
+    return issues
+
+
+def markdown_link(label: str, url: str) -> str:
+    return f"[{label}]({url})"
+
+
+def render_release_notes(
+    tag: str,
+    previous_tag: str,
+    repo: str,
+    prs: list[PullRequest],
+    issues: list[Issue],
+) -> str:
+    readme_url = f"https://github.com/{repo}/blob/{tag}/README.md#whats-different-in-this-fork"
+    compare_url = f"https://github.com/{repo}/compare/{previous_tag}...{tag}"
+    previous_release_url = f"https://github.com/{repo}/releases/tag/{previous_tag}"
+
+    lines = [
+        f"# {tag}",
+        "",
+        "> **UNOFFICIAL FORK - This is NOT the official STFC Community Mod.**",
+        ">",
+        f"> This build comes from [Guffawaffle's personal fork](https://github.com/{repo}) and contains experimental features not yet accepted upstream.",
+        "> **For the official mod, go to [netniV/stfc-mod](https://github.com/netniV/stfc-mod/releases/latest).**",
+        "> **To support the project, [sponsor netniV](https://github.com/sponsors/netniV)** - he built this.",
+        "",
+        "---",
+        "",
+        "### Release Assets",
+        "- `stfc-community-mod.zip` - recommended Windows download",
+        f"- `stfc-community-mod-{tag}.zip` - versioned Windows archive",
+        "- `stfc-community-mod-windows-x64.tar.zst` - Windows archive for launcher/update tooling",
+        "- `stfc-community-mod-macos-universal.tar.zst` - macOS dylib archive for launcher/update tooling",
+        "- `version.dll` - direct drop-in update for existing installs",
+        "- `SHA256SUMS.txt` - optional hash verification for release assets",
+        "",
+        "### Included Changes",
+        f"Compared with {markdown_link(previous_tag, previous_release_url)}.",
+        "",
+    ]
+
+    if prs:
+        lines.append("#### Merged PRs")
+        for pr in prs:
+            issue_suffix = ""
+            if pr.issues:
+                issue_suffix = " (fixes " + ", ".join(f"#{number}" for number in pr.issues) + ")"
+            lines.append(f"- {markdown_link(f'#{pr.number}', pr.url)} {pr.title}{issue_suffix}")
+        lines.append("")
+    else:
+        lines.extend(["#### Merged PRs", "- No merged PRs were detected in this release range.", ""])
+
+    if issues:
+        lines.append("#### Issues Fixed")
+        for issue in issues:
+            via = ", ".join(f"#{number}" for number in issue.prs)
+            lines.append(f"- {markdown_link(f'#{issue.number}', issue.url)} {issue.title} (via {via})")
+        lines.append("")
+
+    lines.extend(
+        [
+            "### What's Different In This Fork?",
+            f"See the {markdown_link('fork README', readme_url)} for a list of experimental features.",
+            "",
+            "### Compare",
+            f"Full compare: {compare_url}",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", default=os.environ.get("GITHUB_REF_NAME", ""), help="Release tag to describe.")
+    parser.add_argument("--target", default=os.environ.get("GITHUB_SHA", "HEAD"), help="Target commit/ref for the release.")
+    parser.add_argument("--previous-tag", default="", help="Previous stable fork tag. Inferred when omitted.")
+    parser.add_argument("--repo", default="", help="GitHub repository owner/name. Defaults to current gh repo.")
+    parser.add_argument("--pr-limit", type=int, default=200, help="Merged PRs to inspect when matching merge commits.")
+    parser.add_argument("--output", default="", help="Write markdown to this path instead of stdout.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    if not args.tag:
+        raise RuntimeError("--tag is required when GITHUB_REF_NAME is not set")
+
+    repo = resolve_repository(args.repo or None)
+    previous_tag = resolve_previous_tag(args.tag, args.previous_tag or None)
+    target_sha = git("rev-parse", f"{args.target}^{{commit}}")
+    commit_order = {sha.lower(): index for index, sha in enumerate(commits_in_range(previous_tag, target_sha))}
+    prs = merged_prs_for_commits(repo, commit_order, args.pr_limit)
+    issues = issues_for_prs(repo, prs)
+    notes = render_release_notes(args.tag, previous_tag, repo, prs, issues)
+
+    if args.output:
+        Path(args.output).write_text(notes, encoding="utf-8")
+    else:
+        print(notes)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- replaces release-note commit-title dumps with PR-based release notes
- adds `scripts/generate_release_notes.py` to render merged PRs and fixed issues since the previous stable fork tag
- adds a draft `v2.1.0-guffa.5` changelog generated from the current `v2.1.0-guffa.4..main` range
- updates the release checklist to keep release notes focused on PRs/issues instead of raw commits

## Validation
- `py -X utf8 -m py_compile scripts/generate_release_notes.py`
- generated `v2.1.0-guffa.5` notes with explicit `--previous-tag v2.1.0-guffa.4`
- generated `v2.1.0-guffa.5` notes with inferred previous tag and compared against the saved draft
- `git diff --check`