### PR TITLE
fix(axf): disclose dirty cycle source state

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,20 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
+  provider-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Test AXF provider contracts
+        run: node --test scripts/axf/*.test.mjs
+
   build-win:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-2025-vs2026

--- a/scripts/axf/README.md
+++ b/scripts/axf/README.md
@@ -97,6 +97,21 @@ then calls the private dispatcher at `/mnt/d/dev/stfc-mod/.ax-priv/ax.ps1`
 through the tracked `.ax/ax.ps1` facade. The existing Windows worktree at
 `/mnt/d/dev/stfc-mod` is not used as the build root.
 
+Successful build/deploy/cycle receipts include `sourceProvenance`. The provider
+uses one Git tracked-plus-untracked-nonignored NUL-delimited manifest for both
+source identity and Windows synchronization. It materializes that manifest in a
+fresh mirror with a new Git checkout, verifies the staged fingerprint, and
+fails if the source changes during synchronization. Ignored/private files are
+neither synchronized nor disclosed, and dirty initialized submodules fail
+closed.
+
+Clean receipts identify a reproducible commit. Dirty receipts distinguish the
+HEAD base commit from a deterministic `sourceStateId`, include a
+privacy-bounded ordered path summary with truncation metadata, and retain the
+private dispatcher’s distinct build/deployed artifact hashes. Legacy
+dispatcher commit fields must agree with the canonical base commit. Diffs and
+source bodies are never returned.
+
 The dump query commands currently run the existing Python dump tools from
 `/mnt/d/dev/stfc-mod/.ax-priv` and use that reference cache. The pure decoder
 validation path is native to `/srv/stfc-mod`.

--- a/scripts/axf/source-provenance.mjs
+++ b/scripts/axf/source-provenance.mjs
@@ -1,0 +1,378 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  realpathSync
+} from "node:fs";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep
+} from "node:path";
+
+export const SOURCE_PROVENANCE_VERSION = 1;
+export const DEFAULT_CHANGED_PATH_LIMIT = 64;
+
+function stableCompare(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function normalizeGitPath(value) {
+  return String(value).split(sep).join("/").replaceAll("\\", "/").replace(/^\.\/+/, "");
+}
+
+function git(repoRoot, args, { allowFailure = false } = {}) {
+  const result = spawnSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024
+  });
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(
+      `git ${args.join(" ")} failed: ${String(result.stderr || result.error || "unknown error").trim()}`
+    );
+  }
+  return result.status === 0 ? result.stdout : null;
+}
+
+function parsePorcelain(output) {
+  const records = String(output ?? "").split("\0");
+  const entries = [];
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+    const status = record.slice(0, 2);
+    const path = normalizeGitPath(record.slice(3));
+    const entry = { status, path };
+    if (/[RC]/.test(status)) {
+      const originalPath = records[index + 1];
+      if (originalPath) {
+        entry.originalPath = normalizeGitPath(originalPath);
+        index += 1;
+      }
+    }
+    entries.push(entry);
+  }
+
+  return entries.sort((left, right) =>
+    stableCompare(
+      `${left.path}\0${left.status}\0${left.originalPath ?? ""}`,
+      `${right.path}\0${right.status}\0${right.originalPath ?? ""}`
+    )
+  );
+}
+
+function hashText(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function repositoryRelativePath(repoRoot, candidate) {
+  const target = resolve(repoRoot, candidate);
+  const relativeTarget = relative(resolve(repoRoot), target);
+  if (
+    relativeTarget === ".." ||
+    relativeTarget.startsWith(`..${sep}`) ||
+    isAbsolute(relativeTarget)
+  ) {
+    throw new Error(`Source manifest path escapes the repository: ${candidate}`);
+  }
+  return target;
+}
+
+function pathContains(parent, child) {
+  const childRelative = relative(resolve(parent), resolve(child));
+  return (
+    childRelative === "" ||
+    (!childRelative.startsWith(`..${sep}`) &&
+      childRelative !== ".." &&
+      !isAbsolute(childRelative))
+  );
+}
+
+export function resolvePhysicalCandidate(candidate) {
+  let existing = resolve(candidate);
+  const suffix = [];
+  while (!existsSync(existing)) {
+    const parent = dirname(existing);
+    if (parent === existing) {
+      throw new Error(`No existing ancestor for path: ${candidate}`);
+    }
+    suffix.unshift(basename(existing));
+    existing = parent;
+  }
+  return resolve(realpathSync(existing), ...suffix);
+}
+
+export function assertIsolatedMirrorRoot(candidate, protectedRoots) {
+  const physicalCandidate = resolvePhysicalCandidate(candidate);
+  if (physicalCandidate === dirname(physicalCandidate)) {
+    throw new Error(`Unsafe mirror root: ${physicalCandidate}`);
+  }
+  for (const protectedRoot of protectedRoots) {
+    const physicalProtected = resolvePhysicalCandidate(protectedRoot);
+    if (
+      pathContains(physicalCandidate, physicalProtected) ||
+      pathContains(physicalProtected, physicalCandidate)
+    ) {
+      throw new Error(
+        `Mirror root overlaps a protected path: ${physicalCandidate}`
+      );
+    }
+  }
+  return physicalCandidate;
+}
+
+function submoduleGitlinks(repoRoot) {
+  const links = new Map();
+  for (const record of git(repoRoot, ["ls-files", "--stage", "-z"]).split("\0")) {
+    if (!record) continue;
+    const match = record.match(/^160000 ([a-f0-9]{40,64}) \d+\t(.+)$/s);
+    if (match) {
+      links.set(normalizeGitPath(match[2]), match[1]);
+    }
+  }
+  return links;
+}
+
+function assertNoHiddenIndexEntries(repoRoot, prefix = "") {
+  for (const record of git(
+    repoRoot,
+    ["ls-files", "-v", "-z", "--cached"]
+  ).split("\0")) {
+    if (!record) continue;
+    const tag = record.slice(0, 1);
+    if (tag === "S" || /^[a-z]$/.test(tag)) {
+      const path = normalizeGitPath(record.slice(2));
+      throw new Error(
+        `Tracked source uses assume-unchanged or skip-worktree: ${normalizeGitPath(`${prefix}${path}`)}`
+      );
+    }
+  }
+}
+
+function listRepositoryFiles(repoRoot, prefix = "") {
+  assertNoHiddenIndexEntries(repoRoot, prefix);
+  const links = submoduleGitlinks(repoRoot);
+  const files = [];
+  const listed = git(repoRoot, [
+    "ls-files",
+    "-z",
+    "--cached",
+    "--others",
+    "--exclude-standard"
+  ]).split("\0");
+
+  for (const rawPath of listed) {
+    if (!rawPath) continue;
+    const path = normalizeGitPath(rawPath);
+    const submoduleCommit = links.get(path);
+    if (submoduleCommit) {
+      const submoduleRoot = repositoryRelativePath(repoRoot, path);
+      if (!existsSync(join(submoduleRoot, ".git"))) {
+        continue;
+      }
+      const actualCommit = git(submoduleRoot, ["rev-parse", "HEAD"]).trim();
+      const dirty = git(submoduleRoot, [
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--untracked-files=all",
+        "--ignored=no"
+      ]);
+      if (actualCommit !== submoduleCommit || dirty) {
+        throw new Error(
+          `Dirty or mismatched submodule source is not supported: ${normalizeGitPath(`${prefix}${path}`)}`
+        );
+      }
+      files.push(
+        ...listRepositoryFiles(
+          submoduleRoot,
+          normalizeGitPath(`${prefix}${path}/`)
+        )
+      );
+      continue;
+    }
+
+    const target = repositoryRelativePath(repoRoot, path);
+    try {
+      const stat = lstatSync(target);
+      if (stat.isFile() || stat.isSymbolicLink()) {
+        files.push(normalizeGitPath(`${prefix}${path}`));
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+
+  return files;
+}
+
+function manifestEvidence(repoRoot, path) {
+  const target = repositoryRelativePath(repoRoot, path);
+  const stat = lstatSync(target);
+  if (stat.isSymbolicLink()) {
+    return {
+      path,
+      kind: "symlink",
+      digest: hashText(readlinkSync(target))
+    };
+  }
+  if (stat.isFile()) {
+    return {
+      path,
+      kind: "file",
+      digest: createHash("sha256").update(readFileSync(target)).digest("hex")
+    };
+  }
+  throw new Error(`Unsupported source manifest entry: ${path}`);
+}
+
+function createManifest(repoRoot) {
+  const paths = [...new Set(listRepositoryFiles(repoRoot))].sort(stableCompare);
+  const windowsKeys = new Map();
+  for (const path of paths) {
+    const key = path.normalize("NFC").toLowerCase();
+    const existing = windowsKeys.get(key);
+    if (existing && existing !== path) {
+      throw new Error(
+        `Source paths collide on Windows: ${existing} and ${path}`
+      );
+    }
+    windowsKeys.set(key, path);
+  }
+  const evidence = paths.map((path) => manifestEvidence(repoRoot, path));
+  return {
+    paths,
+    fingerprint: `sha256:${hashText(JSON.stringify(evidence))}`
+  };
+}
+
+export function fingerprintSourcePaths(repoRoot, paths) {
+  const normalizedPaths = [...paths].map(normalizeGitPath).sort(stableCompare);
+  const evidence = normalizedPaths.map((path) =>
+    manifestEvidence(repoRoot, path)
+  );
+  return `sha256:${hashText(JSON.stringify(evidence))}`;
+}
+
+function collectStableSourceState(repoRoot) {
+  const normalizedRoot = resolve(repoRoot);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const baseCommit = git(normalizedRoot, ["rev-parse", "HEAD"]).trim();
+    const status = git(normalizedRoot, [
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+      "--ignored=no"
+    ]);
+    const manifest = createManifest(normalizedRoot);
+    const baseAfter = git(normalizedRoot, ["rev-parse", "HEAD"]).trim();
+    const statusAfter = git(normalizedRoot, [
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+      "--ignored=no"
+    ]);
+    if (baseCommit === baseAfter && status === statusAfter) {
+      return {
+        baseCommit,
+        status,
+        entries: parsePorcelain(status),
+        manifest
+      };
+    }
+  }
+  throw new Error("Repository source changed while provenance was collected.");
+}
+
+/**
+ * Describe one stable, canonical source snapshot and return the exact file
+ * manifest that must be used to materialize it.
+ */
+export function collectSourceSnapshot(
+  repoRoot,
+  { pathLimit = DEFAULT_CHANGED_PATH_LIMIT } = {}
+) {
+  if (!Number.isInteger(pathLimit) || pathLimit < 0) {
+    throw new Error("pathLimit must be a non-negative integer");
+  }
+
+  const state = collectStableSourceState(repoRoot);
+  const worktreeDirty = state.entries.length > 0;
+  const fingerprint = worktreeDirty
+    ? hashText(
+        JSON.stringify({
+          schemaVersion: SOURCE_PROVENANCE_VERSION,
+          baseCommit: state.baseCommit,
+          sourceManifestFingerprint: state.manifest.fingerprint
+        })
+      )
+    : null;
+
+  return {
+    provenance: {
+      schemaVersion: SOURCE_PROVENANCE_VERSION,
+      sourceStateKind: worktreeDirty ? "dirty-worktree" : "clean-commit",
+      worktreeDirty,
+      baseCommit: state.baseCommit,
+      baseCommitDescription: worktreeDirty
+        ? "HEAD is the base commit; sourceStateId also includes the synchronized working-tree state."
+        : "HEAD identifies this clean source state.",
+      sourceStateId: worktreeDirty
+        ? `dirty-sha256:${fingerprint}`
+        : `git:${state.baseCommit}`,
+      worktreeFingerprint: fingerprint ? `sha256:${fingerprint}` : null,
+      sourceManifestFingerprint: state.manifest.fingerprint,
+      sourceFileCount: state.manifest.paths.length,
+      changedPathCount: state.entries.length,
+      changedPaths: state.entries.slice(0, pathLimit),
+      changedPathsTruncated: state.entries.length > pathLimit,
+      changedPathLimit: pathLimit,
+      ignoredPathsIncluded: false
+    },
+    manifest: state.manifest
+  };
+}
+
+export function collectSourceProvenance(repoRoot, options = {}) {
+  return collectSourceSnapshot(repoRoot, options).provenance;
+}
+
+export function normalizeSourceReceipt(parsed, sourceProvenance) {
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed)
+  ) {
+    throw new Error("Windows dispatcher did not return an object receipt.");
+  }
+  const canonicalBase = sourceProvenance.baseCommit.toLowerCase();
+  for (const field of ["baseCommit", "commit"]) {
+    if (!(field in parsed)) continue;
+    const value = parsed[field];
+    if (
+      typeof value !== "string" ||
+      !/^[a-f0-9]{7,64}$/i.test(value) ||
+      !canonicalBase.startsWith(value.toLowerCase())
+    ) {
+      throw new Error(
+        `Windows dispatcher ${field} conflicts with canonical base commit.`
+      );
+    }
+  }
+  return {
+    ...parsed,
+    baseCommit: sourceProvenance.baseCommit,
+    ...("commit" in parsed ? { commit: sourceProvenance.baseCommit } : {}),
+    sourceProvenance
+  };
+}

