### PR TITLE
Make fleet arrival notifications UI-independent

### DIFF
--- a/docs/20260725-fleet-arrival-hidden-ui-runtime-evidence.md
+++ b/docs/20260725-fleet-arrival-hidden-ui-runtime-evidence.md
@@ -16,9 +16,11 @@ than audio or notification policy.
 The replacement subscriber:
 
 - is armed by a safe fleet widget or event observation of an active transition;
-- scans all fleet slots at a bounded 250 ms cadence only while a fleet still requires transition follow-through;
+- scans all fleet slots at 250 ms for the first 30 seconds, then backs off to five seconds while a fleet still
+  requires transition follow-through;
 - shuts itself off after all observed fleets reach stable states;
-- suspends after a runtime access failure until a safe observation rearms it;
+- suspends after eight consecutive zero-fleet reads or a runtime access failure until a safe observation rearms it;
+- expires after a hard 24-hour lifetime so one request cannot poll forever;
 - feeds the existing deduplicating fleet-state notification machine.
 
 The first guarded canary established that the scanner could activate safely:
@@ -65,7 +67,10 @@ The final bounded build then passed back-to-back human tests with the Faction an
 This proves the final subscriber remained dormant before activity, followed the active fleet across both modal tests,
 delivered each arrival exactly once, and stopped after the last fleet reached a stable state.
 
-## Follow-up
+On 2026-07-26, the human observer also confirmed arrival audio while the Claims window was open. This completes the
+named Faction, Claims, and representative modal-surface acceptance matrix.
 
-The event canary remains opportunistic but is not required for delivery. Decide separately whether its demonstrated
-coverage justifies retaining that additional detour; do not couple that cleanup to the validated scanner behavior.
+## Final hook decision
+
+The `FleetEvents.TriggerPlayerFleetsChangedEvent` canary was removed before release. It produced zero observations in
+the relevant runtime test and is not required by the validated widget-triggered, `FleetsManager` follow-through path.

--- a/docs/20260725-fleet-arrival-hidden-ui-runtime-evidence.md
+++ b/docs/20260725-fleet-arrival-hidden-ui-runtime-evidence.md
@@ -1,0 +1,71 @@
+# Fleet Arrival Hidden-UI Runtime Evidence — 2026-07-25
+
+## Decision
+
+Fleet-arrival notifications no longer need the Fleet Bar to remain visible. A bounded `FleetsManager` scan from the
+shared frame tick detected the arrival transition and delivered both configured outputs while a full-screen game
+window obscured the Fleet Bar.
+
+## Evidence
+
+The first canary used `FleetEvents.TriggerPlayerFleetsChangedEvent` as the proposed UI-independent source. Its hook
+installed successfully, but a one-system hidden-Fleet-Bar arrival produced neither observer traffic nor notification
+delivery. Recalling with the Fleet Bar visible immediately produced sound, isolating the failure to observation rather
+than audio or notification policy.
+
+The replacement subscriber:
+
+- is armed by a safe fleet widget or event observation of an active transition;
+- scans all fleet slots at a bounded 250 ms cadence only while a fleet still requires transition follow-through;
+- shuts itself off after all observed fleets reach stable states;
+- suspends after a runtime access failure until a safe observation rearms it;
+- feeds the existing deduplicating fleet-state notification machine.
+
+The first guarded canary established that the scanner could activate safely:
+
+```text
+23:18:56.287 [FleetState] source=fleet-state-widget status=runtime-ready
+23:18:56.302 [FleetState] source=fleets-manager-scan status=active cadenceMs=250 fleetCount=7
+```
+
+Two hidden-Fleet-Bar arrivals then completed the full delivery path:
+
+```text
+23:35:39.680 [FleetState] source=fleets-manager-scan kind=ARRIVED_IN_SYSTEM
+23:35:40.104 [NotifyAudio] Played notification sound event=fleet.arrived_in_system sound=arrival
+23:35:40.444 [Notify] WinRT notification requested title='Fleet Arrived'
+
+23:39:36.614 [FleetState] source=fleets-manager-scan kind=ARRIVED_IN_SYSTEM
+23:39:37.000 [NotifyAudio] Played notification sound event=fleet.arrived_in_system sound=arrival
+23:39:37.371 [Notify] WinRT notification requested title='Fleet Arrived'
+```
+
+The human observer confirmed the second hidden-ui notification and sound were received.
+
+Before publication, the canary was tightened from continuous post-login scanning to activity-triggered bounded
+follow-through so it does not become a broad frame poller.
+
+The final bounded build then passed back-to-back human tests with the Faction and Refinery surfaces open:
+
+```text
+23:47:00.748 [FleetState] source=fleet-state-widget status=scan-requested state=128
+23:47:00.761 [FleetState] source=fleets-manager-scan status=active cadenceMs=250 fleetCount=7 followThrough=1
+
+23:47:14.934 [FleetState] source=fleets-manager-scan kind=ARRIVED_IN_SYSTEM
+23:47:15.351 [NotifyAudio] Played notification sound event=fleet.arrived_in_system sound=arrival
+23:47:15.698 [Notify] WinRT notification requested title='Fleet Arrived'
+
+23:47:38.358 [FleetState] source=fleets-manager-scan kind=ARRIVED_IN_SYSTEM
+23:47:38.743 [NotifyAudio] Played notification sound event=fleet.arrived_in_system sound=arrival
+23:47:39.112 [Notify] WinRT notification requested title='Fleet Arrived'
+
+23:47:45.951 [FleetState] source=fleets-manager-scan status=idle
+```
+
+This proves the final subscriber remained dormant before activity, followed the active fleet across both modal tests,
+delivered each arrival exactly once, and stopped after the last fleet reached a stable state.
+
+## Follow-up
+
+The event canary remains opportunistic but is not required for delivery. Decide separately whether its demonstrated
+coverage justifies retaining that additional detour; do not couple that cleanup to the validated scanner behavior.

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -39,7 +39,7 @@ This inventory records source-level seams from a static-only review. It does not
 
 | Seam | Owner / file | Functionality supported | Risk class | Confidence / status |
 | --- | --- | --- | --- | --- |
-| `ScreenManager.Update` frame tick | `mods/src/patches/frame_tick.cc`, installed from `mods/src/patches/patches.cc` | Central frame fan-out for hotkeys, optional live-debug tick, and original frame policy | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
+| `ScreenManager.Update` frame tick | `mods/src/patches/frame_tick.cc`, installed from `mods/src/patches/patches.cc` | Central frame fan-out for hotkeys, activity-triggered fleet-state follow-through, optional live-debug tick, and original frame policy | R5 behavioral | Operationally relied on; hook installation runtime-verified on 2026-07-25. |
 | `ShortcutsManager.InitializeActions` | `mods/src/patches/parts/hotkeys.cc` | Controls whether Scopely shortcut initialization runs according to shortcut policy | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `ShortcutsManager.LateUpdate` | `mods/src/patches/parts/hotkeys.cc` | Suppresses native shortcut update when dispatcher-owned input should win | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `ShortcutsManager.SelectShip(int)` | `mods/src/patches/parts/hotkeys.cc` | Native fleet-selection suppression/fallthrough around numeric ship selection | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
@@ -49,8 +49,9 @@ This inventory records source-level seams from a static-only review. It does not
 | `SectionManager.BackButtonPressed` | `mods/src/patches/parts/hotkeys.cc` | Escape/back duplicate suppression | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `NavigationInteractionUIViewController.OnSetCourseButtonClick` | `mods/src/patches/parts/hotkeys.cc` | Duplicate set-course suppression | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `NavigationZoom.Update` | `mods/src/patches/parts/zoom.cc` | Zoom in/out, preset, min/max, and reset dispatch | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
-| `FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)` | `mods/src/patches/parts/fleet_arrival.cc`, owned by `FleetArrivalHooks` | Fleet Bar-independent player fleet-state observation for notifications | R4 native interpretation | Refreshed dump and script-method relationship mapped on 2026-07-25; targeted runtime validation pending. |
+| `FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)` | `mods/src/patches/parts/fleet_arrival.cc`, owned by `FleetArrivalHooks` | Opportunistic player fleet-state observation for notifications | R4 native interpretation | Hook installed successfully on 2026-07-25 but produced no observation during a hidden-Fleet-Bar one-system arrival; not sufficient as the authoritative source. |
 | `FleetStateWidget.SetWidgetData` | `mods/src/patches/parts/fleet_arrival.cc`, owned by `FleetArrivalHooks` | Opportunistic Fleet Bar fallback into the shared fleet-state notification machine | R4/R5 native interpretation / product behavior | Operationally relied on; static relationship mapped; retained as a deduped fallback rather than the authoritative source. |
+| `FleetsManager` scan from the shared frame tick | `mods/src/patches/fleet_notifications.cc`, called from `mods/src/patches/frame_tick.cc` | Fleet Bar-independent follow-through at a bounded 250 ms cadence while an observed fleet remains transitional | R5 behavioral | Runtime-validated twice on 2026-07-25: hidden-Fleet-Bar arrivals produced the expected transition, audio playback, and WinRT request; continuous post-login polling removed before publication. |
 | `DeploymentEvents.Trigger*` live-debug/runtime-sync hooks | `mods/src/patches/parts/live_debug.cc` and `mods/src/patches/parts/deployment_runtime_observers.cc` | Historical fleet runtime observation, live-debug events, notifications, and sync triggers | R4/R5 native interpretation / product behavior | Dormant/disabled after unattended action-queue stall evidence; do not reactivate as the fleet-notification source. |
 | `live_debug_tick(ScreenManager*)` | `mods/src/patches/parts/live_debug.cc`, reached through the frame tick subscriber when live query is enabled | File-backed live-debug request polling and read-only response generation | R4 native interpretation | Static relationship mapped; gated by `LiveDebugChannelEnabled()`; not newly runtime-verified by this pass. |
 | `probe::dump_*` / `probe::search_methods` | `mods/src/probe/probe.h` | Header-only IL2CPP runtime introspection toolkit | R0 while unused; R3/R4 if invoked in-process | Static toolkit only in this inventory. No active call site was found in the reviewed patch surface; do not treat it as a safe runtime probe without a separate ledger row and approval. |
@@ -58,16 +59,16 @@ This inventory records source-level seams from a static-only review. It does not
 ### `Digit.PrimeServer.Events.FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)`
 
 - Owner / file: `FleetArrivalHooks` in `mods/src/patches/parts/fleet_arrival.cc`.
-- Intended question: observe authoritative player fleet-state changes while full-screen UI prevents `FleetStateWidget` refreshes.
+- Intended question: observe player fleet-state changes while full-screen UI prevents `FleetStateWidget` refreshes.
 - Static evidence: the 2026-07-25 private research corpus contains `FleetEvents.TriggerPlayerFleetsChangedEvent` at `0x1565180` with the static signature `void(List<FleetPlayerData>)`; multiple game systems subscribe handlers with the same payload.
 - Risk class: R4 native interpretation. The hook calls the original first, then reads only the supplied list and existing typed `FleetPlayerData` fields.
 - Confidence rung: static relationship.
-- Runtime evidence: pending the issue #184 Windows smoke lane.
+- Runtime evidence: the hook installed successfully on 2026-07-25, but a one-system arrival with the Fleet Bar hidden emitted neither hook traffic nor a notification. A visible-Fleet-Bar recall immediately afterward produced sound, isolating the failure to observation rather than delivery.
 - Payload confidence: list shape and element type are statically corroborated; firing order, coverage, and transition timing remain unverified.
 - Original/trampoline confidence: unverified for this exact seam.
 - Flag / rollback path: gated by `patches.fleetarrivalhooks` plus an enabled fleet-state notification delivery; removing this one registry-owned detour restores the widget-only path.
-- Status: targeted canary pending runtime promotion evidence.
-- Next action: verify hook installation and exactly-once arrival delivery with the Fleet Bar visible and obscured; watch the unattended action queue for regressions.
+- Status: installed canary with insufficient event coverage; retained only as an opportunistic source.
+- Next action: treat the bounded `FleetsManager` frame subscriber as the authoritative UI-independent source, then decide separately whether this event detour still earns its hook surface.
 
 ### `Digit.Prime.GameInput.ShortcutsManager.OnShipLocateAction(InputAction.CallbackContext)`
 

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -49,7 +49,7 @@ This inventory records source-level seams from a static-only review. It does not
 | `SectionManager.BackButtonPressed` | `mods/src/patches/parts/hotkeys.cc` | Escape/back duplicate suppression | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `NavigationInteractionUIViewController.OnSetCourseButtonClick` | `mods/src/patches/parts/hotkeys.cc` | Duplicate set-course suppression | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `NavigationZoom.Update` | `mods/src/patches/parts/zoom.cc` | Zoom in/out, preset, min/max, and reset dispatch | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
