### PR TITLE
Run required PR builds after branch updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,8 @@
 # @file ci.yaml
 # @brief CI build workflow — compiles the community patch on Windows and macOS.
 #
-# Triggers automatically for main branch updates and for PRs only when they
-# are opened/reopened as reviewable or moved out of draft. Builds release
+# Triggers automatically for main branch updates and for reviewable PRs when
+# they are opened, updated, reopened, or moved out of draft. Builds release
 # artifacts for both platforms using xmake, creates a universal macOS app
 # bundle (arm64 + x86_64 via lipo), ad-hoc signs it, and packages a .dmg
 # installer. Uploads version.dll (Windows) and the .dmg (macOS) as build
@@ -18,7 +18,7 @@ on:
       - "v*"
   pull_request:
     branches: ["main", "dev"]
-    types: [opened, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What changed

- Add `synchronize` to the Build workflow's pull-request activity types.
- Update the workflow header comment to describe branch-update builds.

## Why

Protected `main` requires `build-win` and `build-mac`, but updated PR heads were not receiving those contexts. Manual workflow runs do not satisfy the PR-required checks, which blocked the release stack after restacking.

Draft PR jobs remain gated by the existing job condition, while `ready_for_review`, `reopened`, and newly pushed reviewable heads continue to run.

Closes #192.

## Validation

- `git diff --check`
- Manual workflow inspection against the existing draft job conditions
- This PR's `ready_for_review` event will verify the unchanged draft gating and required Windows/macOS contexts.