--- a/scripts/axf/source-provenance.test.mjs
+++ b/scripts/axf/source-provenance.test.mjs
@@ -1,0 +1,351 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  assertIsolatedMirrorRoot,
+  collectSourceProvenance,
+  collectSourceSnapshot,
+  fingerprintSourcePaths,
+  normalizeGitPath,
+  normalizeSourceReceipt
+} from "./source-provenance.mjs";
+
+const roots = [];
+
+function run(repoRoot, args) {
+  const result = spawnSync("git", ["-C", repoRoot, ...args], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "stfc-source-provenance-"));
+  roots.push(root);
+  run(root, ["init", "-q"]);
+  run(root, ["config", "user.name", "STFC Test"]);
+  run(root, ["config", "user.email", "stfc-test@example.invalid"]);
+  run(root, ["config", "commit.gpgsign", "false"]);
+  writeFileSync(join(root, ".gitignore"), "ignored/\n");
+  writeFileSync(join(root, "tracked.cpp"), "int value = 1;\n");
+  run(root, ["add", "."]);
+  run(root, ["commit", "-qm", "fixture"]);
+  return root;
+}
+
+test.afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("clean source identifies a reproducible commit", () => {
+  const root = fixture();
+  const provenance = collectSourceProvenance(root);
+
+  assert.equal(provenance.worktreeDirty, false);
+  assert.equal(provenance.sourceStateKind, "clean-commit");
+  assert.equal(provenance.sourceStateId, `git:${provenance.baseCommit}`);
+  assert.equal(provenance.worktreeFingerprint, null);
+  assert.deepEqual(provenance.changedPaths, []);
+});
+
+test("modified source cannot be mistaken for clean HEAD", () => {
+  const root = fixture();
+  writeFileSync(join(root, "tracked.cpp"), "int value = 2;\n");
+  const provenance = collectSourceProvenance(root);
+
+  assert.equal(provenance.worktreeDirty, true);
+  assert.equal(provenance.sourceStateKind, "dirty-worktree");
+  assert.match(provenance.sourceStateId, /^dirty-sha256:[a-f0-9]{64}$/);
+  assert.match(provenance.worktreeFingerprint, /^sha256:[a-f0-9]{64}$/);
+  assert.deepEqual(provenance.changedPaths, [{ status: " M", path: "tracked.cpp" }]);
+  assert.match(provenance.baseCommitDescription, /base commit/);
+});
+
+test("source-state identity changes when dirty file content changes", () => {
+  const root = fixture();
+  writeFileSync(join(root, "tracked.cpp"), "int value = 2;\n");
+  const first = collectSourceProvenance(root).sourceStateId;
+  writeFileSync(join(root, "tracked.cpp"), "int value = 3;\n");
+  const second = collectSourceProvenance(root).sourceStateId;
+
+  assert.notEqual(first, second);
+});
+
+test("staged changes retain index status evidence", () => {
+  const root = fixture();
+  writeFileSync(join(root, "tracked.cpp"), "int staged = 1;\n");
+  run(root, ["add", "tracked.cpp"]);
+
+  assert.deepEqual(collectSourceProvenance(root).changedPaths, [
+    { status: "M ", path: "tracked.cpp" }
+  ]);
+});
+
+test("untracked files contribute path and content identity", () => {
+  const root = fixture();
+  writeFileSync(join(root, "new.cpp"), "int new_value = 1;\n");
+  const first = collectSourceProvenance(root);
+  writeFileSync(join(root, "new.cpp"), "int new_value = 2;\n");
+  const second = collectSourceProvenance(root);
+
+  assert.deepEqual(first.changedPaths, [{ status: "??", path: "new.cpp" }]);
+  assert.notEqual(first.sourceStateId, second.sourceStateId);
+});
+
+test("ignored private artifacts are neither disclosed nor fingerprinted", () => {
+  const root = fixture();
+  mkdirSync(join(root, "ignored"));
+  writeFileSync(join(root, "ignored", "secret.txt"), "private-one");
+  const firstSnapshot = collectSourceSnapshot(root);
+  const first = firstSnapshot.provenance;
+  writeFileSync(join(root, "ignored", "secret.txt"), "private-two");
+  const secondSnapshot = collectSourceSnapshot(root);
+  const second = secondSnapshot.provenance;
+
+  assert.equal(first.worktreeDirty, false);
+  assert.deepEqual(second, first);
+  assert.deepEqual(secondSnapshot.manifest, firstSnapshot.manifest);
+  assert.equal(
+    firstSnapshot.manifest.paths.includes("ignored/secret.txt"),
+    false
+  );
+  assert.equal(JSON.stringify(first).includes("secret"), false);
+});
+
+test("changed path evidence is ordered, bounded, and reports truncation", () => {
+  const root = fixture();
+  for (const name of ["z.cpp", "a.cpp", "m.cpp"]) {
+    writeFileSync(join(root, name), name);
+  }
+
+  const provenance = collectSourceProvenance(root, { pathLimit: 2 });
+  assert.equal(provenance.changedPathCount, 3);
+  assert.deepEqual(
+    provenance.changedPaths.map((entry) => entry.path),
+    ["a.cpp", "m.cpp"]
+  );
+  assert.equal(provenance.changedPathsTruncated, true);
+  assert.equal(provenance.changedPathLimit, 2);
+});
+
+test("path evidence is separator-normalized and contains no source bodies", () => {
+  assert.equal(normalizeGitPath("mods\\src\\patches\\file.cc"), "mods/src/patches/file.cc");
+
+  const root = fixture();
+  const sourceBody = "super-secret-source-body";
+  writeFileSync(join(root, "tracked.cpp"), sourceBody);
+  const serialized = JSON.stringify(collectSourceProvenance(root));
+
+  assert.equal(serialized.includes(sourceBody), false);
+  assert.equal(readFileSync(join(root, "tracked.cpp"), "utf8"), sourceBody);
+});
+
+test("dirty initialized submodules fail closed", () => {
+  const submodule = fixture();
+  const root = fixture();
+  run(root, [
+    "-c",
+    "protocol.file.allow=always",
+    "submodule",
+    "add",
+    "-q",
+    submodule,
+    "vendor/submodule"
+  ]);
+  run(root, ["commit", "-qm", "add submodule"]);
+
+  const clean = collectSourceSnapshot(root);
+  assert.equal(
+    clean.manifest.paths.includes("vendor/submodule/tracked.cpp"),
+    true
+  );
+
+  writeFileSync(
+    join(root, "vendor", "submodule", "tracked.cpp"),
+    "int submodule_value = 2;\n"
+  );
+  assert.throws(
+    () => collectSourceSnapshot(root),
+    /Dirty or mismatched submodule source is not supported/
+  );
+  writeFileSync(
+    join(root, "vendor", "submodule", "tracked.cpp"),
+    "int submodule_value = 3;\n"
+  );
+  assert.throws(
+    () => collectSourceSnapshot(root),
+    /Dirty or mismatched submodule source is not supported/
+  );
+});
+
+test("receipt normalization preserves artifacts and pins canonical source identity", () => {
+  const root = fixture();
+  writeFileSync(join(root, "tracked.cpp"), "int dirty = 1;\n");
+  const provenance = collectSourceProvenance(root);
+  const receipt = normalizeSourceReceipt(
+    {
+      ok: true,
+      commit: provenance.baseCommit,
+      buildHash: "ARTIFACT-SHA256",
+      deployedHash: "ARTIFACT-SHA256",
+      hashMatch: true
+    },
+    provenance
+  );
+
+  assert.equal(receipt.baseCommit, provenance.baseCommit);
+  assert.equal(receipt.commit, provenance.baseCommit);
+  assert.deepEqual(receipt.sourceProvenance, provenance);
+  assert.equal(receipt.buildHash, "ARTIFACT-SHA256");
+  assert.equal(receipt.deployedHash, "ARTIFACT-SHA256");
+  assert.equal(receipt.hashMatch, true);
+});
+
+test("receipt normalization accepts and canonicalizes a legacy short commit", () => {
+  const root = fixture();
+  const provenance = collectSourceProvenance(root);
+  const receipt = normalizeSourceReceipt(
+    {
+      ok: true,
+      commit: provenance.baseCommit.slice(0, 7),
+      buildHash: "ARTIFACT-SHA256",
+      deployedHash: "ARTIFACT-SHA256",
+      hashMatch: true
+    },
+    provenance
+  );
+
+  assert.equal(receipt.commit, provenance.baseCommit);
+  assert.equal(receipt.baseCommit, provenance.baseCommit);
+  assert.equal(receipt.hashMatch, true);
+});
+
+test("receipt normalization rejects invalid or conflicting source identity", () => {
+  const root = fixture();
+  const provenance = collectSourceProvenance(root);
+
+  assert.throws(
+    () => normalizeSourceReceipt("not-json", provenance),
+    /did not return an object receipt/
+  );
+  assert.throws(
+    () =>
+      normalizeSourceReceipt(
+        { commit: "f".repeat(40), baseCommit: provenance.baseCommit },
+        provenance
+      ),
+    /commit conflicts with canonical base commit/
+  );
+  assert.throws(
+    () =>
+      normalizeSourceReceipt(
+        { commit: provenance.baseCommit.slice(0, 6) },
+        provenance
+      ),
+    /commit conflicts with canonical base commit/
+  );
+  assert.throws(
+    () =>
+      normalizeSourceReceipt(
+        { commit: provenance.baseCommit, baseCommit: "e".repeat(40) },
+        provenance
+      ),
+    /baseCommit conflicts with canonical base commit/
+  );
+});
+
+test("destination fingerprint detects copied-source drift", () => {
+  const root = fixture();
+  writeFileSync(join(root, "untracked.cpp"), "int untracked = 1;\n");
+  const snapshot = collectSourceSnapshot(root);
+  const destination = mkdtempSync(
+    join(tmpdir(), "stfc-source-destination-")
+  );
+  roots.push(destination);
+
+  for (const path of snapshot.manifest.paths) {
+    const target = join(destination, path);
+    mkdirSync(dirname(target), { recursive: true });
+    cpSync(join(root, path), target, { verbatimSymlinks: true });
+  }
+
+  assert.equal(
+    fingerprintSourcePaths(destination, snapshot.manifest.paths),
+    snapshot.manifest.fingerprint
+  );
+  writeFileSync(join(destination, "untracked.cpp"), "int untracked = 2;\n");
+  assert.notEqual(
+    fingerprintSourcePaths(destination, snapshot.manifest.paths),
+    snapshot.manifest.fingerprint
+  );
+});
+
+test("Windows-colliding source paths fail closed", () => {
+  const root = fixture();
+  writeFileSync(join(root, "Case.cpp"), "int upper = 1;\n");
+  writeFileSync(join(root, "case.cpp"), "int lower = 1;\n");
+
+  assert.throws(
+    () => collectSourceSnapshot(root),
+    /Source paths collide on Windows/
+  );
+});
+
+test("mirror isolation resolves symlinked parents for build, stage, and backup paths", () => {
+  const root = mkdtempSync(join(tmpdir(), "stfc-mirror-guard-"));
+  roots.push(root);
+  const protectedRoot = join(root, "game");
+  const alias = join(root, "alias");
+  mkdirSync(protectedRoot);
+  symlinkSync(protectedRoot, alias, "dir");
+
+  for (const candidate of [
+    join(alias, "build-mirror"),
+    join(alias, "build-mirror.stage-test"),
+    join(alias, "build-mirror.previous-test")
+  ]) {
+    assert.throws(
+      () => assertIsolatedMirrorRoot(candidate, [protectedRoot]),
+      /Mirror root overlaps a protected path/
+    );
+  }
+
+  const safe = join(root, "safe", "build-mirror");
+  assert.equal(assertIsolatedMirrorRoot(safe, [protectedRoot]), safe);
+});
+
+test("assume-unchanged tracked source fails closed", () => {
+  const root = fixture();
+  run(root, ["update-index", "--assume-unchanged", "tracked.cpp"]);
+  writeFileSync(join(root, "tracked.cpp"), "int hidden = 2;\n");
+  assert.equal(run(root, ["status", "--porcelain"]), "");
+
+  assert.throws(
+    () => collectSourceSnapshot(root),
+    /Tracked source uses assume-unchanged or skip-worktree/
+  );
+});
+
+test("skip-worktree tracked source fails closed", () => {
+  const root = fixture();
+  run(root, ["update-index", "--skip-worktree", "tracked.cpp"]);
+  writeFileSync(join(root, "tracked.cpp"), "int hidden = 3;\n");
+  assert.equal(run(root, ["status", "--porcelain"]), "");
+
+  assert.throws(
+    () => collectSourceSnapshot(root),
+    /Tracked source uses assume-unchanged or skip-worktree/
+  );
+});