-| `FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)` | `mods/src/patches/parts/fleet_arrival.cc`, owned by `FleetArrivalHooks` | Opportunistic player fleet-state observation for notifications | R4 native interpretation | Hook installed successfully on 2026-07-25 but produced no observation during a hidden-Fleet-Bar one-system arrival; not sufficient as the authoritative source. |
+| `FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)` | Removed release canary; historical evidence below | Rejected opportunistic player fleet-state observation for notifications | R4 native interpretation | Hook installed successfully on 2026-07-25 but produced zero observations during the relevant hidden-Fleet-Bar arrival and was removed before release. |
 | `FleetStateWidget.SetWidgetData` | `mods/src/patches/parts/fleet_arrival.cc`, owned by `FleetArrivalHooks` | Opportunistic Fleet Bar fallback into the shared fleet-state notification machine | R4/R5 native interpretation / product behavior | Operationally relied on; static relationship mapped; retained as a deduped fallback rather than the authoritative source. |
 | `FleetsManager` scan from the shared frame tick | `mods/src/patches/fleet_notifications.cc`, called from `mods/src/patches/frame_tick.cc` | Fleet Bar-independent follow-through at a bounded 250 ms cadence while an observed fleet remains transitional | R5 behavioral | Runtime-validated twice on 2026-07-25: hidden-Fleet-Bar arrivals produced the expected transition, audio playback, and WinRT request; continuous post-login polling removed before publication. |
 | `DeploymentEvents.Trigger*` live-debug/runtime-sync hooks | `mods/src/patches/parts/live_debug.cc` and `mods/src/patches/parts/deployment_runtime_observers.cc` | Historical fleet runtime observation, live-debug events, notifications, and sync triggers | R4/R5 native interpretation / product behavior | Dormant/disabled after unattended action-queue stall evidence; do not reactivate as the fleet-notification source. |
@@ -58,7 +58,7 @@ This inventory records source-level seams from a static-only review. It does not
 
 ### `Digit.PrimeServer.Events.FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)`
 
-- Owner / file: `FleetArrivalHooks` in `mods/src/patches/parts/fleet_arrival.cc`.
+- Former owner / file: release canary in `FleetArrivalHooks`, removed from `mods/src/patches/parts/fleet_arrival.cc`.
 - Intended question: observe player fleet-state changes while full-screen UI prevents `FleetStateWidget` refreshes.
 - Static evidence: the 2026-07-25 private research corpus contains `FleetEvents.TriggerPlayerFleetsChangedEvent` at `0x1565180` with the static signature `void(List<FleetPlayerData>)`; multiple game systems subscribe handlers with the same payload.
 - Risk class: R4 native interpretation. The hook calls the original first, then reads only the supplied list and existing typed `FleetPlayerData` fields.
@@ -66,9 +66,9 @@ This inventory records source-level seams from a static-only review. It does not
 - Runtime evidence: the hook installed successfully on 2026-07-25, but a one-system arrival with the Fleet Bar hidden emitted neither hook traffic nor a notification. A visible-Fleet-Bar recall immediately afterward produced sound, isolating the failure to observation rather than delivery.
 - Payload confidence: list shape and element type are statically corroborated; firing order, coverage, and transition timing remain unverified.
 - Original/trampoline confidence: unverified for this exact seam.
-- Flag / rollback path: gated by `patches.fleetarrivalhooks` plus an enabled fleet-state notification delivery; removing this one registry-owned detour restores the widget-only path.
-- Status: installed canary with insufficient event coverage; retained only as an opportunistic source.
-- Next action: treat the bounded `FleetsManager` frame subscriber as the authoritative UI-independent source, then decide separately whether this event detour still earns its hook surface.
+- Flag / rollback path: the canary was removed without changing the validated widget/scanner path.
+- Status: rejected and removed before release because it added hook surface without demonstrated coverage.
+- Next action: keep absent unless new authoritative runtime evidence justifies a separately reviewed seam.
 
 ### `Digit.Prime.GameInput.ShortcutsManager.OnShipLocateAction(InputAction.CallbackContext)`
 

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -49,9 +49,25 @@ This inventory records source-level seams from a static-only review. It does not
 | `SectionManager.BackButtonPressed` | `mods/src/patches/parts/hotkeys.cc` | Escape/back duplicate suppression | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `NavigationInteractionUIViewController.OnSetCourseButtonClick` | `mods/src/patches/parts/hotkeys.cc` | Duplicate set-course suppression | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
 | `NavigationZoom.Update` | `mods/src/patches/parts/zoom.cc` | Zoom in/out, preset, min/max, and reset dispatch | R5 behavioral | Operationally relied on; static relationship mapped; not newly runtime-verified by this pass. |
-| `DeploymentEvents.Trigger*` live-debug/runtime-sync hooks | `mods/src/patches/parts/live_debug.cc`, installed from `mods/src/patches/patches.cc` when live query, fleet runtime sync, or fleet notifications need them | Fleet runtime observation, live-debug recent events, notifications, and sync triggers | R4/R5 native interpretation / product behavior | Grouped because the hooks share one event-source boundary; operationally relied on where configured; static relationship mapped; not newly runtime-verified by this pass. |
+| `FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)` | `mods/src/patches/parts/fleet_arrival.cc`, owned by `FleetArrivalHooks` | Fleet Bar-independent player fleet-state observation for notifications | R4 native interpretation | Refreshed dump and script-method relationship mapped on 2026-07-25; targeted runtime validation pending. |
+| `FleetStateWidget.SetWidgetData` | `mods/src/patches/parts/fleet_arrival.cc`, owned by `FleetArrivalHooks` | Opportunistic Fleet Bar fallback into the shared fleet-state notification machine | R4/R5 native interpretation / product behavior | Operationally relied on; static relationship mapped; retained as a deduped fallback rather than the authoritative source. |
+| `DeploymentEvents.Trigger*` live-debug/runtime-sync hooks | `mods/src/patches/parts/live_debug.cc` and `mods/src/patches/parts/deployment_runtime_observers.cc` | Historical fleet runtime observation, live-debug events, notifications, and sync triggers | R4/R5 native interpretation / product behavior | Dormant/disabled after unattended action-queue stall evidence; do not reactivate as the fleet-notification source. |
 | `live_debug_tick(ScreenManager*)` | `mods/src/patches/parts/live_debug.cc`, reached through the frame tick subscriber when live query is enabled | File-backed live-debug request polling and read-only response generation | R4 native interpretation | Static relationship mapped; gated by `LiveDebugChannelEnabled()`; not newly runtime-verified by this pass. |
 | `probe::dump_*` / `probe::search_methods` | `mods/src/probe/probe.h` | Header-only IL2CPP runtime introspection toolkit | R0 while unused; R3/R4 if invoked in-process | Static toolkit only in this inventory. No active call site was found in the reviewed patch surface; do not treat it as a safe runtime probe without a separate ledger row and approval. |
+
+### `Digit.PrimeServer.Events.FleetEvents.TriggerPlayerFleetsChangedEvent(List<FleetPlayerData>)`
+
+- Owner / file: `FleetArrivalHooks` in `mods/src/patches/parts/fleet_arrival.cc`.
+- Intended question: observe authoritative player fleet-state changes while full-screen UI prevents `FleetStateWidget` refreshes.
+- Static evidence: the 2026-07-25 private research corpus contains `FleetEvents.TriggerPlayerFleetsChangedEvent` at `0x1565180` with the static signature `void(List<FleetPlayerData>)`; multiple game systems subscribe handlers with the same payload.
+- Risk class: R4 native interpretation. The hook calls the original first, then reads only the supplied list and existing typed `FleetPlayerData` fields.
+- Confidence rung: static relationship.
+- Runtime evidence: pending the issue #184 Windows smoke lane.
+- Payload confidence: list shape and element type are statically corroborated; firing order, coverage, and transition timing remain unverified.
+- Original/trampoline confidence: unverified for this exact seam.
+- Flag / rollback path: gated by `patches.fleetarrivalhooks` plus an enabled fleet-state notification delivery; removing this one registry-owned detour restores the widget-only path.
+- Status: targeted canary pending runtime promotion evidence.
+- Next action: verify hook installation and exactly-once arrival delivery with the Fleet Bar visible and obscured; watch the unattended action queue for regressions.
 
 ### `Digit.Prime.GameInput.ShortcutsManager.OnShipLocateAction(InputAction.CallbackContext)`
 

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -285,7 +285,7 @@ notifications_surge_time_left = false
 enabled = false
 
 [notifications.system.fleet]
-# Fleet-bar derived OS notifications.
+# Fleet-state derived OS notifications.
 arrived_in_system = false
 arrived_at_destination = false
 started_mining = false
@@ -309,7 +309,7 @@ docked = { system = false, audio = false, sound = "soft" }
 repair_complete = { system = false, audio = false, sound = "repair" }
 
 [notifications.audio.fleet]
-# Fleet-bar derived audio cues. These are independent of OS notifications.
+# Fleet-state derived audio cues. These are independent of OS notifications.
 arrived_in_system = false
 
 #  <[=====================================================]>

