### PR TITLE
[WL-003] Publish machine-readable Windows release manifest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,20 @@ env:
   DOTNET_NOLOGO: true
 
 jobs:
+  release-manifest-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate release manifest fixtures
+        run: python -m unittest tests.test_generate_release_manifest -v
+
   build-win:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: windows-2025-vs2026

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@
 # Triggered when a tag matching "v*" is pushed.  Verifies that the CI Build
 # workflow succeeded for the same commit, downloads its artifacts, packages
 # them into a .zip, detects alpha/beta pre-releases, and publishes a GitHub
-# release with the Windows .zip and macOS .dmg attached.
+# release with the signed Windows mod, launcher archive, canonical release
+# manifest, existing manual archives, and macOS installer attached.
 
 name: Create Release
 
@@ -85,10 +86,12 @@ jobs:
         run: |
           cp stfc-community-mod/version.dll version.dll
           cp stfc-community-mod.zip stfc-community-mod-${{ github.ref_name }}.zip
+          test -f stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip
           sha256sum version.dll \
             stfc-community-mod.zip \
             stfc-community-mod-${{ github.ref_name }}.zip \
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \
+            stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip \
             stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst \
             stfc-community-mod-installer/stfc-community-mod-installer.dmg > SHA256SUMS.txt
 
@@ -113,6 +116,26 @@ jobs:
           fi
 
           echo "release_name=$release_name" >> "$GITHUB_OUTPUT"
+
+      - name: Generate and validate release manifest
+        run: |
+          python3 scripts/generate_release_manifest.py generate \
+            --tag "${{ github.ref_name }}" \
+            --target "${{ github.sha }}" \
+            --repository "${{ github.repository }}" \
+            --artifact-root "$PWD" \
+            --spec scripts/windows_release_manifest_spec.json \
+            --output stfc-community-mod-release-manifest.json
+
+          python3 scripts/generate_release_manifest.py validate \
+            --tag "${{ github.ref_name }}" \
+            --target "${{ github.sha }}" \
+            --repository "${{ github.repository }}" \
+            --artifact-root "$PWD" \
+            --spec scripts/windows_release_manifest_spec.json \
+            --manifest stfc-community-mod-release-manifest.json
+
+          sha256sum stfc-community-mod-release-manifest.json >> SHA256SUMS.txt
 
       - name: Generate release body
         run: |
@@ -149,9 +172,11 @@ jobs:
             stfc-community-mod-${{ github.ref_name }}.zip \
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst.sha256 \
+            stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip \
             stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst \
             stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst.sha256 \
             stfc-community-mod-installer/stfc-community-mod-installer.dmg \
+            stfc-community-mod-release-manifest.json \
             SHA256SUMS.txt \
             --repo "${{ github.repository }}" \
             --clobber

--- a/docs/windows-launcher/CODE_SIGNING.md
+++ b/docs/windows-launcher/CODE_SIGNING.md
@@ -60,7 +60,11 @@ channels, hashes, or withdrawal state. A detached manifest-signature design
 with replay protection remains a separate release-control deliverable.
 
 Until that design is accepted, a manifest checksum must not be described as a
-manifest signature.
+manifest signature. Schema v1 therefore declares
+`manifestAuthenticity.scheme: none` while recording independent Authenticode
+expectations for each PE artifact or signed archive member. The complete
+producer and consumer contract is in
+`docs/windows-launcher/RELEASE_MANIFEST.md`.
 
 ## Rollback and credential retirement
 

--- a/docs/windows-launcher/CONTRACT.md
+++ b/docs/windows-launcher/CONTRACT.md
@@ -154,21 +154,41 @@ action.
 Release discovery uses GitHub releases from `Guffawaffle/stfc-mod`. The
 launcher consumes a machine-readable manifest published with each release.
 