--- a/scripts/axf/stfc-provider.mjs
+++ b/scripts/axf/stfc-provider.mjs
@@ -12,11 +12,22 @@ import {
   statSync,
   writeFileSync
 } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import {
+  dirname,
+  join,
+  relative,
+  resolve
+} from "node:path";
 import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
+import {
+  assertIsolatedMirrorRoot,
+  collectSourceSnapshot,
+  fingerprintSourcePaths,
+  normalizeSourceReceipt
+} from "./source-provenance.mjs";
 
-const PROVIDER_VERSION = "0.2.0";
+const PROVIDER_VERSION = "0.3.0";
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 const DEFAULT_GAME_ROOT = "/mnt/c/Games/Star Trek Fleet Command/default/game";
 const GAME_ROOT = process.env.STFC_GAME_ROOT || DEFAULT_GAME_ROOT;
@@ -299,10 +310,26 @@ function commandWindowsAx(axCommand, options, argMap = {}) {
     return fail("Windows interop is not available.", interop);
   }
   const shouldSync = axCommand !== "game-running";
-  const sync = shouldSync ? syncWindowsBuildRoot() : ok({ skipped: true, reason: "command does not use repo build files" });
+  let sourceSnapshot = null;
+  let sourceProvenance = null;
+  if (shouldSync) {
+    try {
+      sourceSnapshot = collectSourceSnapshot(REPO_ROOT);
+      sourceProvenance = sourceSnapshot.provenance;
+    } catch (error) {
+      return fail("Unable to establish build source provenance.", {
+        interop: interop.summary,
+        sourceProvenanceError: error?.message ?? String(error)
+      });
+    }
+  }
+  const sync = shouldSync
+    ? syncWindowsBuildRoot(sourceSnapshot)
+    : ok({ skipped: true, reason: "command does not use repo build files" });
   if (!sync.ok) {
     return fail("Failed to sync WSL repo to the Windows build mirror.", {
       interop: interop.summary,
+      sourceProvenance,
       sync: sync.data
     });
   }