--- a/manifests/gameplay_seam_unmanaged_baseline.json
+++ b/manifests/gameplay_seam_unmanaged_baseline.json
@@ -182,38 +182,6 @@
       "reason": "Grandfathered unmanaged hook-like site from the manual 2026-06 gameplay seam baseline."
     },
     {
-      "id": "raw_spud_static_detour:mods/src/patches/parts/fleet_arrival.cc:521482d00446:1",
-      "kind": "raw_spud_static_detour",
-      "path": "mods/src/patches/parts/fleet_arrival.cc",
-      "normalized_text": "SPUD_STATIC_DETOUR(set_widget_data, FleetStateWidget_SetWidgetData_Hook);",
-      "category": "legacy_unmanaged",
-      "reason": "Grandfathered unmanaged hook-like site from the manual 2026-06 gameplay seam baseline."
-    },
-    {
-      "id": "raw_spud_static_detour:mods/src/patches/parts/fleet_arrival.cc:7fc0c7d656d0:1",
-      "kind": "raw_spud_static_detour",
-      "path": "mods/src/patches/parts/fleet_arrival.cc",
-      "normalized_text": "SPUD_STATIC_DETOUR(handle_mining_depleted, ToastFleetObserver_HandleMiningDepleted_Hook);",
-      "category": "legacy_unmanaged",
-      "reason": "Grandfathered unmanaged hook-like site from the manual 2026-06 gameplay seam baseline."
-    },
-    {
-      "id": "raw_spud_static_detour:mods/src/patches/parts/fleet_arrival.cc:7dab15373dbd:1",
-      "kind": "raw_spud_static_detour",
-      "path": "mods/src/patches/parts/fleet_arrival.cc",
-      "normalized_text": "SPUD_STATIC_DETOUR(queue_notifications, ToastFleetObserver_QueueNotifications_Hook);",
-      "category": "legacy_unmanaged",
-      "reason": "Grandfathered unmanaged hook-like site from the manual 2026-06 gameplay seam baseline."
-    },
-    {
-      "id": "raw_spud_static_detour:mods/src/patches/parts/fleet_arrival.cc:b7db5b22e22c:1",
-      "kind": "raw_spud_static_detour",
-      "path": "mods/src/patches/parts/fleet_arrival.cc",
-      "normalized_text": "SPUD_STATIC_DETOUR(update_timer_widget, MiningObjectViewerWidget_UpdateTimerWidget_Hook);",
-      "category": "legacy_unmanaged",
-      "reason": "Grandfathered unmanaged hook-like site from the manual 2026-06 gameplay seam baseline."
-    },
-    {
       "id": "raw_spud_static_detour:mods/src/patches/parts/free_resize.cc:be0e0cdee2c6:1",
       "kind": "raw_spud_static_detour",
       "path": "mods/src/patches/parts/free_resize.cc",

--- a/manifests/hook_support_tiers.json
+++ b/manifests/hook_support_tiers.json
@@ -25,7 +25,7 @@
       "id": "FrameTickHooks",
       "tier": "internal",
       "source": "mods/src/patches/frame_tick.cc",
-      "rationale": "Central frame fan-out for registered subscribers."
+      "rationale": "Central frame fan-out for hotkeys, fleet notifications, diagnostics, and runtime sync."
     },
     {
       "id": "FleetArrivalHooks",

--- a/manifests/hook_support_tiers.json
+++ b/manifests/hook_support_tiers.json
@@ -28,6 +28,12 @@
       "rationale": "Central frame fan-out for registered subscribers."
     },
     {
+      "id": "FleetArrivalHooks",
+      "tier": "production",
+      "source": "mods/src/patches/parts/fleet_arrival.cc",
+      "rationale": "Release-supported fleet-state, arrival, mining, and incoming-attack notification hooks."
+    },
+    {
       "id": "HotkeyHooks",
       "tier": "production",
       "source": "mods/src/patches/parts/hotkeys.cc",

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -287,7 +287,7 @@ namespace Patches
   constexpr bool improveresponsivenesshooks = true;  ///< Input-responsiveness improvements.
   constexpr bool miscpatches                = true;  ///< Misc one-off fixes.
   constexpr bool objecttracker              = true;  ///< In-system object tracking overlay.
-  constexpr bool fleetarrivalhooks          = true;  ///< Fleet arrival detection from the bottom fleet bar.
+  constexpr bool fleetarrivalhooks          = true;  ///< Fleet arrival detection from player fleet-state changes.
   constexpr bool panhooks                   = true;  ///< Pan-momentum hooks.
   constexpr bool resolutionlistfix          = false; ///< Resolution-list population fix; disabled after Unity 6 update.
   constexpr bool syncpatches                = true;  ///< Data-sync network hooks.

--- a/mods/src/patches/fleet_notification_scan_policy.cc
+++ b/mods/src/patches/fleet_notification_scan_policy.cc
@@ -1,30 +1,80 @@
 #include "patches/fleet_notification_scan_policy.h"
 
 void FleetNotificationScanPolicy::RequestScan()
-{ scan_requested_ = true; }
+{
+  if (scan_requested_) {
+    return;
+  }
+
+  scan_requested_          = true;
+  consecutive_empty_scans_ = 0;
+  started_ms_.reset();
+  last_scan_ms_.reset();
+}
 
 void FleetNotificationScanPolicy::Suspend()
 {
-  scan_requested_ = false;
+  scan_requested_          = false;
+  consecutive_empty_scans_ = 0;
+  started_ms_.reset();
   last_scan_ms_.reset();
 }
 
 void FleetNotificationScanPolicy::Reset()
 { Suspend(); }
 
-bool FleetNotificationScanPolicy::ShouldScan(const int64_t now_ms)
+FleetNotificationScanDecision FleetNotificationScanPolicy::Evaluate(const int64_t now_ms)
 {
   if (!scan_requested_) {
-    return false;
+    return FleetNotificationScanDecision::Idle;
   }
 
-  if (!last_scan_ms_.has_value() || now_ms < *last_scan_ms_
-      || now_ms - *last_scan_ms_ >= kFleetNotificationScanIntervalMs) {
+  if (!started_ms_.has_value() || now_ms < *started_ms_ || (last_scan_ms_.has_value() && now_ms < *last_scan_ms_)) {
+    started_ms_              = now_ms;
+    last_scan_ms_            = now_ms;
+    consecutive_empty_scans_ = 0;
+    return FleetNotificationScanDecision::Scan;
+  }
+
+  const auto lifetime_ms = now_ms - *started_ms_;
+  if (lifetime_ms >= kFleetNotificationScanMaxLifetimeMs) {
+    Suspend();
+    return FleetNotificationScanDecision::Expired;
+  }
+
+  const auto interval_ms = lifetime_ms >= kFleetNotificationScanBackoffAfterMs ? kFleetNotificationScanBackoffIntervalMs
+                                                                               : kFleetNotificationScanIntervalMs;
+  if (!last_scan_ms_.has_value() || now_ms - *last_scan_ms_ >= interval_ms) {
     last_scan_ms_ = now_ms;
-    return true;
+    return FleetNotificationScanDecision::Scan;
   }
 
-  return false;
+  return FleetNotificationScanDecision::Wait;
+}
+
+FleetNotificationScanObservation FleetNotificationScanPolicy::RecordObservation(const int observed_count,
+                                                                                const int follow_through_count)
+{
+  if (!scan_requested_) {
+    return FleetNotificationScanObservation::Settled;
+  }
+
+  if (observed_count <= 0) {
+    ++consecutive_empty_scans_;
+    if (consecutive_empty_scans_ >= kFleetNotificationScanMaxConsecutiveEmpty) {
+      Suspend();
+      return FleetNotificationScanObservation::NoFleets;
+    }
+    return FleetNotificationScanObservation::Continue;
+  }
+
+  consecutive_empty_scans_ = 0;
+  if (follow_through_count <= 0) {
+    Suspend();
+    return FleetNotificationScanObservation::Settled;
+  }
+
+  return FleetNotificationScanObservation::Continue;
 }
 
 bool FleetNotificationScanPolicy::ScanRequested() const

--- a/mods/src/patches/fleet_notification_scan_policy.cc
+++ b/mods/src/patches/fleet_notification_scan_policy.cc
@@ -1,0 +1,31 @@
+#include "patches/fleet_notification_scan_policy.h"
+
+void FleetNotificationScanPolicy::RequestScan()
+{ scan_requested_ = true; }
+
+void FleetNotificationScanPolicy::Suspend()
+{
+  scan_requested_ = false;
+  last_scan_ms_.reset();
+}
+
+void FleetNotificationScanPolicy::Reset()
+{ Suspend(); }
+
+bool FleetNotificationScanPolicy::ShouldScan(const int64_t now_ms)
+{
+  if (!scan_requested_) {
+    return false;
+  }
+
+  if (!last_scan_ms_.has_value() || now_ms < *last_scan_ms_
+      || now_ms - *last_scan_ms_ >= kFleetNotificationScanIntervalMs) {
+    last_scan_ms_ = now_ms;
+    return true;
+  }
+
+  return false;
+}
+
+bool FleetNotificationScanPolicy::ScanRequested() const
+{ return scan_requested_; }

--- a/mods/src/patches/fleet_notification_scan_policy.h
+++ b/mods/src/patches/fleet_notification_scan_policy.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+constexpr int64_t kFleetNotificationScanIntervalMs = 250;
+
+class FleetNotificationScanPolicy
+{
+public:
+  void               RequestScan();
+  void               Suspend();
+  void               Reset();
+  [[nodiscard]] bool ShouldScan(int64_t now_ms);
+  [[nodiscard]] bool ScanRequested() const;
+
+private:
+  bool                   scan_requested_ = false;
+  std::optional<int64_t> last_scan_ms_;
+};

--- a/mods/src/patches/fleet_notification_scan_policy.h
+++ b/mods/src/patches/fleet_notification_scan_policy.h
@@ -3,18 +3,38 @@
 #include <cstdint>
 #include <optional>
 
-constexpr int64_t kFleetNotificationScanIntervalMs = 250;
+constexpr int64_t kFleetNotificationScanIntervalMs          = 250;
+constexpr int64_t kFleetNotificationScanBackoffAfterMs      = 30'000;
+constexpr int64_t kFleetNotificationScanBackoffIntervalMs   = 5'000;
+constexpr int64_t kFleetNotificationScanMaxLifetimeMs       = 24LL * 60 * 60 * 1'000;
+constexpr int     kFleetNotificationScanMaxConsecutiveEmpty = 8;
+
+enum class FleetNotificationScanDecision : uint8_t {
+  Idle,
+  Wait,
+  Scan,
+  Expired,
+};
+
+enum class FleetNotificationScanObservation : uint8_t {
+  Continue,
+  Settled,
+  NoFleets,
+};
 
 class FleetNotificationScanPolicy
 {
 public:
-  void               RequestScan();
-  void               Suspend();
-  void               Reset();
-  [[nodiscard]] bool ShouldScan(int64_t now_ms);
-  [[nodiscard]] bool ScanRequested() const;
+  void                                           RequestScan();
+  void                                           Suspend();
+  void                                           Reset();
+  [[nodiscard]] FleetNotificationScanDecision    Evaluate(int64_t now_ms);
+  [[nodiscard]] FleetNotificationScanObservation RecordObservation(int observed_count, int follow_through_count);
+  [[nodiscard]] bool                             ScanRequested() const;
 
 private:
-  bool                   scan_requested_ = false;
+  bool                   scan_requested_          = false;
+  int                    consecutive_empty_scans_ = 0;
+  std::optional<int64_t> started_ms_;
   std::optional<int64_t> last_scan_ms_;
 };

--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -2,7 +2,7 @@
  * @file fleet_notifications.cc
  * @brief Fleet notification state machine and message generation.
  *
- * This module tracks the last observed fleet-bar states and mining ETA hints,
+ * This module tracks the last observed fleet states and mining ETA hints,
  * then emits OS notifications when meaningful fleet transitions occur.
  */
 #include "patches/fleet_notifications.h"
@@ -92,12 +92,18 @@ NotificationKind incoming_attack_notification_kind_for_delivery(IncomingAttackPo
 std::optional<NotificationKind> notification_kind_from_fleet_transition(FleetBarTransitionNotificationKind kind)
 {
   switch (kind) {
-    case FleetBarTransitionNotificationKind::ArrivedInSystem: return NotificationKind::FleetArrivedInSystem;
-    case FleetBarTransitionNotificationKind::ArrivedAtDestination: return NotificationKind::FleetArrivedAtDestination;
-    case FleetBarTransitionNotificationKind::StartedMining: return NotificationKind::FleetStartedMining;
-    case FleetBarTransitionNotificationKind::RepairComplete: return NotificationKind::FleetRepairComplete;
-    case FleetBarTransitionNotificationKind::Docked: return NotificationKind::FleetDocked;
-    default: return std::nullopt;
+    case FleetBarTransitionNotificationKind::ArrivedInSystem:
+      return NotificationKind::FleetArrivedInSystem;
+    case FleetBarTransitionNotificationKind::ArrivedAtDestination:
+      return NotificationKind::FleetArrivedAtDestination;
+    case FleetBarTransitionNotificationKind::StartedMining:
+      return NotificationKind::FleetStartedMining;
+    case FleetBarTransitionNotificationKind::RepairComplete:
+      return NotificationKind::FleetRepairComplete;
+    case FleetBarTransitionNotificationKind::Docked:
+      return NotificationKind::FleetDocked;
+    default:
+      return std::nullopt;
   }
 }
 
@@ -268,9 +274,9 @@ int64_t duration_ticks_to_seconds(int64_t ticks)
   return static_cast<int64_t>(std::llround(static_cast<double>(ticks) / 10000000.0));
 }
 
-void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& shipName, FleetState oldState,
-                                       FleetState newState, const std::string& resourceName,
-                                       const std::string& cargoText)
+void maybe_notify_fleet_state_transition(uint64_t fleetId, const std::string& shipName, FleetState oldState,
+                                         FleetState newState, const std::string& resourceName,
+                                         const std::string& cargoText, std::string_view observationSource)
 {
   auto eta_it = s_mining_viewer_remaining_seconds.find(fleetId);
   auto etaText =
@@ -295,8 +301,8 @@ void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& ship
   }
 
   if (decision.suppressed_ambiguous_docked) {
-    spdlog::debug("[FleetBar] suppress ambiguous docked transition id={} ship='{}' oldState={} newState={}", fleetId,
-                  shipName, static_cast<int>(oldState), static_cast<int>(newState));
+    spdlog::debug("[FleetState] source={} suppress ambiguous docked transition id={} ship='{}' oldState={} newState={}",
+                  observationSource, fleetId, shipName, static_cast<int>(oldState), static_cast<int>(newState));
     return;
   }
 
@@ -304,8 +310,9 @@ void maybe_notify_fleet_bar_transition(uint64_t fleetId, const std::string& ship
     return;
   }
 
-  spdlog::debug("[FleetBar] {} id={} ship='{}'", fleet_bar_transition_notification_kind_name(decision.kind), fleetId,
-                shipName);
+  spdlog::debug("[FleetState] source={} kind={} id={} ship='{}' oldState={} newState={}", observationSource,
+                fleet_bar_transition_notification_kind_name(decision.kind), fleetId, shipName,
+                static_cast<int>(oldState), static_cast<int>(newState));
   const auto notification_kind = notification_kind_from_fleet_transition(decision.kind);
   if (notification_kind.has_value()) {
     notification_emit(notification_kind.value(), decision.title.c_str(), decision.body.c_str());
@@ -332,7 +339,7 @@ bool fleet_notifications_runtime_events_enabled()
          || notification_delivery_enabled(NotificationKind::FleetRepairComplete);
 }
 
-const char* fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
+const char* fleet_notifications_observe_fleet_state(FleetPlayerData* fleet, std::string_view observationSource)
 {
   if (!fleet) {
     return nullptr;
@@ -362,7 +369,8 @@ const char* fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet)
   s_fleet_bar_cargo_fill_levels[fleetId] = cargoFillLevel;
 
   if (hadPreviousState && previousState != currentState) {
-    maybe_notify_fleet_bar_transition(fleetId, shipName, previousState, currentState, resourceName, cargoText);
+    maybe_notify_fleet_state_transition(fleetId, shipName, previousState, currentState, resourceName, cargoText,
+                                        observationSource);
     runtimeTriggerSource = fleet_runtime_trigger_source_for_state_transition(static_cast<int>(previousState),
                                                                              static_cast<int>(currentState));
   }
@@ -388,7 +396,7 @@ void fleet_notifications_observe_runtime_fleets()
       continue;
     }
 
-    fleet_notifications_observe_fleet_bar(fleet);
+    fleet_notifications_observe_fleet_state(fleet, "fleets-manager-scan");
   }
 }
 