-Proposed manifest:
+The canonical schema, artifact kinds, channel mapping, authenticity boundary,
+withdrawal behavior, and producer/consumer validation rules are defined in
+`docs/windows-launcher/RELEASE_MANIFEST.md`.
+
+Schema v1 shape:
 
 ```json
 {
   "schemaVersion": 1,
   "releaseVersion": "2.1.0-guffa.6",
+  "tag": "v2.1.0-guffa.6",
   "channel": "stable",
+  "releaseState": "active",
   "minimumLauncherVersion": "0.1.0",
+  "source": {
+    "repository": "Guffawaffle/stfc-mod",
+    "targetCommit": "<40 lowercase hex characters>"
+  },
+  "manifestAuthenticity": {
+    "scheme": "none"
+  },
   "artifacts": [
     {
+      "id": "windows-mod-dll-x64",
       "kind": "windows-mod",
+      "platform": "windows",
       "architecture": "x64",
       "fileName": "version.dll",
+      "mediaType": "application/vnd.microsoft.portable-executable",
       "sha256": "<64 lowercase hex characters>",
-      "size": 123
+      "size": 123,
+      "authenticity": {
+        "scheme": "authenticode",
+        "scope": "artifact"
+      }
     }
   ]
 }
@@ -183,6 +203,7 @@ Rules:
 - Unknown manifest schema versions fail closed with an actionable message.
 - Downgrade requires explicit confirmation.
 - Withdrawn releases are not newly offered.
+- Checksums are artifact integrity metadata, not manifest authentication.
 - Network failure must not prevent launching an already healthy installation.
 
 Self-update must use a separate bootstrapper or replace-on-exit helper. The

--- a/docs/windows-launcher/RELEASE_MANIFEST.md
+++ b/docs/windows-launcher/RELEASE_MANIFEST.md
@@ -1,0 +1,181 @@
+# Windows Release Manifest
+
+## Purpose
+
+Every tagged release publishes
+`stfc-community-mod-release-manifest.json`. It is the canonical machine-readable
+index for Windows launcher and mod artifacts. The release workflow generates
+artifact sizes and SHA-256 values from the signed, packaged files and then
+validates the completed manifest against those same files before upload.
+
+The manifest is not handwritten. The checked-in
+`scripts/windows_release_manifest_spec.json` declares stable artifact identity,
+media type, platform, architecture, source path, and expected authenticity
+mechanism. `scripts/generate_release_manifest.py` supplies release identity,
+size, and digest facts.
+
+The older `launcher-spike-manifest.json` beside local launcher packages
+describes only the WL-001 self-contained packaging experiment. It is not a
+release discovery contract and must not be consumed as one.
+
+## Schema v1
+
+```json
+{
+  "schemaVersion": 1,
+  "releaseVersion": "2.1.0-guffa.8",
+  "tag": "v2.1.0-guffa.8",
+  "channel": "stable",
+  "releaseState": "active",
+  "minimumLauncherVersion": "0.1.0",
+  "source": {
+    "repository": "Guffawaffle/stfc-mod",
+    "targetCommit": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "manifestAuthenticity": {
+    "scheme": "none"
+  },
+  "artifacts": [
+    {
+      "id": "windows-mod-dll-x64",
+      "kind": "windows-mod",
+      "platform": "windows",
+      "architecture": "x64",
+      "fileName": "version.dll",
+      "mediaType": "application/vnd.microsoft.portable-executable",
+      "size": 123,
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "authenticity": {
+        "scheme": "authenticode",
+        "scope": "artifact"
+      }
+    }
+  ]
+}
+```
+
+Schema v1 fields are closed: producers reject unknown spec fields, and
+consumers must fail closed on an unknown `schemaVersion`.
+
+### Release identity
+
+- `releaseVersion` is the supported tag without its leading `v`.
+- `tag` is the exact immutable Git tag.
+- `source.repository` uses `owner/name`.
+- `source.targetCommit` is the exact 40-character lowercase commit ID built by
+  the tagged workflow.
+- `minimumLauncherVersion` is the oldest launcher allowed to interpret and act
+  on the release.
+
+### Channels
+
+The generator derives the channel from the tag instead of accepting a
+potentially contradictory workflow input:
+
+| Tag form | Channel | GitHub release behavior |
+|---|---|---|
+| `vX.Y.Z` | `stable` | normal release |
+| `vX.Y.Z-guffa.N` | `stable` | normal fork release |
+| `vX.Y.Z-guffa.rcN` | `preview` | prerelease |
+| `vX.Y.Z.alpha.N` | `preview` | prerelease |
+| `vX.Y.Z.beta.N` | `preview` | prerelease |
+
+Unknown tag forms fail generation. Stable is the launcher default. Selecting
+preview releases requires explicit user intent and must never silently change
+the configured channel.
+
+### Artifact identity
+
+Each artifact has a stable `id` and a semantic `kind`. Schema v1 publishes:
+
+| ID | Kind | Purpose |
+|---|---|---|
+| `windows-mod-dll-x64` | `windows-mod` | Direct signed `version.dll` used by the transactional installer and retained for manual installation. |
+| `windows-mod-archive-x64` | `windows-mod-archive` | Existing Windows archive containing the signed mod DLL. |
+| `windows-launcher-archive-x64` | `windows-launcher` | Self-contained launcher archive containing the signed launcher executable. |
+
+Future bootstrapper or independently installed components receive distinct IDs
+and kinds. Their size, checksum, and authenticity metadata must not be borrowed
+from another artifact.
+
+`fileName` is a release-asset base name, never a local path or URL. Consumers
+resolve it only against the selected GitHub release. Redirects are allowed only
+over HTTPS.
+
+### Integrity and authenticity
+
+`size` and `sha256` describe the exact bytes of the published release asset.
+They detect truncation or mutation only after the launcher has obtained trusted
+release metadata.
+
+Artifact authenticity is independent:
+
+- `scheme: authenticode, scope: artifact` means the downloaded PE file itself
+  must pass Authenticode verification.
+- `scheme: authenticode, scope: contents` names the signed files that must pass
+  Authenticode verification after safe extraction.
+- `scheme: none, scope: none` would explicitly declare that no independent
+  artifact signature is available.
+
+The release workflow signs and verifies Windows PEs before packaging and
+hashing. A checksum is not a signature.
+
+`manifestAuthenticity.scheme` is deliberately `none` in schema v1. GitHub
+release transport and repository controls distribute the JSON, but v1 has no
+detached manifest signature or replay protection. Consumers and release notes
+must not describe the manifest checksum as publisher authentication. A future
+signed-manifest design requires a new reviewed contract.
+
+### Withdrawal
+
+The normal generator emits `releaseState: active`. A release is newly eligible
+only while:
+
+1. its GitHub release still exists and is not draft;
+2. its release/prerelease state matches the selected launcher channel;
+3. the repository withdrawal procedure has not yanked it; and
+4. its manifest validates.
+
+Withdrawals use `scripts/axf/release-withdrawal.ps1` and the durable
+`docs/release-withdrawals/release-withdrawals.jsonl` ledger. Yanked releases are
+not newly offered, even if a client has cached their former active manifest.
+A cached, already-installed healthy mod may continue to launch offline; no
+withdrawal silently removes local files. Replacement, downgrade, or removal
+requires explicit policy and user-visible action.
+
+Schema v1 does not rewrite an immutable historical manifest after withdrawal.
+A future authenticated release index may add live withdrawal state and replay
+protection.
+
+## Generation and validation
+
+The tagged release workflow runs:
+
+```text
+build -> sign -> verify signatures -> package -> generate manifest
+      -> validate manifest against files -> hash manifest -> publish
+```
+
+The generator and validator use the same explicit release identity and checked-
+in artifact spec. Validation reconstructs the entire expected document from the
+packaged files; a filename, size, checksum, channel, commit, repository, or
+metadata mismatch fails the release.
+
+Fixture validation:
+
+```powershell
+py -3 -m unittest tests.test_generate_release_manifest -v
+```
+
+Linux CI uses the equivalent `python -m unittest` command.
+
+## Consumer failure behavior
+
+- Unknown schema, tag, channel, artifact kind, platform, or architecture fails
+  closed for install/update.
+- Missing, duplicate, empty, or mismatched artifacts fail closed.
+- HTTP failure, size mismatch, checksum mismatch, unsafe extraction, or failed
+  Authenticode validation must leave the existing installation untouched.
+- Manifest/network failure must not prevent launching an already healthy
+  installation.
+- Downgrade and preview-channel selection always require explicit user intent.

--- a/scripts/generate_release_manifest.py
+++ b/scripts/generate_release_manifest.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Generate and validate the canonical STFC Community Mod release manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+MANIFEST_SCHEMA_VERSION = 1
+SPEC_VERSION = 1
+TAG_PATTERN = re.compile(
+    r"^v(?P<version>\d+\.\d+\.\d+"
+    r"(?:(?:-guffa\.(?:\d+|rc\d+))|(?:\.(?:alpha|beta)\.\d+))?)$"
+)
+COMMIT_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+IDENTIFIER_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:[-.][0-9A-Za-z.-]+)?$")
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ManifestError(ValueError):
+    """Raised when release manifest input or output violates the v1 contract."""
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exception:
+        raise ManifestError(f"{label} does not exist: {path}") from exception
+    except json.JSONDecodeError as exception:
+        raise ManifestError(
+            f"{label} is not valid JSON at line {exception.lineno}, "
+            f"column {exception.colno}: {exception.msg}"
+        ) from exception
+
+    if not isinstance(value, dict):
+        raise ManifestError(f"{label} root must be a JSON object")
+    return value
+
+
+def _require_keys(
+    value: dict[str, Any],
+    *,
+    required: set[str],
+    optional: set[str] = frozenset(),
+    context: str,
+) -> None:
+    missing = sorted(required - value.keys())
+    unknown = sorted(value.keys() - required - optional)
+    if missing:
+        raise ManifestError(f"{context} is missing required field(s): {', '.join(missing)}")
+    if unknown:
+        raise ManifestError(f"{context} contains unknown field(s): {', '.join(unknown)}")
+
+
+def _require_string(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ManifestError(f"{context} must be a non-empty string")
+    return value
+
+
+def _release_identity(tag: str) -> tuple[str, str]:
+    match = TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise ManifestError(
+            "tag must match a supported release form: "
+            "vX.Y.Z, vX.Y.Z-guffa.N, vX.Y.Z-guffa.rcN, "
+            "vX.Y.Z.alpha.N, or vX.Y.Z.beta.N"
+        )
+
+    version = match.group("version")
+    channel = (
+        "preview"
+        if ".alpha." in version or ".beta." in version or "-guffa.rc" in version
+        else "stable"
+    )
+    return version, channel
+
+
+def _validate_authenticity(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ManifestError(f"{context} must be an object")
+    _require_keys(
+        value,
+        required={"scheme", "scope"},
+        optional={"signedFiles"},
+        context=context,
+    )
+
+    scheme = _require_string(value["scheme"], f"{context}.scheme")
+    scope = _require_string(value["scope"], f"{context}.scope")
+    if scheme not in {"authenticode", "none"}:
+        raise ManifestError(f"{context}.scheme must be 'authenticode' or 'none'")
+    if scope not in {"artifact", "contents", "none"}:
+        raise ManifestError(f"{context}.scope must be 'artifact', 'contents', or 'none'")
+
+    signed_files = value.get("signedFiles")
+    if scheme == "none":
+        if scope != "none" or signed_files is not None:
+            raise ManifestError(
+                f"{context} with scheme 'none' must use scope 'none' and omit signedFiles"
+            )
+    elif scope == "none":
+        raise ManifestError(f"{context} with Authenticode must not use scope 'none'")
+
+    if scope == "contents":
+        if (
+            not isinstance(signed_files, list)
+            or not signed_files
+            or any(not isinstance(item, str) or not item for item in signed_files)
+        ):
+            raise ManifestError(
+                f"{context}.signedFiles must be a non-empty string array for contents scope"
+            )
+        if len(set(signed_files)) != len(signed_files):
+            raise ManifestError(f"{context}.signedFiles must not contain duplicates")
+        for signed_file in signed_files:
+            portable_path = PurePosixPath(signed_file)
+            if (
+                portable_path.is_absolute()
+                or ".." in portable_path.parts
+                or "\\" in signed_file
+            ):
+                raise ManifestError(
+                    f"{context}.signedFiles entries must be safe relative paths "
+                    "using '/' separators"
+                )
+    elif signed_files is not None:
+        raise ManifestError(f"{context}.signedFiles is valid only for contents scope")
+
+    normalized: dict[str, Any] = {"scheme": scheme, "scope": scope}
+    if signed_files is not None:
+        normalized["signedFiles"] = signed_files
+    return normalized
+
+
+def _load_spec(spec_path: Path) -> dict[str, Any]:
+    spec = _load_object(spec_path, "manifest spec")
+    _require_keys(
+        spec,
+        required={"specVersion", "minimumLauncherVersion", "artifacts"},
+        context="manifest spec",
+    )
+    if type(spec["specVersion"]) is not int or spec["specVersion"] != SPEC_VERSION:
+        raise ManifestError(
+            f"unsupported manifest spec version {spec['specVersion']!r}; "
+            f"expected {SPEC_VERSION}"
+        )
+
+    minimum_launcher_version = _require_string(
+        spec["minimumLauncherVersion"],
+        "manifest spec.minimumLauncherVersion",
+    )
+    if VERSION_PATTERN.fullmatch(minimum_launcher_version) is None:
+        raise ManifestError(
+            "manifest spec.minimumLauncherVersion must be a version such as 0.1.0"
+        )
+
+    artifacts = spec["artifacts"]
+    if not isinstance(artifacts, list) or not artifacts:
+        raise ManifestError("manifest spec.artifacts must be a non-empty array")
+
+    normalized_artifacts: list[dict[str, Any]] = []
+    artifact_ids: set[str] = set()
+    for index, artifact in enumerate(artifacts):
+        context = f"manifest spec.artifacts[{index}]"
+        if not isinstance(artifact, dict):
+            raise ManifestError(f"{context} must be an object")
+        _require_keys(
+            artifact,
+            required={
+                "id",
+                "kind",
+                "platform",
+                "architecture",
+                "sourcePath",
+                "fileName",
+                "mediaType",
+                "authenticity",
+            },
+            context=context,
+        )
+
+        artifact_id = _require_string(artifact["id"], f"{context}.id")
+        kind = _require_string(artifact["kind"], f"{context}.kind")
+        platform = _require_string(artifact["platform"], f"{context}.platform")
+        architecture = _require_string(
+            artifact["architecture"],
+            f"{context}.architecture",
+        )
+        source_path = _require_string(artifact["sourcePath"], f"{context}.sourcePath")
+        file_name = _require_string(artifact["fileName"], f"{context}.fileName")
+        media_type = _require_string(artifact["mediaType"], f"{context}.mediaType")
+
+        if IDENTIFIER_PATTERN.fullmatch(artifact_id) is None:
+            raise ManifestError(f"{context}.id must be a lowercase kebab-case identifier")
+        if artifact_id in artifact_ids:
+            raise ManifestError(f"duplicate artifact id: {artifact_id}")
+        artifact_ids.add(artifact_id)
+        if IDENTIFIER_PATTERN.fullmatch(kind) is None:
+            raise ManifestError(f"{context}.kind must be a lowercase kebab-case identifier")
+        if platform != "windows":
+            raise ManifestError(f"{context}.platform must be 'windows' in schema v1")
+        if architecture not in {"x64", "arm64", "neutral"}:
+            raise ManifestError(
+                f"{context}.architecture must be 'x64', 'arm64', or 'neutral'"
+            )
+
+        portable_path = PurePosixPath(source_path)
+        if (
+            portable_path.is_absolute()
+            or ".." in portable_path.parts
+            or "\\" in source_path
+        ):
+            raise ManifestError(
+                f"{context}.sourcePath must be a safe relative path using '/' separators"
+            )
+        if "/" in file_name or "\\" in file_name or file_name in {".", ".."}:
+            raise ManifestError(f"{context}.fileName must be a base file name")
+        if portable_path.name != file_name:
+            raise ManifestError(
+                f"{context}.fileName must match the sourcePath base name"
+            )
+
+        normalized_artifacts.append(
+            {
+                "id": artifact_id,
+                "kind": kind,
+                "platform": platform,
+                "architecture": architecture,
+                "sourcePath": source_path,
+                "fileName": file_name,
+                "mediaType": media_type,
+                "authenticity": _validate_authenticity(
+                    artifact["authenticity"],
+                    f"{context}.authenticity",
+                ),
+            }
+        )
+
+    return {
+        "minimumLauncherVersion": minimum_launcher_version,
+        "artifacts": normalized_artifacts,
+    }
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_manifest(
+    *,
+    tag: str,
+    target_commit: str,
+    repository: str,
+    artifact_root: Path,
+    spec_path: Path,
+) -> dict[str, Any]:
+    release_version, channel = _release_identity(tag)
+    if COMMIT_PATTERN.fullmatch(target_commit) is None:
+        raise ManifestError("target commit must be exactly 40 lowercase hexadecimal characters")
+    if REPOSITORY_PATTERN.fullmatch(repository) is None:
+        raise ManifestError("repository must use the owner/name form")
+
+    root = artifact_root.resolve(strict=True)
+    if not root.is_dir():
+        raise ManifestError(f"artifact root is not a directory: {root}")
+    spec = _load_spec(spec_path)
+
+    artifacts: list[dict[str, Any]] = []
+    for artifact in spec["artifacts"]:
+        source = (root / PurePosixPath(artifact["sourcePath"])).resolve(strict=True)
+        try:
+            source.relative_to(root)
+        except ValueError as exception:
+            raise ManifestError(
+                f"artifact source escapes the artifact root: {artifact['sourcePath']}"
+            ) from exception
+        if not source.is_file():
+            raise ManifestError(f"artifact source is not a file: {artifact['sourcePath']}")
+        size = source.stat().st_size
+        if size <= 0:
+            raise ManifestError(f"artifact source is empty: {artifact['sourcePath']}")
+
+        artifacts.append(
+            {
+                "id": artifact["id"],
+                "kind": artifact["kind"],
+                "platform": artifact["platform"],
+                "architecture": artifact["architecture"],
+                "fileName": artifact["fileName"],
+                "mediaType": artifact["mediaType"],
+                "size": size,
+                "sha256": _hash_file(source),
+                "authenticity": artifact["authenticity"],
+            }
+        )
+
+    return {
+        "schemaVersion": MANIFEST_SCHEMA_VERSION,
+        "releaseVersion": release_version,
+        "tag": tag,
+        "channel": channel,
+        "releaseState": "active",
+        "minimumLauncherVersion": spec["minimumLauncherVersion"],
+        "source": {
+            "repository": repository,
+            "targetCommit": target_commit,
+        },
+        "manifestAuthenticity": {
+            "scheme": "none",
+        },
+        "artifacts": artifacts,
+    }
+
+
+def write_manifest(manifest: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = output_path.with_name(f"{output_path.name}.tmp")
+    temporary_path.write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    temporary_path.replace(output_path)
+
+
+def validate_manifest(
+    *,
+    manifest_path: Path,
+    tag: str,
+    target_commit: str,
+    repository: str,
+    artifact_root: Path,
+    spec_path: Path,
+) -> None:
+    actual = _load_object(manifest_path, "release manifest")
+    schema_version = actual.get("schemaVersion")
+    if type(schema_version) is not int or schema_version != MANIFEST_SCHEMA_VERSION:
+        raise ManifestError(
+            f"unsupported release manifest schema version {schema_version!r}; "
+            f"expected {MANIFEST_SCHEMA_VERSION}"
+        )
+
+    expected = build_manifest(
+        tag=tag,
+        target_commit=target_commit,
+        repository=repository,
+        artifact_root=artifact_root,
+        spec_path=spec_path,
+    )
+    if actual != expected:
+        raise ManifestError(
+            "release manifest does not match the declared release metadata and artifact files"
+        )
+
+    for artifact in actual["artifacts"]:
+        if (
+            type(artifact["size"]) is not int
+            or artifact["size"] <= 0
+            or SHA256_PATTERN.fullmatch(artifact["sha256"]) is None
+        ):
+            raise ManifestError(
+                f"release manifest artifact {artifact['id']!r} has invalid size or SHA-256"
+            )
+
+
+def _add_shared_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--target", required=True, dest="target_commit")
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--artifact-root", required=True, type=Path)
+    parser.add_argument("--spec", required=True, type=Path)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate")
+    _add_shared_arguments(generate_parser)
+    generate_parser.add_argument("--output", required=True, type=Path)
+
+    validate_parser = subparsers.add_parser("validate")
+    _add_shared_arguments(validate_parser)
+    validate_parser.add_argument("--manifest", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        if args.command == "generate":
+            manifest = build_manifest(
+                tag=args.tag,
+                target_commit=args.target_commit,
+                repository=args.repository,
+                artifact_root=args.artifact_root,
+                spec_path=args.spec,
+            )
+            write_manifest(manifest, args.output)
+            print(f"Generated release manifest: {args.output}")
+        else:
+            validate_manifest(
+                manifest_path=args.manifest,
+                tag=args.tag,
+                target_commit=args.target_commit,
+                repository=args.repository,
+                artifact_root=args.artifact_root,
+                spec_path=args.spec,
+            )
+            print(f"Validated release manifest: {args.manifest}")
+    except (ManifestError, OSError) as exception:
+        print(f"error: {exception}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/windows_release_manifest_spec.json
+++ b/scripts/windows_release_manifest_spec.json
@@ -1,0 +1,51 @@
+{
+  "specVersion": 1,
+  "minimumLauncherVersion": "0.1.0",
+  "artifacts": [
+    {
+      "id": "windows-mod-dll-x64",
+      "kind": "windows-mod",
+      "platform": "windows",
+      "architecture": "x64",
+      "sourcePath": "version.dll",
+      "fileName": "version.dll",
+      "mediaType": "application/vnd.microsoft.portable-executable",
+      "authenticity": {
+        "scheme": "authenticode",
+        "scope": "artifact"
+      }
+    },
+    {
+      "id": "windows-mod-archive-x64",
+      "kind": "windows-mod-archive",
+      "platform": "windows",
+      "architecture": "x64",
+      "sourcePath": "stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst",
+      "fileName": "stfc-community-mod-windows-x64.tar.zst",
+      "mediaType": "application/zstd",
+      "authenticity": {
+        "scheme": "authenticode",
+        "scope": "contents",
+        "signedFiles": [
+          "version.dll"
+        ]
+      }
+    },
+    {
+      "id": "windows-launcher-archive-x64",
+      "kind": "windows-launcher",
+      "platform": "windows",
+      "architecture": "x64",
+      "sourcePath": "stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip",
+      "fileName": "stfc-community-mod-launcher-win-x64.zip",
+      "mediaType": "application/zip",
+      "authenticity": {
+        "scheme": "authenticode",
+        "scope": "contents",
+        "signedFiles": [
+          "STFCCommunityMod.Launcher.exe"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/test_generate_release_manifest.py
+++ b/tests/test_generate_release_manifest.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.generate_release_manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    ManifestError,
+    build_manifest,
+    validate_manifest,
+    write_manifest,
+)
+
+
+TARGET_COMMIT = "0123456789abcdef0123456789abcdef01234567"
+REPOSITORY = "Guffawaffle/stfc-mod"
+
+
+class ReleaseManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.artifact_root = self.root / "artifacts"
+        self.artifact_root.mkdir()
+        self.mod = self.artifact_root / "version.dll"
+        self.launcher = self.artifact_root / "launcher.zip"
+        self.mod.write_bytes(b"signed-mod-fixture")
+        self.launcher.write_bytes(b"signed-launcher-fixture")
+        self.spec_path = self.root / "spec.json"
+        self.spec_path.write_text(
+            json.dumps(
+                {
+                    "specVersion": 1,
+                    "minimumLauncherVersion": "0.1.0",
+                    "artifacts": [
+                        {
+                            "id": "windows-mod-dll-x64",
+                            "kind": "windows-mod",
+                            "platform": "windows",
+                            "architecture": "x64",
+                            "sourcePath": "version.dll",
+                            "fileName": "version.dll",
+                            "mediaType": "application/vnd.microsoft.portable-executable",
+                            "authenticity": {
+                                "scheme": "authenticode",
+                                "scope": "artifact",
+                            },
+                        },
+                        {
+                            "id": "windows-launcher-archive-x64",
+                            "kind": "windows-launcher",
+                            "platform": "windows",
+                            "architecture": "x64",
+                            "sourcePath": "launcher.zip",
+                            "fileName": "launcher.zip",
+                            "mediaType": "application/zip",
+                            "authenticity": {
+                                "scheme": "authenticode",
+                                "scope": "contents",
+                                "signedFiles": ["STFCCommunityMod.Launcher.exe"],
+                            },
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def _build(self, tag: str = "v2.1.0-guffa.8") -> dict[str, object]:
+        return build_manifest(
+            tag=tag,
+            target_commit=TARGET_COMMIT,
+            repository=REPOSITORY,
+            artifact_root=self.artifact_root,
+            spec_path=self.spec_path,
+        )
+
+    def test_fixture_generates_and_validates_artifact_facts(self) -> None:
+        manifest = self._build()
+        manifest_path = self.root / "release-manifest.json"
+        write_manifest(manifest, manifest_path)
+
+        validate_manifest(
+            manifest_path=manifest_path,
+            tag="v2.1.0-guffa.8",
+            target_commit=TARGET_COMMIT,
+            repository=REPOSITORY,
+            artifact_root=self.artifact_root,
+            spec_path=self.spec_path,
+        )
+
+        self.assertEqual(MANIFEST_SCHEMA_VERSION, manifest["schemaVersion"])
+        self.assertEqual("2.1.0-guffa.8", manifest["releaseVersion"])
+        self.assertEqual("stable", manifest["channel"])
+        self.assertEqual("none", manifest["manifestAuthenticity"]["scheme"])
+        self.assertEqual(self.mod.stat().st_size, manifest["artifacts"][0]["size"])
+        self.assertRegex(manifest["artifacts"][0]["sha256"], r"^[0-9a-f]{64}$")
+
+    def test_checked_in_release_spec_round_trips_fixture_layout(self) -> None:
+        repository_root = Path(__file__).resolve().parents[1]
+        checked_in_spec = repository_root / "scripts" / "windows_release_manifest_spec.json"
+        spec = json.loads(checked_in_spec.read_text(encoding="utf-8"))
+        fixture_root = self.root / "release-layout"
+        fixture_root.mkdir()
+        for index, artifact in enumerate(spec["artifacts"]):
+            artifact_path = fixture_root / artifact["sourcePath"]
+            artifact_path.parent.mkdir(parents=True, exist_ok=True)
+            artifact_path.write_bytes(f"release-artifact-{index}".encode())
+
+        manifest = build_manifest(
+            tag="v2.1.0-guffa.8",
+            target_commit=TARGET_COMMIT,
+            repository=REPOSITORY,
+            artifact_root=fixture_root,
+            spec_path=checked_in_spec,
+        )
+        manifest_path = self.root / "checked-in-spec-manifest.json"
+        write_manifest(manifest, manifest_path)
+        validate_manifest(
+            manifest_path=manifest_path,
+            tag="v2.1.0-guffa.8",
+            target_commit=TARGET_COMMIT,
+            repository=REPOSITORY,
+            artifact_root=fixture_root,
+            spec_path=checked_in_spec,
+        )
+
+        self.assertEqual(
+            [
+                "windows-mod-dll-x64",
+                "windows-mod-archive-x64",
+                "windows-launcher-archive-x64",
+            ],
+            [artifact["id"] for artifact in manifest["artifacts"]],
+        )
+
+    def test_preview_channel_is_derived_from_supported_tag(self) -> None:
+        manifest = self._build("v2.2.0-guffa.rc1")
+        self.assertEqual("preview", manifest["channel"])
+
+    def test_tampered_artifact_fails_validation(self) -> None:
+        manifest_path = self.root / "release-manifest.json"
+        write_manifest(self._build(), manifest_path)
+        self.mod.write_bytes(b"tampered")
+
+        with self.assertRaisesRegex(ManifestError, "does not match"):
+            validate_manifest(
+                manifest_path=manifest_path,
+                tag="v2.1.0-guffa.8",
+                target_commit=TARGET_COMMIT,
+                repository=REPOSITORY,
+                artifact_root=self.artifact_root,
+                spec_path=self.spec_path,
+            )
+
+    def test_unknown_manifest_schema_fails_closed(self) -> None:
+        manifest = self._build()
+        manifest["schemaVersion"] = 2
+        manifest_path = self.root / "release-manifest.json"
+        write_manifest(manifest, manifest_path)
+
+        with self.assertRaisesRegex(ManifestError, "unsupported release manifest schema"):
+            validate_manifest(
+                manifest_path=manifest_path,
+                tag="v2.1.0-guffa.8",
+                target_commit=TARGET_COMMIT,
+                repository=REPOSITORY,
+                artifact_root=self.artifact_root,
+                spec_path=self.spec_path,
+            )
+
+    def test_boolean_schema_version_fails_closed(self) -> None:
+        manifest = self._build()
+        manifest["schemaVersion"] = True
+        manifest_path = self.root / "release-manifest.json"
+        write_manifest(manifest, manifest_path)
+
+        with self.assertRaisesRegex(ManifestError, "unsupported release manifest schema"):
+            validate_manifest(
+                manifest_path=manifest_path,
+                tag="v2.1.0-guffa.8",
+                target_commit=TARGET_COMMIT,
+                repository=REPOSITORY,
+                artifact_root=self.artifact_root,
+                spec_path=self.spec_path,
+            )
+
+    def test_artifact_source_cannot_escape_root(self) -> None:
+        spec = json.loads(self.spec_path.read_text(encoding="utf-8"))
+        spec["artifacts"][0]["sourcePath"] = "../version.dll"
+        spec["artifacts"][0]["fileName"] = "version.dll"
+        self.spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+        with self.assertRaisesRegex(ManifestError, "safe relative path"):
+            self._build()
+
+    def test_empty_artifact_fails_closed(self) -> None:
+        self.mod.write_bytes(b"")
+        with self.assertRaisesRegex(ManifestError, "artifact source is empty"):
+            self._build()
+
+    def test_signed_archive_member_cannot_escape_extraction_root(self) -> None:
+        spec = json.loads(self.spec_path.read_text(encoding="utf-8"))
+        spec["artifacts"][1]["authenticity"]["signedFiles"] = ["../launcher.exe"]
+        self.spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+        with self.assertRaisesRegex(ManifestError, "safe relative paths"):
+            self._build()
+
+    def test_unknown_release_tag_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ManifestError, "supported release form"):
+            self._build("vnext")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- adds a deterministic Python generator and independent validator for `stfc-community-mod-release-manifest.json`
- derives release version and stable/preview channel from supported immutable tag forms
- records exact repository/commit provenance, minimum launcher version, artifact identity, media type, byte size, lowercase SHA-256, and per-artifact authenticity expectations
- adds a checked-in Windows artifact spec for direct `version.dll`, the existing Windows mod archive, and the self-contained launcher archive
- explicitly distinguishes direct Authenticode, Authenticode inside an archive, checksum integrity, and the currently unsigned JSON manifest
- validates unknown schema/tag forms, artifact tampering, empty files, path traversal, and unsafe signed-member paths with fail-closed fixture tests
- wires the fixture contract into normal CI and generation/revalidation into the tagged release workflow
- publishes the existing launcher ZIP and canonical manifest without removing or renaming any existing direct DLL, archive, DMG, or checksum asset
- documents channel, artifact-kind, withdrawal, offline, downgrade, and consumer failure semantics

## Why

The installer, updater, repair flow, and future launcher self-update all need one release-selection contract before they can safely download bytes. Handwritten sizes and checksums would drift, while treating a checksum as publisher authentication would overstate the current trust boundary.

WL-003 makes release metadata a derived artifact of the signed/package outputs. The workflow reconstructs the expected manifest during validation, so filename, size, digest, channel, source commit, repository, or policy drift fails the release before upload.

## Release and safety boundaries

- Windows PEs are signed and verified before packaging and hashing.
- `manifestAuthenticity.scheme` is deliberately `none`; schema v1 does not claim a detached signature or replay protection.
- Archive entries identify which extracted PE must pass Authenticode verification.
- Manifest paths are release asset base names, never arbitrary local paths or URLs.
- Unknown schema/tag/channel/artifact/platform combinations fail closed for install/update.
- Withdrawn releases are not newly offered; cached healthy installations are not silently removed.
- Network or manifest failure must not prevent launching an already healthy installation.
- Existing manual `version.dll` and archive distribution remains supported.

## Validation

- `py -3 -m unittest tests.test_generate_release_manifest -v` — 9/9 passed on Windows Python 3.12
- `python3 -m unittest tests.test_generate_release_manifest -v` — 9/9 passed under WSL/Linux Python 3.12
- `py -3 -m py_compile scripts/generate_release_manifest.py tests/test_generate_release_manifest.py` — passed
- `npx --yes yaml-lint .github/workflows/ci.yaml .github/workflows/release.yaml` — passed
- checked-in release spec fixture round-trip — passed for all three declared Windows artifacts
- `git diff --check` — passed

A real tagged release remains the manual acceptance gate because only that protected path can exercise OIDC signing, post-sign packaging, release creation, and final asset upload together.

Tracks #174. Blocks #175 and #180 until accepted.

Lex frame: `frame-1785138126495-e816a248-0387-4c76-88de-c154097cc219`