@@ -310,6 +337,7 @@ function commandWindowsAx(axCommand, options, argMap = {}) {
   if (!xmakePrep.ok) {
     return fail("Failed to prepare Windows xmake configuration.", {
       interop: interop.summary,
+      sourceProvenance,
       sync: sync.data,
       xmakePrep: xmakePrep.data
     });
@@ -334,8 +362,18 @@ function commandWindowsAx(axCommand, options, argMap = {}) {
     maxBuffer: 128 * 1024 * 1024
   });
   const parsed = parseJsonMaybe(result.stdout);
+  let receipt = parsed;
+  let receiptError = null;
+  if (sourceProvenance) {
+    try {
+      receipt = normalizeSourceReceipt(parsed, sourceProvenance);
+    } catch (error) {
+      receiptError = error?.message ?? String(error);
+    }
+  }
   const data = {
     interop: interop.summary,
+    sourceProvenance,
     sync: sync.data,
     xmakePrep: xmakePrep.data,
     windowsCommand: axCommand,
@@ -344,10 +382,18 @@ function commandWindowsAx(axCommand, options, argMap = {}) {
     error: result.error,
     stdoutTail: tailLines(result.stdout, intOpt(options.tail, 40)),
     stderrTail: tailLines(result.stderr, intOpt(options.tail, 40)),
-    result: parsed
+    result: receiptError ? parsed : receipt
   };
-  const scriptOk = result.exitCode === 0 && !(parsed && typeof parsed === "object" && parsed.ok === false);
-  return scriptOk ? ok(parsed) : fail(`Windows .ax ${axCommand} failed.`, data);
+  if (receiptError) {
+    return fail("Windows .ax receipt source provenance is inconsistent.", {
+      ...data,
+      sourceProvenanceError: receiptError
+    });
+  }
+  const scriptOk =
+    result.exitCode === 0 &&
+    !(receipt && typeof receipt === "object" && receipt.ok === false);
+  return scriptOk ? ok(receipt) : fail(`Windows .ax ${axCommand} failed.`, data);
 }
 
 function commandValidation(validationCommand, options) {
@@ -956,7 +1002,8 @@ function runProcess(commandPath, args = [], options = {}) {
   const result = spawnSync(commandPath, args, {
     cwd: options.cwd ?? REPO_ROOT,
     encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: [options.input === undefined ? "ignore" : "pipe", "pipe", "pipe"],
+    input: options.input,
     env: options.env ?? process.env,
     maxBuffer: options.maxBuffer ?? 32 * 1024 * 1024
   });
@@ -1116,36 +1163,143 @@ function windowsInteropInfo({ probe = false } = {}) {
   };
 }
 
-function syncWindowsBuildRoot() {
-  mkdirSync(WINDOWS_BUILD_ROOT, { recursive: true });
-  const excludes = [
-    ".git/",
-    ".xmake/",
-    "build/",
-    "node_modules/",
-    ".cache/",
-    ".DS_Store"
-  ];
-  const args = [
-    "-a",
-    "--delete",
-    ...excludes.flatMap((entry) => ["--exclude", entry]),
-    `${REPO_ROOT}/`,
-    `${WINDOWS_BUILD_ROOT}/`
-  ];
-  const result = runProcess("rsync", args, {
-    cwd: REPO_ROOT,
-    maxBuffer: 64 * 1024 * 1024
-  });
-  const data = {
-    source: REPO_ROOT,
-    destination: WINDOWS_BUILD_ROOT,
-    destinationWin: toWindowsPath(WINDOWS_BUILD_ROOT),
-    exitCode: result.exitCode,
-    stdoutTail: tailLines(result.stdout, 40),
-    stderrTail: tailLines(result.stderr, 40)
-  };
-  return result.exitCode === 0 ? ok(data) : fail("rsync failed.", data);
+function assertSafeWindowsBuildRoot() {
+  return assertIsolatedMirrorRoot(WINDOWS_BUILD_ROOT, [
+    REPO_ROOT,
+    PRIVATE_AX_ROOT,
+    GAME_ROOT
+  ]);
+}
+
+function syncWindowsBuildRoot(sourceSnapshot) {
+  const buildRoot = assertSafeWindowsBuildRoot();
+  const suffix = `${process.pid}-${randomUUID()}`;
+  const protectedRoots = [REPO_ROOT, PRIVATE_AX_ROOT, GAME_ROOT];
+  const stageRoot = assertIsolatedMirrorRoot(
+    `${buildRoot}.stage-${suffix}`,
+    protectedRoots
+  );
+  const backupRoot = assertIsolatedMirrorRoot(
+    `${buildRoot}.previous-${suffix}`,
+    protectedRoots
+  );
+  let clone = null;
+  let sync = null;
+
+  try {
+    mkdirSync(dirname(buildRoot), { recursive: true });
+    clone = runProcess(
+      "git",
+      [
+        "clone",
+        "--no-hardlinks",
+        "--no-checkout",
+        "--no-recurse-submodules",
+        "--quiet",
+        REPO_ROOT,
+        stageRoot
+      ],
+      { cwd: dirname(buildRoot), maxBuffer: 64 * 1024 * 1024 }
+    );
+    if (clone.exitCode !== 0) {
+      throw new Error(`git clone failed: ${firstLine(clone.stderr)}`);
+    }
+    const cloneHead = runProcess(
+      "git",
+      ["-C", stageRoot, "rev-parse", "HEAD"],
+      { cwd: dirname(buildRoot) }
+    );
+    if (
+      cloneHead.exitCode !== 0 ||
+      cloneHead.stdout.trim() !== sourceSnapshot.provenance.baseCommit
+    ) {
+      throw new Error("Staged mirror HEAD does not match the canonical base commit.");
+    }
+
+    const manifestInput =
+      sourceSnapshot.manifest.paths.length > 0
+        ? `${sourceSnapshot.manifest.paths.join("\0")}\0`
+        : "";
+    sync = runProcess(
+      "rsync",
+      [
+        "-a",
+        "--relative",
+        "--from0",
+        "--files-from=-",
+        `${REPO_ROOT}/`,
+        `${stageRoot}/`
+      ],
+      {
+        cwd: REPO_ROOT,
+        input: manifestInput,
+        maxBuffer: 64 * 1024 * 1024
+      }
+    );
+    if (sync.exitCode !== 0) {
+      throw new Error(`rsync failed: ${firstLine(sync.stderr)}`);
+    }
+
+    const stagedFingerprint = fingerprintSourcePaths(
+      stageRoot,
+      sourceSnapshot.manifest.paths
+    );
+    if (stagedFingerprint !== sourceSnapshot.manifest.fingerprint) {
+      throw new Error("Staged mirror content does not match the canonical source manifest.");
+    }
+    const postSyncSnapshot = collectSourceSnapshot(REPO_ROOT);
+    if (
+      JSON.stringify(postSyncSnapshot.provenance) !==
+        JSON.stringify(sourceSnapshot.provenance) ||
+      postSyncSnapshot.manifest.fingerprint !==
+        sourceSnapshot.manifest.fingerprint
+    ) {
+      throw new Error("Repository source changed while the Windows mirror was synchronized.");
+    }
+
+    if (exists(buildRoot)) {
+      renameSync(buildRoot, backupRoot);
+    }
+    try {
+      renameSync(stageRoot, buildRoot);
+    } catch (error) {
+      if (exists(backupRoot) && !exists(buildRoot)) {
+        renameSync(backupRoot, buildRoot);
+      }
+      throw error;
+    }
+    if (exists(backupRoot)) {
+      rmSync(backupRoot, { recursive: true, force: true });
+    }
+
+    return ok({
+      source: REPO_ROOT,
+      destination: buildRoot,
+      destinationWin: toWindowsPath(buildRoot),
+      baseCommit: sourceSnapshot.provenance.baseCommit,
+      sourceManifestFingerprint: sourceSnapshot.manifest.fingerprint,
+      sourceFileCount: sourceSnapshot.manifest.paths.length,
+      cloneExitCode: clone.exitCode,
+      syncExitCode: sync.exitCode
+    });
+  } catch (error) {
+    if (exists(stageRoot)) {
+      rmSync(stageRoot, { recursive: true, force: true });
+    }
+    if (exists(backupRoot) && !exists(buildRoot)) {
+      renameSync(backupRoot, buildRoot);
+    }
+    return fail("Failed to materialize an exact Windows build mirror.", {
+      source: REPO_ROOT,
+      destination: buildRoot,
+      destinationWin: toWindowsPath(buildRoot),
+      error: error?.message ?? String(error),
+      cloneExitCode: clone?.exitCode ?? null,
+      cloneStderrTail: tailLines(clone?.stderr, 20),
+      syncExitCode: sync?.exitCode ?? null,
+      syncStderrTail: tailLines(sync?.stderr, 20)
+    });
+  }
 }
 
 function prepareWindowsXmake(interop) {


### PR DESCRIPTION
## What changed

- derive source identity and Windows synchronization from one canonical Git tracked-plus-untracked-nonignored NUL-delimited manifest
- materialize each build in a fresh exact-HEAD mirror, verify the copied fingerprint, and fail if source changes during synchronization
- physically reject mirror, stage, and backup roots that overlap the source checkout, private AX root, or game directory, including symlink-parent aliases
- identify clean sources as `git:<commit>` and dirty sources as content-sensitive `dirty-sha256:<digest>` states
- emit bounded changed-path evidence without ignored/private files, diffs, or source bodies
- fail closed on dirty/mismatched initialized submodules, assume-unchanged or skip-worktree entries, and Windows-colliding source paths
- validate legacy dispatcher `commit`/`baseCommit` prefixes against the canonical base while preserving build/deployed hashes and `hashMatch`
- add a Node 24 provider-contract CI job

## Root cause

The old provider returned a legacy commit from a reusable Windows mirror even when rsync built dirty working-tree source. Its provenance helper and rsync also selected different file sets, so ignored/private files could be copied under a clean receipt, and dirty submodule content could collide.

## Validation

- 17/17 temp-only source-provenance and receipt contracts passing
- syntax checks pass for provider and helper
- isolated `/tmp` clone + exact-manifest rsync proof copied 1,484 files and matched the full staged fingerprint
- ignored paths are excluded; dirty submodules, hidden index flags, path aliases, and Windows path collisions fail closed
- `git diff --check` passes
- AXF companion contract merged in Guffawaffle/axf#57
- hosted provider, Windows, launcher, and macOS checks rerun on every replacement head

Refs #189. Keep #189 open until the post-merge native-Windows dirty-source cycle satisfies its acceptance signal.

Tracks the owning cross-repo contract in Guffawaffle/axf#56.