@@ -438,7 +446,7 @@ void fleet_notifications_notify_incoming_attack_target(const ToastFleetQueueNoti
       return;
     }
     notification_emit(incoming_attack_notification_kind_for_delivery(attacker_kind), title ? title : "Incoming Attack!",
-              body.c_str());
+                      body.c_str());
     return;
   }
 

--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -9,6 +9,7 @@
 
 #include "config.h"
 #include "errormsg.h"
+#include "patches/fleet_notification_scan_policy.h"
 #include "patches/live_debug.h"
 #include "patches/live_debug_fleet_serializers.h"
 #include "patches/notification_audio.h"
@@ -38,6 +39,8 @@ std::unordered_map<uint64_t, std::string> s_fleet_bar_ship_names;
 std::unordered_map<uint64_t, std::string> s_fleet_bar_resource_names;
 std::unordered_map<uint64_t, float>       s_fleet_bar_cargo_fill_levels;
 std::unordered_map<uint64_t, int64_t>     s_mining_viewer_remaining_seconds;
+FleetNotificationScanPolicy               s_runtime_scan_policy;
+bool                                      s_runtime_scan_active_logged = false;
 
 constexpr size_t kIncomingAttackDedupeMaxEntries = 256;
 
@@ -53,6 +56,22 @@ struct IncomingAttackNotificationContext {
 int64_t incoming_attack_now_seconds()
 {
   return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+bool fleet_state_requires_scan_follow_through(const FleetState state)
+{
+  switch (state) {
+    case FleetState::TieringUp:
+    case FleetState::Repairing:
+    case FleetState::Battling:
+    case FleetState::WarpCharging:
+    case FleetState::Warping:
+    case FleetState::Impulsing:
+    case FleetState::Capturing:
+      return true;
+    default:
+      return false;
+  }
 }
 
 bool incoming_attack_notifications_enabled_for_kind(IncomingAttackPolicyAttackerKind attackerKind,
@@ -322,6 +341,8 @@ void maybe_notify_fleet_state_transition(uint64_t fleetId, const std::string& sh
 
 void fleet_notifications_init()
 {
+  s_runtime_scan_policy.Reset();
+  s_runtime_scan_active_logged = false;
   notification_init();
   notification_audio_init();
 }
@@ -347,6 +368,13 @@ const char* fleet_notifications_observe_fleet_state(FleetPlayerData* fleet, std:
 
   auto fleetId        = fleet->Id;
   auto currentState   = fleet->CurrentState;
+  if (observationSource != "fleets-manager-scan" && fleet_state_requires_scan_follow_through(currentState)
+      && !s_runtime_scan_policy.ScanRequested()) {
+    s_runtime_scan_policy.RequestScan();
+    spdlog::info("[FleetState] source={} status=scan-requested fleet={} state={}", observationSource, fleetId,
+                 static_cast<int>(currentState));
+  }
+
   auto shipName       = fleet_bar_ship_name(fleet);
   auto resourceName   = fleet_bar_resource_name(fleet);
   auto cargoFillLevel = fleet->CargoResourceFillLevel;
@@ -379,15 +407,16 @@ const char* fleet_notifications_observe_fleet_state(FleetPlayerData* fleet, std:
   return runtimeTriggerSource;
 }
 
-void fleet_notifications_observe_runtime_fleets()
+FleetNotificationRuntimeScanResult fleet_notifications_observe_runtime_fleets()
 {
+  FleetNotificationRuntimeScanResult result;
   if (!fleet_notifications_runtime_events_enabled()) {
-    return;
+    return result;
   }
 
   auto* fleets_manager = FleetsManager::Instance();
   if (!fleets_manager) {
-    return;
+    return result;
   }
 
   for (int slot_index = 0; slot_index < kFleetIndexMax; ++slot_index) {
@@ -397,7 +426,42 @@ void fleet_notifications_observe_runtime_fleets()
     }
 
     fleet_notifications_observe_fleet_state(fleet, "fleets-manager-scan");
+    ++result.observed_count;
+    if (fleet_state_requires_scan_follow_through(fleet->CurrentState)) {
+      ++result.follow_through_count;
+    }
   }
+
+  return result;
+}
+
+void fleet_notifications_tick()
+{
+  const auto now_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
+          .count();
+  if (!s_runtime_scan_policy.ShouldScan(now_ms)) {
+    return;
+  }
+
+  const auto result = fleet_notifications_observe_runtime_fleets();
+  if (result.observed_count > 0 && !s_runtime_scan_active_logged) {
+    s_runtime_scan_active_logged = true;
+    spdlog::info("[FleetState] source=fleets-manager-scan status=active cadenceMs={} fleetCount={} followThrough={}",
+                 kFleetNotificationScanIntervalMs, result.observed_count, result.follow_through_count);
+  }
+
+  if (result.observed_count > 0 && result.follow_through_count == 0) {
+    s_runtime_scan_policy.Suspend();
+    s_runtime_scan_active_logged = false;
+    spdlog::info("[FleetState] source=fleets-manager-scan status=idle");
+  }
+}
+
+void fleet_notifications_suspend_runtime_scan()
+{
+  s_runtime_scan_policy.Suspend();
+  s_runtime_scan_active_logged = false;
 }
 
 void fleet_notifications_observe_node_depleted(int64_t fleetId)

--- a/mods/src/patches/fleet_notifications.cc
+++ b/mods/src/patches/fleet_notifications.cc
@@ -366,10 +366,10 @@ const char* fleet_notifications_observe_fleet_state(FleetPlayerData* fleet, std:
     return nullptr;
   }
 
-  auto fleetId        = fleet->Id;
-  auto currentState   = fleet->CurrentState;
-  if (observationSource != "fleets-manager-scan" && fleet_state_requires_scan_follow_through(currentState)
-      && !s_runtime_scan_policy.ScanRequested()) {
+  auto fleetId      = fleet->Id;
+  auto currentState = fleet->CurrentState;
+  if (fleet_notifications_runtime_events_enabled() && observationSource != "fleets-manager-scan"
+      && fleet_state_requires_scan_follow_through(currentState) && !s_runtime_scan_policy.ScanRequested()) {
     s_runtime_scan_policy.RequestScan();
     spdlog::info("[FleetState] source={} status=scan-requested fleet={} state={}", observationSource, fleetId,
                  static_cast<int>(currentState));
@@ -440,7 +440,14 @@ void fleet_notifications_tick()
   const auto now_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch())
           .count();
-  if (!s_runtime_scan_policy.ShouldScan(now_ms)) {
+  const auto scan_decision = s_runtime_scan_policy.Evaluate(now_ms);
+  if (scan_decision == FleetNotificationScanDecision::Expired) {
+    s_runtime_scan_active_logged = false;
+    spdlog::warn("[FleetState] source=fleets-manager-scan status=suspended reason=max-lifetime lifetimeMs={}",
+                 kFleetNotificationScanMaxLifetimeMs);
+    return;
+  }
+  if (scan_decision != FleetNotificationScanDecision::Scan) {
     return;
   }
 
@@ -451,10 +458,14 @@ void fleet_notifications_tick()
                  kFleetNotificationScanIntervalMs, result.observed_count, result.follow_through_count);
   }
 
-  if (result.observed_count > 0 && result.follow_through_count == 0) {
-    s_runtime_scan_policy.Suspend();
+  const auto observation = s_runtime_scan_policy.RecordObservation(result.observed_count, result.follow_through_count);
+  if (observation == FleetNotificationScanObservation::Settled) {
     s_runtime_scan_active_logged = false;
     spdlog::info("[FleetState] source=fleets-manager-scan status=idle");
+  } else if (observation == FleetNotificationScanObservation::NoFleets) {
+    s_runtime_scan_active_logged = false;
+    spdlog::warn("[FleetState] source=fleets-manager-scan status=suspended reason=no-fleets emptyScans={}",
+                 kFleetNotificationScanMaxConsecutiveEmpty);
   }
 }
 

--- a/mods/src/patches/fleet_notifications.h
+++ b/mods/src/patches/fleet_notifications.h
@@ -16,6 +16,11 @@
 
 struct FleetPlayerData;
 
+struct FleetNotificationRuntimeScanResult {
+  int observed_count       = 0;
+  int follow_through_count = 0;
+};
+
 /**
  * @brief Initialize notification dependencies used by fleet notifications.
  */
@@ -36,8 +41,19 @@ const char* fleet_notifications_observe_fleet_state(FleetPlayerData* fleet, std:
 
 /**
  * @brief Observe current FleetsManager state for all fleet slots and feed the fleet notification state machine.
+ * @return Observed slot count and the number still requiring transition follow-through.
  */
-void fleet_notifications_observe_runtime_fleets();
+FleetNotificationRuntimeScanResult fleet_notifications_observe_runtime_fleets();
+
+/**
+ * @brief Run the throttled frame subscriber that observes fleets independently of Fleet Bar visibility.
+ */
+void fleet_notifications_tick();
+
+/**
+ * @brief Suspend frame scanning after a runtime access failure until a safe event or widget observation rearms it.
+ */
+void fleet_notifications_suspend_runtime_scan();
 
 /**
  * @brief Observe a mining node depletion event for a fleet.

--- a/mods/src/patches/fleet_notifications.h
+++ b/mods/src/patches/fleet_notifications.h
@@ -2,7 +2,7 @@
  * @file fleet_notifications.h
  * @brief Fleet notification runtime logic independent from hook installation.
  *
- * The hook layer captures live fleet-bar and mining-viewer events, then hands
+ * The hook layer captures live fleet-state and mining-viewer events, then hands
  * those observations to this module. This file contains the notification state
  * machine and message formatting, while the `parts/` layer stays limited to
  * IL2CPP method discovery and hook injection.
@@ -27,11 +27,12 @@ void fleet_notifications_init();
 bool fleet_notifications_runtime_events_enabled();
 
 /**
- * @brief Observe a fleet-bar state refresh, emit notifications, and report a meaningful runtime trigger source.
+ * @brief Observe a fleet-state refresh, emit notifications, and report a meaningful runtime trigger source.
  * @param fleet The fleet currently bound to the widget.
+ * @param observation_source Stable diagnostic name for the observation seam.
  * @return A high-signal runtime trigger source name for meaningful state transitions, or nullptr.
  */
-const char* fleet_notifications_observe_fleet_bar(FleetPlayerData* fleet);
+const char* fleet_notifications_observe_fleet_state(FleetPlayerData* fleet, std::string_view observation_source);
 
 /**
  * @brief Observe current FleetsManager state for all fleet slots and feed the fleet notification state machine.
@@ -49,7 +50,8 @@ void fleet_notifications_observe_node_depleted(int64_t fleetId);
  */
 void fleet_notifications_notify_incoming_attack_target(const ToastFleetQueueNotificationsSignal& signal);
 void fleet_notifications_notify_incoming_attack_target(const char* source, uint64_t targetFleetId, int targetType,
-													   int attackerFleetType = 0, std::string_view attackerIdentity = {});
+                                                       int              attackerFleetType = 0,
+                                                       std::string_view attackerIdentity  = {});
 
 /**
  * @brief Observe the current mining ETA from the mining viewer.

--- a/mods/src/patches/frame_tick.cc
+++ b/mods/src/patches/frame_tick.cc
@@ -9,6 +9,7 @@
 #include <spdlog/spdlog.h>
 
 #include "patches/frame_tick.h"
+#include "patches/fleet_notifications.h"
 #include "patches/fleet_runtime_sync.h"
 #include "patches/hook_registry.h"
 #include "patches/hotkey_router.h"
@@ -21,13 +22,14 @@ namespace {
 constexpr bool kEnableFrameTickHook = true;
 constexpr bool kEnableHotkeyFrameSubscriber = true;
 constexpr bool kEnableLiveDebugFrameSubscriber = true;
+constexpr bool kEnableFleetNotificationFrameSubscriber = true;
 constexpr bool kEnableFleetRuntimeSyncFrameSubscriber = true;
 
 constexpr HookDescriptor kScreenManagerUpdateHook = {
   "ScreenManager.Update",
-  "fan out frame ticks to hotkeys, live-debug, and future frame observers",
+  "fan out frame ticks to hotkeys, fleet notifications, live-debug, and runtime sync",
   {"Assembly-CSharp", "Digit.Client.UI", "ScreenManager", "Update"},
-  "frame-driven hotkeys or diagnostics will not tick",
+  "frame-driven hotkeys, fleet notifications, or diagnostics will not tick",
   HookSupportTier::Internal,
 };
 
@@ -50,6 +52,11 @@ bool fleet_runtime_sync_frame_subscriber_allowed()
   return kEnableFleetRuntimeSyncFrameSubscriber && fleet_runtime_sync_frame_subscriber_enabled();
 }
 
+bool fleet_notification_frame_subscriber_enabled()
+{
+  return kEnableFleetNotificationFrameSubscriber && fleet_notifications_runtime_events_enabled();
+}
+
 void log_frame_tick_subscribers()
 {
   spdlog::info("[FrameTick] subscriber=hotkey_router enabled={} reason=installHotkeyHooks compile_time_enabled={}",
@@ -61,6 +68,9 @@ void log_frame_tick_subscribers()
   spdlog::info("[FrameTick] subscriber=fleet_runtime_sync enabled={} reason=fleet_runtime compile_time_enabled={}",
                fleet_runtime_sync_frame_subscriber_allowed(),
                kEnableFleetRuntimeSyncFrameSubscriber);
+  spdlog::info("[FrameTick] subscriber=fleet_notifications enabled={} reason=fleet_arrival_delivery "
+               "compile_time_enabled={}",
+               fleet_notification_frame_subscriber_enabled(), kEnableFleetNotificationFrameSubscriber);
 }
 
 void tick_live_debug(ScreenManager* screen_manager)
@@ -95,6 +105,23 @@ void tick_fleet_runtime_sync()
   }
 }
 
+void tick_fleet_notifications()
+{
+  if (!fleet_notification_frame_subscriber_enabled()) {
+    return;
+  }
+
+  try {
+    fleet_notifications_tick();
+  } catch (const std::exception& ex) {
+    fleet_notifications_suspend_runtime_scan();
+    spdlog::error("[FrameTick] subscriber=fleet_notifications status=failed error='{}'", ex.what());
+  } catch (...) {
+    fleet_notifications_suspend_runtime_scan();
+    spdlog::error("[FrameTick] subscriber=fleet_notifications status=failed error='unknown exception'");
+  }
+}
+
 bool tick_hotkeys(ScreenManager* screen_manager)
 {
   ScopedModImpactTimer impact_timer(ModImpactProbe::FrameTickHotkeys, ModImpactMonitorEnabled());
@@ -125,6 +152,7 @@ void ScreenManager_Update_FrameTick_Hook(auto original, ScreenManager* screen_ma
   }
 
   tick_live_debug(screen_manager);
+  tick_fleet_notifications();
   tick_fleet_runtime_sync();
 }
 }
@@ -141,7 +169,7 @@ void InstallFrameTickHooks()
   }
 
   if (!hotkey_frame_subscriber_enabled() && !live_debug_frame_subscriber_enabled()
-      && !fleet_runtime_sync_frame_subscriber_allowed()) {
+      && !fleet_notification_frame_subscriber_enabled() && !fleet_runtime_sync_frame_subscriber_allowed()) {
     hooks.record_skipped(kScreenManagerUpdateHook, "no enabled frame subscribers");
     hooks.log_summary();
     return;

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -815,9 +815,14 @@ void notification_show(const char* title, const char* body)
 
 bool notification_delivery_enabled(NotificationKind kind)
 {
+#if !STFCMOD_PLATFORM_WINDOWS
+  (void)kind;
+  return false;
+#else
   const auto& notifications = Config::Get().notifications;
   return (notifications.enabled && notification_policy_system_enabled(kind))
          || (notifications.audio_enabled && notification_policy_audio_enabled(kind));
+#endif
 }
 
 void notification_emit(NotificationKind kind, const char* title, const char* body)

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -7,12 +7,12 @@
  * feature has a single targeted path instead of several inference fallbacks.
  */
 #include "config.h"
-#include "errormsg.h"
 
+#include <il2cpp/il2cpp_helper.h>
 #include <patches/fleet_notifications.h>
 #include <patches/fleet_runtime_sync.h>
+#include <patches/hook_registry.h>
 #include <patches/live_debug.h>
-#include <il2cpp/il2cpp_helper.h>
 #include <prime/FleetPlayerData.h>
 #include <prime/IList.h>
 #include <prime/MiningObjectViewerWidget.h>
@@ -28,24 +28,67 @@
 #include <string>
 #include <string_view>
 
-namespace {
-constexpr int kNotificationProducerTypeIncomingFleet = 7;
-constexpr std::string_view kFleetArrivalOwner = "FleetArrivalHooks";
-constexpr std::string_view kFleetStateWidgetSeam = "Digit.Prime.HUD.FleetStateWidget.SetWidgetData";
-constexpr std::string_view kFleetRuntimeSyncEffect = "defer-fleet-runtime-snapshot";
-constexpr ptrdiff_t kIncomingFleetParamsTargetTypeOffset = 0x18;
-constexpr ptrdiff_t kIncomingFleetParamsQuickScanResultOffset = 0x20;
-constexpr ptrdiff_t kIncomingFleetParamsParamsObjectOffset = 0x28;
-constexpr ptrdiff_t kIncomingFleetParamsParamsCaseOffset = 0x30;
-constexpr ptrdiff_t kIncomingFleetParamsObjectFleetIdOffset = 0x10;
-constexpr ptrdiff_t kQuickScanFleetDataFleetTypeOffset = 0x18;
-constexpr ptrdiff_t kQuickScanFleetDataTargetIdOffset = 0x20;
-constexpr ptrdiff_t kQuickScanFleetDataTargetFleetIdOffset = 0x28;
+namespace
+{
+constexpr int              kNotificationProducerTypeIncomingFleet = 7;
+constexpr std::string_view kFleetArrivalOwner                     = "FleetArrivalHooks";
+constexpr std::string_view kFleetStateWidgetSeam                  = "Digit.Prime.HUD.FleetStateWidget.SetWidgetData";
+constexpr std::string_view kPlayerFleetsChangedSeam =
+    "Digit.PrimeServer.Events.FleetEvents.TriggerPlayerFleetsChangedEvent";
+constexpr std::string_view kFleetRuntimeSyncEffect                   = "defer-fleet-runtime-snapshot";
+constexpr ptrdiff_t        kIncomingFleetParamsTargetTypeOffset      = 0x18;
+constexpr ptrdiff_t        kIncomingFleetParamsQuickScanResultOffset = 0x20;
+constexpr ptrdiff_t        kIncomingFleetParamsParamsObjectOffset    = 0x28;
+constexpr ptrdiff_t        kIncomingFleetParamsParamsCaseOffset      = 0x30;
+constexpr ptrdiff_t        kIncomingFleetParamsObjectFleetIdOffset   = 0x10;
+constexpr ptrdiff_t        kQuickScanFleetDataFleetTypeOffset        = 0x18;
+constexpr ptrdiff_t        kQuickScanFleetDataTargetIdOffset         = 0x20;
+constexpr ptrdiff_t        kQuickScanFleetDataTargetFleetIdOffset    = 0x28;
+
+constexpr HookDescriptor kPlayerFleetsChangedHook = {
+    "FleetEvents.TriggerPlayerFleetsChangedEvent",
+    "observe player fleet-state changes without depending on Fleet Bar visibility",
+    {"Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Events", "FleetEvents", "TriggerPlayerFleetsChangedEvent"},
+    "fleet arrival notifications may be missed while full-screen UI is open",
+    HookSupportTier::Production,
+};
+
+constexpr HookDescriptor kFleetStateWidgetHook = {
+    "FleetStateWidget.SetWidgetData",
+    "observe Fleet Bar state refreshes as an opportunistic arrival fallback",
+    {"Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget", "SetWidgetData"},
+    "Fleet Bar refreshes will not provide fallback fleet-state observations",
+    HookSupportTier::Production,
+};
+
+constexpr HookDescriptor kMiningDepletedHook = {
+    "ToastFleetObserver.HandleMiningDepleted",
+    "emit node-depleted fleet notifications",
+    {"Assembly-CSharp", "Digit.Prime.HUD", "ToastFleetObserver", "HandleMiningDepleted"},
+    "node-depleted fleet notifications will not fire",
+    HookSupportTier::Production,
+};
+
+constexpr HookDescriptor kQueueNotificationsHook = {
+    "ToastFleetObserver.QueueNotifications",
+    "classify incoming fleet attacks from materialized game notifications",
+    {"Assembly-CSharp", "Digit.Prime.HUD", "ToastFleetObserver", "QueueNotifications"},
+    "incoming fleet attack notifications will not fire",
+    HookSupportTier::Production,
+};
+
+constexpr HookDescriptor kMiningTimerHook = {
+    "MiningObjectViewerWidget.UpdateTimerWidget",
+    "capture mining ETA context for fleet notifications",
+    {"Assembly-CSharp", "Digit.Prime.ObjectViewer", "MiningObjectViewerWidget", "UpdateTimerWidget"},
+    "mining ETA context will be absent from fleet notifications",
+    HookSupportTier::Production,
+};
 
 struct QuickScanData {
-  int fleet_type = 0;
+  int         fleet_type = 0;
   std::string target_id;
-  uint64_t target_fleet_id = 0;
+  uint64_t    target_fleet_id = 0;
 };
 
 std::string read_string_field(Il2CppObject* object, ptrdiff_t offset)
@@ -61,11 +104,11 @@ QuickScanData read_quick_scan_data(Il2CppObject* quickScanResult)
     return data;
   }
 
-  data.fleet_type = *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(quickScanResult) +
-                                                kQuickScanFleetDataFleetTypeOffset);
-  data.target_id = read_string_field(quickScanResult, kQuickScanFleetDataTargetIdOffset);
-  data.target_fleet_id = static_cast<uint64_t>(*reinterpret_cast<int64_t*>(reinterpret_cast<char*>(quickScanResult) +
-                                                                           kQuickScanFleetDataTargetFleetIdOffset));
+  data.fleet_type =
+      *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(quickScanResult) + kQuickScanFleetDataFleetTypeOffset);
+  data.target_id       = read_string_field(quickScanResult, kQuickScanFleetDataTargetIdOffset);
+  data.target_fleet_id = static_cast<uint64_t>(
+      *reinterpret_cast<int64_t*>(reinterpret_cast<char*>(quickScanResult) + kQuickScanFleetDataTargetFleetIdOffset));
   return data;
 }
 
@@ -80,10 +123,9 @@ FleetPlayerData* fleet_bar_widget_context(void* self)
   return get_context ? get_context(self) : nullptr;
 }
 
-void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
+void observe_fleet_state(FleetPlayerData* fleet, std::string_view seam, std::string_view observationSource)
 {
-  auto* fleet = fleet_bar_widget_context(self);
-  if (const auto* trigger_source = fleet_notifications_observe_fleet_bar(fleet)) {
+  if (const auto* trigger_source = fleet_notifications_observe_fleet_state(fleet, observationSource)) {
     auto*      hull       = fleet ? fleet->Hull : nullptr;
     const auto hull_name  = hull && hull->Name ? to_string(hull->Name) : std::string{};
     const auto fleet_id   = fleet ? fleet->Id : 0;
@@ -91,11 +133,29 @@ void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
     const auto prev_state = fleet ? static_cast<int>(fleet->PreviousState) : -1;
     spdlog::info("[FleetRuntimeTrigger] stage=observed source={} owner={} seam={} fleet={} hull='{}' state={} prev={} "
                  "effect={}",
-                 trigger_source, kFleetArrivalOwner, kFleetStateWidgetSeam, fleet_id, hull_name, state, prev_state,
+                 trigger_source, kFleetArrivalOwner, seam, fleet_id, hull_name, state, prev_state,
                  kFleetRuntimeSyncEffect);
-    fleet_runtime_sync_trigger(gameplay_dispatch_context(trigger_source, kFleetArrivalOwner, kFleetStateWidgetSeam,
-                                                         trigger_source, kFleetRuntimeSyncEffect));
+    fleet_runtime_sync_trigger(
+        gameplay_dispatch_context(trigger_source, kFleetArrivalOwner, seam, trigger_source, kFleetRuntimeSyncEffect));
   }
+}
+
+void FleetEvents_TriggerPlayerFleetsChangedEvent_Hook(auto original, IList* changedFleets)
+{
+  original(changedFleets);
+
+  const auto changed_fleet_count = changedFleets ? changedFleets->Count : 0;
+  spdlog::debug("[FleetState] source=player-fleets-changed changedCount={}", changed_fleet_count);
+  for (int index = 0; changedFleets && index < changed_fleet_count; ++index) {
+    auto* fleet = reinterpret_cast<FleetPlayerData*>(changedFleets->Get(index));
+    observe_fleet_state(fleet, kPlayerFleetsChangedSeam, "player-fleets-changed");
+  }
+}
+
+void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
+{
+  auto* fleet = fleet_bar_widget_context(self);
+  observe_fleet_state(fleet, kFleetStateWidgetSeam, "fleet-state-widget");
 
   original(self);
 }
@@ -116,49 +176,40 @@ void ToastFleetObserver_QueueNotifications_Hook(auto original, void* self, IList
       continue;
     }
 
-    auto* incoming_params = notification->IncomingFleetParams;
-    auto target_type = incoming_params ? *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(incoming_params) +
-                                                                     kIncomingFleetParamsTargetTypeOffset)
-                                       : -1;
+    auto* incoming_params   = notification->IncomingFleetParams;
+    auto  target_type       = incoming_params ? *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(incoming_params)
+                                                                            + kIncomingFleetParamsTargetTypeOffset)
+                                              : -1;
     auto* quick_scan_result = incoming_params
-                                  ? *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(incoming_params) +
-                                                                      kIncomingFleetParamsQuickScanResultOffset)
+                                  ? *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(incoming_params)
+                                                                      + kIncomingFleetParamsQuickScanResultOffset)
                                   : nullptr;
-    auto quick_scan = read_quick_scan_data(quick_scan_result);
-    auto params_case = incoming_params ? *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(incoming_params) +
-                                                                     kIncomingFleetParamsParamsCaseOffset)
-                                       : 0;
-    auto* params_object = incoming_params
-                              ? *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(incoming_params) +
-                                                                  kIncomingFleetParamsParamsObjectOffset)
-                              : nullptr;
+    auto  quick_scan        = read_quick_scan_data(quick_scan_result);
+    auto  params_case       = incoming_params ? *reinterpret_cast<int32_t*>(reinterpret_cast<char*>(incoming_params)
+                                                                            + kIncomingFleetParamsParamsCaseOffset)
+                                              : 0;
+    auto* params_object = incoming_params ? *reinterpret_cast<Il2CppObject**>(reinterpret_cast<char*>(incoming_params)
+                                                                              + kIncomingFleetParamsParamsObjectOffset)
+                                          : nullptr;
     uint64_t target_fleet_id = 0;
     if (params_case == 4 && params_object) {
-      target_fleet_id = static_cast<uint64_t>(*reinterpret_cast<int64_t*>(reinterpret_cast<char*>(params_object) +
-                                                                          kIncomingFleetParamsObjectFleetIdOffset));
+      target_fleet_id = static_cast<uint64_t>(*reinterpret_cast<int64_t*>(reinterpret_cast<char*>(params_object)
+                                                                          + kIncomingFleetParamsObjectFleetIdOffset));
     }
 
-    spdlog::debug("[IncomingAttack] queue index={} count={} targetType={} paramsCase={} targetFleetId={} quickScanFleetType={} quickScanTargetFleetId={} quickScanTargetId='{}'",
-                  index,
-                  notification_count,
-                  target_type,
-                  params_case,
-                  target_fleet_id,
-                  quick_scan.fleet_type,
-                  quick_scan.target_fleet_id,
-                  quick_scan.target_id);
-    live_debug_record_incoming_fleet_materialized("ToastFleetObserver.QueueNotifications",
-                                                  target_type,
-                                                  target_fleet_id,
-                                                  quick_scan.fleet_type,
-                                                  quick_scan.target_fleet_id,
+    spdlog::debug("[IncomingAttack] queue index={} count={} targetType={} paramsCase={} targetFleetId={} "
+                  "quickScanFleetType={} quickScanTargetFleetId={} quickScanTargetId='{}'",
+                  index, notification_count, target_type, params_case, target_fleet_id, quick_scan.fleet_type,
+                  quick_scan.target_fleet_id, quick_scan.target_id);
+    live_debug_record_incoming_fleet_materialized("ToastFleetObserver.QueueNotifications", target_type, target_fleet_id,
+                                                  quick_scan.fleet_type, quick_scan.target_fleet_id,
                                                   quick_scan.target_id);
     ToastFleetQueueNotificationsSignal signal;
-    signal.source = "toast-fleet-queue";
-    signal.target_fleet_id = target_fleet_id;
-    signal.target_type = target_type;
+    signal.source              = "toast-fleet-queue";
+    signal.target_fleet_id     = target_fleet_id;
+    signal.target_type         = target_type;
     signal.attacker_fleet_type = quick_scan.fleet_type;
-    signal.attacker_identity = quick_scan.target_id;
+    signal.attacker_identity   = quick_scan.target_id;
     fleet_notifications_notify_incoming_attack_target(signal);
   }
 
@@ -170,8 +221,8 @@ void MiningObjectViewerWidget_UpdateTimerWidget_Hook(auto original, MiningObject
 {
   original(self, selectedFleet);
 
-  auto* timerContext  = self ? self->_miningTimerWidgetContext : nullptr;
-  auto remainingTicks = timerContext ? timerContext->RemainingTime.Ticks : -1;
+  auto* timerContext   = self ? self->_miningTimerWidgetContext : nullptr;
+  auto  remainingTicks = timerContext ? timerContext->RemainingTime.Ticks : -1;
   fleet_notifications_observe_mining_timer(selectedFleet, remainingTicks);
 }
 } // namespace
@@ -179,52 +230,79 @@ void MiningObjectViewerWidget_UpdateTimerWidget_Hook(auto original, MiningObject
 void InstallFleetArrivalHooks()
 {
   fleet_notifications_init();
+  HookModuleHealth hooks("FleetArrivalHooks");
+
+  if (!fleet_notifications_runtime_events_enabled()) {
+    hooks.record_skipped(kPlayerFleetsChangedHook, "no enabled fleet-state notification deliveries");
+  } else {
+    auto fleet_events =
+        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Events", "FleetEvents");
+    if (!fleet_events.isValidHelper()) {
+      fleet_events = il2cpp_get_class_helper("Assembly-CSharp", "Digit.PrimeServer.Events", "FleetEvents");
+    }
+
+    if (!fleet_events.isValidHelper()) {
+      hooks.record_missing_helper(kPlayerFleetsChangedHook);
+    } else {
+      auto trigger_player_fleets_changed = fleet_events.GetMethod("TriggerPlayerFleetsChangedEvent", 1);
+      if (trigger_player_fleets_changed == nullptr) {
+        hooks.record_missing_method(kPlayerFleetsChangedHook);
+      } else {
+        HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kPlayerFleetsChangedHook, trigger_player_fleets_changed,
+                                         FleetEvents_TriggerPlayerFleetsChangedEvent_Hook);
+      }
+    }
+  }
 
   auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
   if (!fleet_state_widget.isValidHelper()) {
-    ErrorMsg::MissingHelper("Digit.Prime.HUD", "FleetStateWidget");
-    return;
+    hooks.record_missing_helper(kFleetStateWidgetHook);
+  } else {
+    auto set_widget_data = fleet_state_widget.GetMethod("SetWidgetData");
+    if (set_widget_data == nullptr) {
+      hooks.record_missing_method(kFleetStateWidgetHook);
+    } else {
+      HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kFleetStateWidgetHook, set_widget_data,
+                                       FleetStateWidget_SetWidgetData_Hook);
+    }
   }
-
-  auto set_widget_data = fleet_state_widget.GetMethod("SetWidgetData");
-  if (set_widget_data == nullptr) {
-    ErrorMsg::MissingMethod("FleetStateWidget", "SetWidgetData");
-    return;
-  }
-
-  SPUD_STATIC_DETOUR(set_widget_data, FleetStateWidget_SetWidgetData_Hook);
 
   auto toast_fleet_observer = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "ToastFleetObserver");
   if (!toast_fleet_observer.isValidHelper()) {
-    spdlog::warn("[Fleet] ToastFleetObserver helper not found; fleet observer hooks disabled");
+    hooks.record_missing_helper(kMiningDepletedHook);
+    hooks.record_missing_helper(kQueueNotificationsHook);
   } else {
     auto handle_mining_depleted = toast_fleet_observer.GetMethod("HandleMiningDepleted");
     if (handle_mining_depleted == nullptr) {
-      spdlog::warn("[Fleet] ToastFleetObserver.HandleMiningDepleted not found; node depleted notifications disabled");
+      hooks.record_missing_method(kMiningDepletedHook);
     } else {
-      SPUD_STATIC_DETOUR(handle_mining_depleted, ToastFleetObserver_HandleMiningDepleted_Hook);
+      HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kMiningDepletedHook, handle_mining_depleted,
+                                       ToastFleetObserver_HandleMiningDepleted_Hook);
     }
 
     auto queue_notifications = toast_fleet_observer.GetMethod("QueueNotifications", 1);
     if (queue_notifications == nullptr) {
-      spdlog::warn("[IncomingAttack] ToastFleetObserver.QueueNotifications not found; incoming attack notifications disabled");
+      hooks.record_missing_method(kQueueNotificationsHook);
     } else {
-      SPUD_STATIC_DETOUR(queue_notifications, ToastFleetObserver_QueueNotifications_Hook);
+      HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kQueueNotificationsHook, queue_notifications,
+                                       ToastFleetObserver_QueueNotifications_Hook);
     }
   }
 
-  auto mining_object_viewer = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.ObjectViewer", "MiningObjectViewerWidget");
+  auto mining_object_viewer =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.ObjectViewer", "MiningObjectViewerWidget");
   if (!mining_object_viewer.isValidHelper()) {
-    spdlog::warn("[MiningViewer] MiningObjectViewerWidget helper not found; mining ETA disabled");
-    return;
+    hooks.record_missing_helper(kMiningTimerHook);
+  } else {
+    auto update_timer_widget =
+        mining_object_viewer.GetMethod<void(MiningObjectViewerWidget*, FleetPlayerData*)>("UpdateTimerWidget", 1);
+    if (update_timer_widget == nullptr) {
+      hooks.record_missing_method(kMiningTimerHook);
+    } else {
+      HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kMiningTimerHook, update_timer_widget,
+                                       MiningObjectViewerWidget_UpdateTimerWidget_Hook);
+    }
   }
 
-  auto update_timer_widget = mining_object_viewer.GetMethod<void(MiningObjectViewerWidget*, FleetPlayerData*)>(
-      "UpdateTimerWidget", 1);
-  if (update_timer_widget == nullptr) {
-    spdlog::warn("[MiningViewer] MiningObjectViewerWidget.UpdateTimerWidget not found; mining ETA disabled");
-    return;
-  }
-
-  SPUD_STATIC_DETOUR(update_timer_widget, MiningObjectViewerWidget_UpdateTimerWidget_Hook);
+  hooks.log_summary();
 }

--- a/mods/src/patches/parts/fleet_arrival.cc
+++ b/mods/src/patches/parts/fleet_arrival.cc
@@ -30,11 +30,9 @@
 
 namespace
 {
-constexpr int              kNotificationProducerTypeIncomingFleet = 7;
-constexpr std::string_view kFleetArrivalOwner                     = "FleetArrivalHooks";
-constexpr std::string_view kFleetStateWidgetSeam                  = "Digit.Prime.HUD.FleetStateWidget.SetWidgetData";
-constexpr std::string_view kPlayerFleetsChangedSeam =
-    "Digit.PrimeServer.Events.FleetEvents.TriggerPlayerFleetsChangedEvent";
+constexpr int              kNotificationProducerTypeIncomingFleet    = 7;
+constexpr std::string_view kFleetArrivalOwner                        = "FleetArrivalHooks";
+constexpr std::string_view kFleetStateWidgetSeam                     = "Digit.Prime.HUD.FleetStateWidget.SetWidgetData";
 constexpr std::string_view kFleetRuntimeSyncEffect                   = "defer-fleet-runtime-snapshot";
 constexpr ptrdiff_t        kIncomingFleetParamsTargetTypeOffset      = 0x18;
 constexpr ptrdiff_t        kIncomingFleetParamsQuickScanResultOffset = 0x20;
@@ -44,14 +42,6 @@ constexpr ptrdiff_t        kIncomingFleetParamsObjectFleetIdOffset   = 0x10;
 constexpr ptrdiff_t        kQuickScanFleetDataFleetTypeOffset        = 0x18;
 constexpr ptrdiff_t        kQuickScanFleetDataTargetIdOffset         = 0x20;
 constexpr ptrdiff_t        kQuickScanFleetDataTargetFleetIdOffset    = 0x28;
-
-constexpr HookDescriptor kPlayerFleetsChangedHook = {
-    "FleetEvents.TriggerPlayerFleetsChangedEvent",
-    "observe player fleet-state changes without depending on Fleet Bar visibility",
-    {"Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Events", "FleetEvents", "TriggerPlayerFleetsChangedEvent"},
-    "fleet arrival notifications may be missed while full-screen UI is open",
-    HookSupportTier::Production,
-};
 
 constexpr HookDescriptor kFleetStateWidgetHook = {
     "FleetStateWidget.SetWidgetData",
@@ -140,18 +130,6 @@ void observe_fleet_state(FleetPlayerData* fleet, std::string_view seam, std::str
   }
 }
 
-void FleetEvents_TriggerPlayerFleetsChangedEvent_Hook(auto original, IList* changedFleets)
-{
-  original(changedFleets);
-
-  const auto changed_fleet_count = changedFleets ? changedFleets->Count : 0;
-  spdlog::debug("[FleetState] source=player-fleets-changed changedCount={}", changed_fleet_count);
-  for (int index = 0; changedFleets && index < changed_fleet_count; ++index) {
-    auto* fleet = reinterpret_cast<FleetPlayerData*>(changedFleets->Get(index));
-    observe_fleet_state(fleet, kPlayerFleetsChangedSeam, "player-fleets-changed");
-  }
-}
-
 void FleetStateWidget_SetWidgetData_Hook(auto original, void* self)
 {
   auto* fleet = fleet_bar_widget_context(self);
@@ -231,28 +209,6 @@ void InstallFleetArrivalHooks()
 {
   fleet_notifications_init();
   HookModuleHealth hooks("FleetArrivalHooks");
-
-  if (!fleet_notifications_runtime_events_enabled()) {
-    hooks.record_skipped(kPlayerFleetsChangedHook, "no enabled fleet-state notification deliveries");
-  } else {
-    auto fleet_events =
-        il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Events", "FleetEvents");
-    if (!fleet_events.isValidHelper()) {
-      fleet_events = il2cpp_get_class_helper("Assembly-CSharp", "Digit.PrimeServer.Events", "FleetEvents");
-    }
-
-    if (!fleet_events.isValidHelper()) {
-      hooks.record_missing_helper(kPlayerFleetsChangedHook);
-    } else {
-      auto trigger_player_fleets_changed = fleet_events.GetMethod("TriggerPlayerFleetsChangedEvent", 1);
-      if (trigger_player_fleets_changed == nullptr) {
-        hooks.record_missing_method(kPlayerFleetsChangedHook);
-      } else {
-        HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kPlayerFleetsChangedHook, trigger_player_fleets_changed,
-                                         FleetEvents_TriggerPlayerFleetsChangedEvent_Hook);
-      }
-    }
-  }
 
   auto fleet_state_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.HUD", "FleetStateWidget");
   if (!fleet_state_widget.isValidHelper()) {

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -14,6 +14,7 @@
 #include "file.h"
 #include "patches/action_queue_guard_policy.h"
 #include "patches/deployment_runtime_observers.h"
+#include "patches/fleet_notifications.h"
 #include "patches/fleet_runtime_sync.h"
 #include "patches/notification_service.h"
 #include "patches/patch_install_policy.h"
@@ -264,6 +265,7 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
   install_frame_tick_hooks = install_frame_tick_hooks || LiveDebugChannelEnabled();
 #endif
   install_frame_tick_hooks   = install_frame_tick_hooks || fleet_runtime_sync_frame_subscriber_enabled();
+  install_frame_tick_hooks   = install_frame_tick_hooks || fleet_notifications_runtime_events_enabled();
   const PatchEntry patches[] = {
       {"UiScaleHooks", "patches.uiscalehooks", "", "", InstallUiScaleHooks, cfg.installUiScaleHooks, false, true},
       {"ZoomHooks", "patches.zoomhooks", "", "ZoomPlanetViewHooks", InstallZoomHooks, cfg.installZoomHooks, false,
@@ -274,8 +276,8 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
       {"PanHooks", "patches.panhooks", "", "", InstallPanHooks, cfg.installPanHooks, false, true},
       {"ImproveResponsivenessHooks", "patches.improveresponsivenesshooks", "", "", InstallImproveResponsivenessHooks,
        cfg.installImproveResponsivenessHooks, false, true},
-      {"FrameTickHooks", "", "hotkeys|live-debug|fleet-runtime-sync", "FrameTickHooks", InstallFrameTickHooks, false,
-       install_frame_tick_hooks, true},
+      {"FrameTickHooks", "", "hotkeys|live-debug|fleet-notifications|fleet-runtime-sync", "FrameTickHooks",
+       InstallFrameTickHooks, false, install_frame_tick_hooks, true},
       {"HotkeyHooks", "patches.hotkeyhooks", "", "HotkeyHooks", InstallHotkeyHooks, cfg.installHotkeyHooks, false,
        true},
       {"OpenBulkClaimGiftsHooks", "ui.auto_open_bulk_claim_flyout", "", "OpenBulkClaimGiftsHooks",

--- a/tests/src/test_fleet_notification_scan_policy.cc
+++ b/tests/src/test_fleet_notification_scan_policy.cc
@@ -9,16 +9,16 @@ TEST_SUITE("fleet_notification_scan_policy")
     FleetNotificationScanPolicy policy;
 
     CHECK_FALSE(policy.ScanRequested());
-    CHECK_FALSE(policy.ShouldScan(1'000));
+    CHECK(policy.Evaluate(1'000) == FleetNotificationScanDecision::Idle);
 
     policy.RequestScan();
 
     CHECK(policy.ScanRequested());
-    CHECK(policy.ShouldScan(1'000));
-    CHECK_FALSE(policy.ShouldScan(1'249));
-    CHECK(policy.ShouldScan(1'250));
-    CHECK_FALSE(policy.ShouldScan(1'499));
-    CHECK(policy.ShouldScan(1'500));
+    CHECK(policy.Evaluate(1'000) == FleetNotificationScanDecision::Scan);
+    CHECK(policy.Evaluate(1'249) == FleetNotificationScanDecision::Wait);
+    CHECK(policy.Evaluate(1'250) == FleetNotificationScanDecision::Scan);
+    CHECK(policy.Evaluate(1'499) == FleetNotificationScanDecision::Wait);
+    CHECK(policy.Evaluate(1'500) == FleetNotificationScanDecision::Scan);
   }
 
   TEST_CASE("recovers if the supplied monotonic clock moves backwards")
@@ -26,24 +26,62 @@ TEST_SUITE("fleet_notification_scan_policy")
     FleetNotificationScanPolicy policy;
     policy.RequestScan();
 
-    CHECK(policy.ShouldScan(5'000));
-    CHECK(policy.ShouldScan(4'000));
-    CHECK_FALSE(policy.ShouldScan(4'249));
-    CHECK(policy.ShouldScan(4'250));
+    CHECK(policy.Evaluate(5'000) == FleetNotificationScanDecision::Scan);
+    CHECK(policy.Evaluate(4'000) == FleetNotificationScanDecision::Scan);
+    CHECK(policy.Evaluate(4'249) == FleetNotificationScanDecision::Wait);
+    CHECK(policy.Evaluate(4'250) == FleetNotificationScanDecision::Scan);
   }
 
-  TEST_CASE("suspends after runtime access failure until rearmed")
+  TEST_CASE("backs off long-lived transitional scans")
   {
     FleetNotificationScanPolicy policy;
     policy.RequestScan();
-    REQUIRE(policy.ShouldScan(10'000));
+    REQUIRE(policy.Evaluate(10'000) == FleetNotificationScanDecision::Scan);
 
-    policy.Suspend();
+    CHECK(policy.Evaluate(10'000 + kFleetNotificationScanBackoffAfterMs) == FleetNotificationScanDecision::Scan);
+    CHECK(policy.Evaluate(10'000 + kFleetNotificationScanBackoffAfterMs + 4'999)
+          == FleetNotificationScanDecision::Wait);
+    CHECK(policy.Evaluate(10'000 + kFleetNotificationScanBackoffAfterMs + 5'000)
+          == FleetNotificationScanDecision::Scan);
+  }
 
+  TEST_CASE("suspends after repeated zero-fleet observations until rearmed")
+  {
+    FleetNotificationScanPolicy policy;
+    policy.RequestScan();
+    REQUIRE(policy.Evaluate(10'000) == FleetNotificationScanDecision::Scan);
+
+    for (int index = 1; index < kFleetNotificationScanMaxConsecutiveEmpty; ++index) {
+      CHECK(policy.RecordObservation(0, 0) == FleetNotificationScanObservation::Continue);
+    }
+    CHECK(policy.RecordObservation(0, 0) == FleetNotificationScanObservation::NoFleets);
     CHECK_FALSE(policy.ScanRequested());
-    CHECK_FALSE(policy.ShouldScan(10'250));
+    CHECK(policy.Evaluate(10'250) == FleetNotificationScanDecision::Idle);
 
     policy.RequestScan();
-    CHECK(policy.ShouldScan(10'250));
+    CHECK(policy.Evaluate(10'250) == FleetNotificationScanDecision::Scan);
+  }
+
+  TEST_CASE("settles when observed fleets no longer require follow-through")
+  {
+    FleetNotificationScanPolicy policy;
+    policy.RequestScan();
+    REQUIRE(policy.Evaluate(10'000) == FleetNotificationScanDecision::Scan);
+
+    CHECK(policy.RecordObservation(7, 1) == FleetNotificationScanObservation::Continue);
+    CHECK(policy.RecordObservation(7, 0) == FleetNotificationScanObservation::Settled);
+    CHECK_FALSE(policy.ScanRequested());
+  }
+
+  TEST_CASE("expires a scan request after the hard lifetime")
+  {
+    FleetNotificationScanPolicy policy;
+    policy.RequestScan();
+    REQUIRE(policy.Evaluate(10'000) == FleetNotificationScanDecision::Scan);
+
+    CHECK(policy.Evaluate(10'000 + kFleetNotificationScanMaxLifetimeMs) == FleetNotificationScanDecision::Expired);
+
+    CHECK_FALSE(policy.ScanRequested());
+    CHECK(policy.Evaluate(10'000 + kFleetNotificationScanMaxLifetimeMs + 250) == FleetNotificationScanDecision::Idle);
   }
 }

--- a/tests/src/test_fleet_notification_scan_policy.cc
+++ b/tests/src/test_fleet_notification_scan_policy.cc
@@ -1,0 +1,49 @@
+#include <doctest/doctest.h>
+
+#include "patches/fleet_notification_scan_policy.h"
+
+TEST_SUITE("fleet_notification_scan_policy")
+{
+  TEST_CASE("waits for a bounded follow-through request before scanning")
+  {
+    FleetNotificationScanPolicy policy;
+
+    CHECK_FALSE(policy.ScanRequested());
+    CHECK_FALSE(policy.ShouldScan(1'000));
+
+    policy.RequestScan();
+
+    CHECK(policy.ScanRequested());
+    CHECK(policy.ShouldScan(1'000));
+    CHECK_FALSE(policy.ShouldScan(1'249));
+    CHECK(policy.ShouldScan(1'250));
+    CHECK_FALSE(policy.ShouldScan(1'499));
+    CHECK(policy.ShouldScan(1'500));
+  }
+
+  TEST_CASE("recovers if the supplied monotonic clock moves backwards")
+  {
+    FleetNotificationScanPolicy policy;
+    policy.RequestScan();
+
+    CHECK(policy.ShouldScan(5'000));
+    CHECK(policy.ShouldScan(4'000));
+    CHECK_FALSE(policy.ShouldScan(4'249));
+    CHECK(policy.ShouldScan(4'250));
+  }
+
+  TEST_CASE("suspends after runtime access failure until rearmed")
+  {
+    FleetNotificationScanPolicy policy;
+    policy.RequestScan();
+    REQUIRE(policy.ShouldScan(10'000));
+
+    policy.Suspend();
+
+    CHECK_FALSE(policy.ScanRequested());
+    CHECK_FALSE(policy.ShouldScan(10'250));
+
+    policy.RequestScan();
+    CHECK(policy.ShouldScan(10'250));
+  }
+}

--- a/tests/src/test_native_source_safety.cc
+++ b/tests/src/test_native_source_safety.cc
@@ -86,8 +86,8 @@ TEST_CASE("fleet runtime sync requests require gameplay dispatch provenance")
 TEST_CASE("fleet notifications use one targeted runtime owner and keep broad deployment observers dormant")
 {
   const auto fleet_arrival_source = read_text_file("mods/src/patches/parts/fleet_arrival.cc");
-  CHECK(contains(fleet_arrival_source, "FleetEvents.TriggerPlayerFleetsChangedEvent"));
-  CHECK(contains(fleet_arrival_source, "FleetEvents_TriggerPlayerFleetsChangedEvent_Hook"));
+  CHECK_FALSE(contains(fleet_arrival_source, "FleetEvents.TriggerPlayerFleetsChangedEvent"));
+  CHECK_FALSE(contains(fleet_arrival_source, "FleetEvents_TriggerPlayerFleetsChangedEvent_Hook"));
   CHECK(contains(fleet_arrival_source, "HOOK_REGISTRY_SPUD_STATIC_DETOUR"));
   CHECK(contains(fleet_arrival_source, "fleet_notifications_observe_fleet_state"));
 
@@ -104,8 +104,9 @@ TEST_CASE("fleet notifications use one targeted runtime owner and keep broad dep
 
   const auto fleet_notifications_source = read_text_file("mods/src/patches/fleet_notifications.cc");
   CHECK(contains(fleet_notifications_source, "status=scan-requested"));
-  CHECK(contains(fleet_notifications_source, "result.follow_through_count == 0"));
-  CHECK(contains(fleet_notifications_source, "s_runtime_scan_policy.Suspend()"));
+  CHECK(contains(fleet_notifications_source, "FleetNotificationScanObservation::Settled"));
+  CHECK(contains(fleet_notifications_source, "reason=no-fleets"));
+  CHECK(contains(fleet_notifications_source, "reason=max-lifetime"));
 }
 
 TEST_CASE("sidecar local enqueue requires copied payload provenance")

--- a/tests/src/test_native_source_safety.cc
+++ b/tests/src/test_native_source_safety.cc
@@ -8,46 +8,46 @@
 
 namespace
 {
-  std::filesystem::path find_repo_file(const std::string_view relative_path)
-  {
-    auto current = std::filesystem::current_path();
-    while (!current.empty()) {
-      const auto candidate = current / std::filesystem::path(relative_path);
-      if (std::filesystem::exists(candidate)) {
-        return candidate;
-      }
-
-      if (!current.has_parent_path()) {
-        break;
-      }
-
-      const auto parent = current.parent_path();
-      if (parent == current) {
-        break;
-      }
-
-      current = parent;
+std::filesystem::path find_repo_file(const std::string_view relative_path)
+{
+  auto current = std::filesystem::current_path();
+  while (!current.empty()) {
+    const auto candidate = current / std::filesystem::path(relative_path);
+    if (std::filesystem::exists(candidate)) {
+      return candidate;
     }
 
-    return {};
+    if (!current.has_parent_path()) {
+      break;
+    }
+
+    const auto parent = current.parent_path();
+    if (parent == current) {
+      break;
+    }
+
+    current = parent;
   }
 
-  std::string read_text_file(const std::string_view relative_path)
-  {
-    const auto path = find_repo_file(relative_path);
-    REQUIRE_MESSAGE(!path.empty(), "Failed to find " << std::string(relative_path));
-
-    std::ifstream input(path, std::ios::binary);
-    REQUIRE_MESSAGE(input.good(), "Failed to open " << path.string());
-
-    std::ostringstream buffer;
-    buffer << input.rdbuf();
-    return buffer.str();
-  }
-
-  bool contains(const std::string& text, const std::string_view needle)
-  { return text.find(needle) != std::string::npos; }
+  return {};
 }
+
+std::string read_text_file(const std::string_view relative_path)
+{
+  const auto path = find_repo_file(relative_path);
+  REQUIRE_MESSAGE(!path.empty(), "Failed to find " << std::string(relative_path));
+
+  std::ifstream input(path, std::ios::binary);
+  REQUIRE_MESSAGE(input.good(), "Failed to open " << path.string());
+
+  std::ostringstream buffer;
+  buffer << input.rdbuf();
+  return buffer.str();
+}
+
+bool contains(const std::string& text, const std::string_view needle)
+{ return text.find(needle) != std::string::npos; }
+} // namespace
 
 TEST_CASE("generated native shortcut pointer callback guard family stays quarantined")
 {
@@ -63,7 +63,7 @@ TEST_CASE("generated native shortcut pointer callback guard family stays quarant
       || contains(hotkeys_source, "native_shortcut_pointer_callback_guard_reason")
       || contains(hotkeys_source, "hotkey_router_should_suppress_native_shortcut_callback");
 
-    CHECK_FALSE(has_generated_callback_guard_install);
+  CHECK_FALSE(has_generated_callback_guard_install);
 }
 
 TEST_CASE("fleet runtime sync requests require gameplay dispatch provenance")
@@ -81,6 +81,21 @@ TEST_CASE("fleet runtime sync requests require gameplay dispatch provenance")
 
   const auto live_debug_source = read_text_file("mods/src/patches/parts/live_debug.cc");
   CHECK_FALSE(contains(live_debug_source, "fleet_runtime_sync_trigger(\""));
+}
+
+TEST_CASE("fleet notifications use one targeted runtime owner and keep broad deployment observers dormant")
+{
+  const auto fleet_arrival_source = read_text_file("mods/src/patches/parts/fleet_arrival.cc");
+  CHECK(contains(fleet_arrival_source, "FleetEvents.TriggerPlayerFleetsChangedEvent"));
+  CHECK(contains(fleet_arrival_source, "FleetEvents_TriggerPlayerFleetsChangedEvent_Hook"));
+  CHECK(contains(fleet_arrival_source, "HOOK_REGISTRY_SPUD_STATIC_DETOUR"));
+  CHECK(contains(fleet_arrival_source, "fleet_notifications_observe_fleet_state"));
+
+  const auto deployment_observer_source = read_text_file("mods/src/patches/parts/deployment_runtime_observers.cc");
+  CHECK_FALSE(contains(deployment_observer_source, "fleet_notifications_observe_runtime_fleets"));
+
+  const auto patch_source = read_text_file("mods/src/patches/patches.cc");
+  CHECK(contains(patch_source, "install_deployment_runtime_observers = false"));
 }
 
 TEST_CASE("sidecar local enqueue requires copied payload provenance")

--- a/tests/src/test_native_source_safety.cc
+++ b/tests/src/test_native_source_safety.cc
@@ -96,6 +96,16 @@ TEST_CASE("fleet notifications use one targeted runtime owner and keep broad dep
 
   const auto patch_source = read_text_file("mods/src/patches/patches.cc");
   CHECK(contains(patch_source, "install_deployment_runtime_observers = false"));
+  CHECK(contains(patch_source, "fleet_notifications_runtime_events_enabled()"));
+
+  const auto frame_tick_source = read_text_file("mods/src/patches/frame_tick.cc");
+  CHECK(contains(frame_tick_source, "fleet_notifications_tick()"));
+  CHECK(contains(frame_tick_source, "subscriber=fleet_notifications"));
+
+  const auto fleet_notifications_source = read_text_file("mods/src/patches/fleet_notifications.cc");
+  CHECK(contains(fleet_notifications_source, "status=scan-requested"));
+  CHECK(contains(fleet_notifications_source, "result.follow_through_count == 0"));
+  CHECK(contains(fleet_notifications_source, "s_runtime_scan_policy.Suspend()"));
 }
 
 TEST_CASE("sidecar local enqueue requires copied payload provenance")

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -16,6 +16,7 @@ do
     add_files("../mods/src/config_schema.cc")
     add_files("../mods/src/diagnostics_file_policy.cc")
     add_files("../mods/src/patches/action_queue_repair_config.cc")
+    add_files("../mods/src/patches/fleet_notification_scan_policy.cc")
     add_files("../mods/src/patches/live_debug_event_store.cc")
     add_files("../mods/src/patches/live_debug_recent_event_requests.cc")
     add_files("../mods/src/patches/live_debug_fleet_serializers.cc")


### PR DESCRIPTION
Closes #184.

## What changed

- Make fleet-arrival notifications independent of Fleet Bar visibility by following active fleet transitions through the existing shared frame tick.
- Keep widget observation as the primary trigger; only an observed transitional fleet requests bounded follow-through.
- Scan every 250 ms for the first 30 seconds, then back off to 5 seconds.
- Suspend after eight consecutive zero-fleet observations and enforce a 24-hour hard maximum for genuinely long-lived repair/tier-up states.
- Remove the unused `FleetEvents.TriggerPlayerFleetsChangedEvent` detour after runtime evidence showed zero observations.
- Gate unsupported-platform behavior explicitly and retain existing notification deduplication.

## Why

Fleet-bar-derived arrival detection stopped observing transitions while modal screens hid the Fleet Bar. The delivery path itself was healthy; the observation layer needed a bounded continuation after a real transition was seen.

## Runtime impact

This is not an always-on fleet poll. A widget-observed transitional fleet activates follow-through, the scanner returns to idle when fleets stabilize, zero-fleet snapshots suspend quickly, long-lived repair/tier-up states use the backed-off cadence, and a hard lifetime prevents an immortal scan.

## Validation

- AXF pure tests passed through the stacked validation runs.
- Windows releasedbg build passed and was deployed.
- In-game system-arrival audio and WinRT notifications succeeded with the Faction window open, Refinery window open, and Claims window open.
- Runtime trace confirmed `scan-requested` → `active`, deliveries, and return to `idle`.
- Required macOS CI supplies compile/package coverage after the branch is restacked on `main`.