### PR TITLE
[WL-005] Generate shared launcher configuration schema

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,8 @@ jobs:
 
       - name: Test
         run: |
+          node --test scripts/test_config_schema.mjs
+          node scripts/generate_config_schema.mjs --check
           xmake build stfc-mod-tests
           xmake run stfc-mod-tests
 

--- a/docs/windows-launcher/CONFIG_SCHEMA.md
+++ b/docs/windows-launcher/CONFIG_SCHEMA.md
@@ -37,8 +37,10 @@ then delegates value-specific behavior to the matching adapter.
 
 - Ordinary runtime defaults and descriptions come from
   `mods/src/defaultconfig.h`. The public surface comes from the reference TOML,
-  while literal `get_config_or_default` reads in `Config::Load()` are scanned
-  as a release-drift guard.
+  while literal `get_config_or_default` reads and canonical custom-reader paths
+  are scanned as a release-drift guard. Hidden runtime settings remain in the
+  schema with `internal` or `experimental` stability so the player UI can omit
+  them without making provenance incomplete.
 - Input defaults come from `ActionSpecs()`. Legacy and deprecated
   `[shortcuts]` paths come from `ShortcutConfigAliases()`.
 - Notification names, legacy paths, sounds, and stability come from

--- a/docs/windows-launcher/CONFIG_SCHEMA.md
+++ b/docs/windows-launcher/CONFIG_SCHEMA.md
@@ -1,0 +1,80 @@
+# Launcher configuration schema
+
+`config-schema.guffawaffle.v1.json` is the generated launcher-facing contract
+for the Guffawaffle release stream. It is derived from the mod's runtime-owned
+C++ defaults and catalogs; do not edit it by hand.
+
+Generate or validate it from the repository root:
+
+```powershell
+node scripts/generate_config_schema.mjs
+node scripts/generate_config_schema.mjs --check
+node --test scripts/test_config_schema.mjs
+```
+
+CI runs both the fixture tests and the stale-artifact check before the C++ test
+suite.
+
+## One settings model, three adapters
+
+Every setting has the same launcher metadata envelope: canonical path, title,
+description, type, runtime default, platform support, apply behavior,
+sensitivity, stability, source support, aliases, and provenance.
+
+The `control` field selects one of three value adapters:
+
+- `scalar` for booleans, numbers, strings, enums, and dynamic sync-target
+  fields;
+- `keybinding` for values generated from the input action and compatibility
+  alias registries;
+- `notification-policy` for the boolean-or-inline-table notification union.
+
+These are not separate player-facing configuration systems. The launcher uses
+one search, category, validation, changed-state, and persistence experience,
+then delegates value-specific behavior to the matching adapter.
+
+## Authoritative producers
+
+- Ordinary runtime defaults and descriptions come from
+  `mods/src/defaultconfig.h`. The public surface comes from the reference TOML,
+  while literal `get_config_or_default` reads in `Config::Load()` are scanned
+  as a release-drift guard.
+- Input defaults come from `ActionSpecs()`. Legacy and deprecated
+  `[shortcuts]` paths come from `ShortcutConfigAliases()`.
+- Notification names, legacy paths, sounds, and stability come from
+  `notification_event_catalog()`. A canonical inline table replaces the whole
+  event policy; it never partially inherits a deprecated value.
+- Dynamic `sync.targets.*` fields are generated from `SyncOptions` and the
+  runtime sync defaults.
+
+The checked-in JSON is a build artifact, not another defaults catalog. A source
+change that alters the generated result must update the artifact in the same
+change.
+
+## Release source and persistence boundary
+
+The schema declares `source.id = "guffawaffle"`. It describes Guffawaffle
+artifacts only. A NetniV installation must use a NetniV-published schema or an
+explicit compatibility adapter; the launcher must not silently apply this
+schema to a different release source.
+
+Release-source selection belongs to launcher state, not the mod TOML. Switching
+sources is a migration transaction with compatibility preview, confirmation,
+backup, and rollback.
+
+TOML remains the current runtime and interchange boundary. Launcher writes are
+sparse and must preserve unknown keys and comments. A future richer
+Guffawaffle-only profile store may compile to this model, but it must retain
+deterministic TOML import/export while the C++ runtime consumes TOML and while
+NetniV compatibility is supported.
+
+## Sensitivity and provenance
+
+`sensitivity` is mandatory so diagnostics and support bundles can redact
+secrets and private endpoints/paths. `provenance.defaultSource` identifies the
+runtime catalog that supplied the default; `provenance.runtimePath` gives the
+corresponding runtime-vars location or wildcard template.
+
+Runtime provenance can add the effective value source (`default`, canonical
+TOML path, compatibility alias, or runtime override) without redefining any
+schema metadata.

--- a/docs/windows-launcher/CONTRACT.md
+++ b/docs/windows-launcher/CONTRACT.md
@@ -196,6 +196,11 @@ runtime remains the parser of record.
 The GUI editor operates against a generated, versioned configuration schema
 rather than duplicating defaults and descriptions by hand in C#.
 
+The settings experience is unified even when the schema delegates value
+handling to scalar, keybinding, and notification-policy adapters. Search,
+categories, changed-state, validation, and persistence behavior remain
+consistent across those control types.
+
 The schema must describe:
 
 - canonical key and section;
@@ -227,6 +232,23 @@ The UI must provide:
 - effective-value and restart-required indicators.
 
 Unknown keys and comments must survive normal edits.
+
+### Release source boundary
+
+The selected release source (`guffawaffle` parity+ or `netniv` upstream) is
+launcher state, not a mod TOML setting. It selects the release manifest,
+artifact trust policy, update stream, migration guidance, and matching
+configuration schema/capability adapter.
+
+Changing sources is a migration transaction. The launcher previews installed
+artifact and configuration compatibility, requires explicit confirmation, and
+retains backup and rollback guarantees. Automatic update never crosses release
+sources silently.
+
+TOML remains the runtime and interchange boundary for NetniV compatibility and
+safe source switching. A future Guffawaffle-only profile store may be richer,
+but it must compile/export deterministic sparse TOML while the C++ runtime
+consumes TOML.
 
 ## Launch contract
 

--- a/docs/windows-launcher/config-schema.guffawaffle.v1.json
+++ b/docs/windows-launcher/config-schema.guffawaffle.v1.json
@@ -22,6 +22,32 @@
   },
   "settings": [
     {
+      "path": "advanced.diagnostics.action_queue_guard_logging",
+      "title": "Action Queue Guard Logging",
+      "description": "Enable detailed action-queue guard breadcrumbs. Hidden opt-in; default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.action_queue_guard_logging",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.action_queue_guard_logging"
+      }
+    },
+    {
       "path": "advanced.diagnostics.battle_catalog",
       "title": "Battle Catalog",
       "description": "Configure battle catalog.",
@@ -312,6 +338,318 @@
       }
     },
     {
+      "path": "advanced.diagnostics.kirshara_queue.check_to_clear_action_queue",
+      "title": "Check To Clear Action Queue",
+      "description": "Configure check to clear action queue.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.check_to_clear_action_queue",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.check_to_clear_action_queue"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.dump_interesting_methods",
+      "title": "Dump Interesting Methods",
+      "description": "Dump current ActionQueueManager method metadata at boot. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.dump_interesting_methods",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.dump_interesting_methods"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.enabled",
+      "title": "Enabled",
+      "description": "Master gate for Kir'shara queue marker diagnostics. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.enabled",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.enabled"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.is_target_valid",
+      "title": "Is Target Valid",
+      "description": "Configure is target valid.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.is_target_valid",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.is_target_valid"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.on_fleet_state_change",
+      "title": "On Fleet State Change",
+      "description": "Configure on fleet state change.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.on_fleet_state_change",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.on_fleet_state_change"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.on_fleets_disposed",
+      "title": "On Fleets Disposed",
+      "description": "Configure on fleets disposed.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.on_fleets_disposed",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.on_fleets_disposed"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.on_player_fleet_state_changed",
+      "title": "On Player Fleet State Changed",
+      "description": "Configure on player fleet state changed.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.on_player_fleet_state_changed",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.on_player_fleet_state_changed"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.on_set_course_response",
+      "title": "On Set Course Response",
+      "description": "Configure on set course response.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.on_set_course_response",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.on_set_course_response"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.on_strike_complete",
+      "title": "On Strike Complete",
+      "description": "Configure on strike complete.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.on_strike_complete",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.on_strike_complete"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.process_queue_deployed",
+      "title": "Process Queue Deployed",
+      "description": "Configure process queue deployed.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.process_queue_deployed",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.process_queue_deployed"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.process_queue_target",
+      "title": "Process Queue Target",
+      "description": "Configure process queue target.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.process_queue_target",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.process_queue_target"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.kirshara_queue.remove_target_and_attack_next",
+      "title": "Remove Target And Attack Next",
+      "description": "Configure remove target and attack next.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.kirshara_queue.remove_target_and_attack_next",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.kirshara_queue.remove_target_and_attack_next"
+      }
+    },
+    {
       "path": "advanced.diagnostics.live_query",
       "title": "Live Query",
       "description": "Enable the live debug/query channel for AX and runtime inspection. Default: false.",
@@ -370,6 +708,32 @@
       }
     },
     {
+      "path": "advanced.diagnostics.mod_impact_monitor",
+      "title": "Mod Impact Monitor",
+      "description": "Enable periodic runtime impact summaries for frame-owned mod hooks. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.mod_impact_monitor",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.mod_impact_monitor"
+      }
+    },
+    {
       "path": "advanced.diagnostics.notification_skip_logging",
       "title": "Notification Skip Logging",
       "description": "Configure notification skip logging.",
@@ -422,6 +786,94 @@
       }
     },
     {
+      "path": "advanced.diagnostics.runtime_trace",
+      "title": "Runtime Trace",
+      "description": "Realtime runtime trace level: off, summary, detailed, or verbose. Any level above off adds runtime overhead.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "off",
+          "summary",
+          "detailed",
+          "verbose"
+        ]
+      },
+      "default": "off",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.runtime_trace",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.runtime_trace"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.runtime_trace_report_interval_ms",
+      "title": "Runtime Trace Report Interval Ms",
+      "description": "Runtime trace summary report interval in milliseconds. Lower intervals increase diagnostic log churn. Default: 5000.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "constraints": {
+        "minimum": 1000,
+        "maximum": 60000
+      },
+      "default": 5000,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.runtime_trace_report_interval_ms",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.runtime_trace_report_interval_ms"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.runtime_trace_track_overhead",
+      "title": "Runtime Trace Track Overhead",
+      "description": "Track runtime trace instrumentation overhead as a separate probe. Default: false for this private fork.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.runtime_trace_track_overhead",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.runtime_trace_track_overhead"
+      }
+    },
+    {
       "path": "advanced.diagnostics.ship_identity",
       "title": "Ship Identity",
       "description": "Reserved native observability toggles for future diagnostics and probes. Default: false.",
@@ -451,6 +903,110 @@
       "provenance": {
         "runtimePath": "advanced.diagnostics.ship_identity",
         "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.ship_identity"
+      }
+    },
+    {
+      "path": "advanced.kirshara_queue.course_target_completion",
+      "title": "Course Target Completion",
+      "description": "Synthesize the missing target completion commit for off-screen queued combat. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.kirshara_queue.course_target_completion",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.kirshara_queue.course_target_completion"
+      }
+    },
+    {
+      "path": "advanced.kirshara_queue.enabled",
+      "title": "Enabled",
+      "description": "Enable the focused Kir'shara queued-combat advancement repair. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.kirshara_queue.enabled",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.kirshara_queue.enabled"
+      }
+    },
+    {
+      "path": "advanced.queue.queue_add_direct_handler",
+      "title": "Queue Add Direct Handler",
+      "description": "Use the widget's direct queue-add handler instead of the generic button press path. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.queue.queue_add_direct_handler",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.queue.queue_add_direct_handler"
+      }
+    },
+    {
+      "path": "advanced.queue.queue_repair_enabled",
+      "title": "Queue Repair Enabled",
+      "description": "Master opt-in gate for queue repair/probe experiments. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.queue.queue_repair_enabled",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.queue.queue_repair_enabled"
       }
     },
     {
@@ -607,6 +1163,32 @@
       "provenance": {
         "runtimePath": "config.settings_url",
         "defaultSource": "mods/src/defaultconfig.h:config.settings_url"
+      }
+    },
+    {
+      "path": "control.allow_key_fallthrough",
+      "title": "Allow Key Fallthrough",
+      "description": "Allow unhandled key frames to fall through to the original game input path.",
+      "category": "control",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "control.allow_key_fallthrough",
+        "defaultSource": "mods/src/config_metadata.h:control.allow_key_fallthrough"
       }
     },
     {
@@ -11071,6 +11653,9 @@
       "valueType": {
         "kind": "integer"
       },
+      "constraints": {
+        "minimum": 0
+      },
       "default": 300,
       "platforms": [
         "windows",
@@ -11096,6 +11681,9 @@
       "control": "scalar",
       "valueType": {
         "kind": "integer"
+      },
+      "constraints": {
+        "minimum": 0
       },
       "default": 30,
       "platforms": [

--- a/docs/windows-launcher/config-schema.guffawaffle.v1.json
+++ b/docs/windows-launcher/config-schema.guffawaffle.v1.json
@@ -1,0 +1,13213 @@
+{
+  "schemaVersion": "1.0.0",
+  "schemaId": "stfc-community-mod.config-schema",
+  "source": {
+    "id": "guffawaffle",
+    "repository": "Guffawaffle/stfc-mod",
+    "persistence": {
+      "runtimeFormat": "toml",
+      "writeMode": "sparse",
+      "authority": "mod-runtime-parser"
+    }
+  },
+  "contract": {
+    "aliasPrecedence": "canonical-wins",
+    "invalidScalarBehavior": "warn-and-use-runtime-default",
+    "unknownKeyBehavior": "preserve",
+    "supportedAdapters": [
+      "scalar",
+      "keybinding",
+      "notification-policy"
+    ]
+  },
+  "settings": [
+    {
+      "path": "advanced.diagnostics.battle_catalog",
+      "title": "Battle Catalog",
+      "description": "Configure battle catalog.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "sidecar.probes.battle_catalog",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.battle_catalog",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.battle_catalog"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.battle_log_decoder",
+      "title": "Battle Log Decoder",
+      "description": "Configure battle log decoder.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "sidecar.probes.battle_log_decoder",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.battle_log_decoder",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.battle_log_decoder"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.debug",
+      "title": "Debug",
+      "description": "Configure debug.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "sidecar.diagnostics.debug",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.debug",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.debug"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.files.action_queue_probe_files",
+      "title": "Action Queue Probe Files",
+      "description": "Configure action queue probe files.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "constraints": {
+        "minimum": 1
+      },
+      "default": 3,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.files.action_queue_probe_files",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.files.action_queue_probe_files"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.files.action_queue_probe_max_kb",
+      "title": "Action Queue Probe Max Kb",
+      "description": "Total number of action queue probe files to keep, including the active file. Default: 3.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "constraints": {
+        "minimum": 1
+      },
+      "default": 8192,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.files.action_queue_probe_max_kb",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.files.action_queue_probe_max_kb"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.files.navhook_trace_files",
+      "title": "Navhook Trace Files",
+      "description": "Configure navhook trace files.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "constraints": {
+        "minimum": 1
+      },
+      "default": 3,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.files.navhook_trace_files",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.files.navhook_trace_files"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.files.navhook_trace_max_kb",
+      "title": "Navhook Trace Max Kb",
+      "description": "Total number of navhook trace files to keep, including the active file. Default: 3.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "constraints": {
+        "minimum": 1
+      },
+      "default": 4096,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.files.navhook_trace_max_kb",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.files.navhook_trace_max_kb"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.files.root",
+      "title": "Root",
+      "description": "Optional root directory for heavy native diagnostics outputs. Empty preserves current locations.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.files.root",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.files.root"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.fleet_selection_timing_logging",
+      "title": "Fleet Selection Timing Logging",
+      "description": "Configure fleet selection timing logging.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.fleet_selection_timing_logging",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.fleet_selection_timing_logging"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.hotkey_suppression_logging",
+      "title": "Hotkey Suppression Logging",
+      "description": "Verbose breadcrumbs for noisy diagnostics. These remain off by default even when advanced.diagnostics.debug is enabled.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.hotkey_suppression_logging",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.hotkey_suppression_logging"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.live_query",
+      "title": "Live Query",
+      "description": "Enable the live debug/query channel for AX and runtime inspection. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.live_query",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.live_query"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.logging",
+      "title": "Logging",
+      "description": "Configure logging.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "sidecar.diagnostics.logging",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.logging",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.logging"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.notification_skip_logging",
+      "title": "Notification Skip Logging",
+      "description": "Configure notification skip logging.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.notification_skip_logging",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.notification_skip_logging"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.refinery_diagnostics",
+      "title": "Refinery Diagnostics",
+      "description": "Enable focused refinery lifecycle/action diagnostics in community_patch.log. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.refinery_diagnostics",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.refinery_diagnostics"
+      }
+    },
+    {
+      "path": "advanced.diagnostics.ship_identity",
+      "title": "Ship Identity",
+      "description": "Reserved native observability toggles for future diagnostics and probes. Default: false.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "sidecar.probes.ship_identity",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.ship_identity",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.ship_identity"
+      }
+    },
+    {
+      "path": "advanced.queue.thin_queue_protection",
+      "title": "Thin Queue Protection",
+      "description": "Recover an authoritative externally destroyed target only when it remains the exact idle head. Default: true.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.queue.thin_queue_protection",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.queue.thin_queue_protection"
+      }
+    },
+    {
+      "path": "battle_log_decoder.emit_feed",
+      "title": "Emit Feed",
+      "description": "Emit sidecar-ready battle report feed events when the decoder is enabled. Default: true.",
+      "category": "battle_log_decoder",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "battle_log_decoder.emit_feed",
+        "defaultSource": "mods/src/defaultconfig.h:battle_log_decoder.emit_feed"
+      }
+    },
+    {
+      "path": "battle_log_decoder.emit_segments",
+      "title": "Emit Segments",
+      "description": "Emit decoded segment summaries when the decoder is enabled. Default: true.",
+      "category": "battle_log_decoder",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "battle_log_decoder.emit_segments",
+        "defaultSource": "mods/src/defaultconfig.h:battle_log_decoder.emit_segments"
+      }
+    },
+    {
+      "path": "buffs.use_out_of_dock_power",
+      "title": "Use Out Of Dock Power",
+      "description": "Apply out-of-dock power buffs even when the ship is undocked. Default: true.",
+      "category": "buffs",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "buffs.use_out_of_dock_power",
+        "defaultSource": "mods/src/defaultconfig.h:buffs.use_out_of_dock_power"
+      }
+    },
+    {
+      "path": "config.assets_url_override",
+      "title": "Assets URL Override",
+      "description": "Override URL for downloading remote asset bundles (empty = use game default).",
+      "category": "config",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "config.assets_url_override",
+        "defaultSource": "mods/src/defaultconfig.h:config.assets_url_override"
+      }
+    },
+    {
+      "path": "config.settings_url",
+      "title": "Settings URL",
+      "description": "URL for fetching remote settings updates (empty = disabled).",
+      "category": "config",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "config.settings_url",
+        "defaultSource": "mods/src/defaultconfig.h:config.settings_url"
+      }
+    },
+    {
+      "path": "control.enable_experimental",
+      "title": "Enable Experimental",
+      "description": "Enable experimental/unstable features (e.g. pan-momentum, WASD move keys). Default: false.",
+      "category": "control",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "control.enable_experimental",
+        "defaultSource": "mods/src/defaultconfig.h:control.enable_experimental"
+      }
+    },
+    {
+      "path": "control.hotkeys_enabled",
+      "title": "Hotkeys Enabled",
+      "description": "Master toggle for keyboard hotkeys. Default: true.",
+      "category": "control",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "control.hotkeys_enabled",
+        "defaultSource": "mods/src/defaultconfig.h:control.hotkeys_enabled"
+      }
+    },
+    {
+      "path": "control.hotkeys_extended",
+      "title": "Hotkeys Extended",
+      "description": "Enable the extended hotkey set (bookmarks, cargo toggles, etc.). Default: true.",
+      "category": "control",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "control.hotkeys_extended",
+        "defaultSource": "mods/src/defaultconfig.h:control.hotkeys_extended"
+      }
+    },
+    {
+      "path": "control.queue_enabled",
+      "title": "Queue Enabled",
+      "description": "Enable the action queue system. Default: true.",
+      "category": "control",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "control.queue_enabled",
+        "defaultSource": "mods/src/defaultconfig.h:control.queue_enabled"
+      }
+    },
+    {
+      "path": "control.select_timer",
+      "title": "Select Timer",
+      "description": "Delay in ms before a tap is registered as a select action. Default: 500.",
+      "category": "control",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 500,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "control.select_timer",
+        "defaultSource": "mods/src/defaultconfig.h:control.select_timer"
+      }
+    },
+    {
+      "path": "control.use_scopely_hotkeys",
+      "title": "Use Scopely Hotkeys",
+      "description": "When true, use Scopely's built-in hotkey layer instead of the mod's. Default: false.",
+      "category": "control",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "control.use_scopely_hotkeys",
+        "defaultSource": "mods/src/defaultconfig.h:control.use_scopely_hotkeys"
+      }
+    },
+    {
+      "path": "graphics.allow_cursor",
+      "title": "Allow Cursor",
+      "description": "Show the OS cursor instead of hiding it. Default: true.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.allow_cursor",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.allow_cursor"
+      }
+    },
+    {
+      "path": "graphics.borderless_fullscreen",
+      "title": "Borderless Fullscreen",
+      "description": "Start in borderless-fullscreen mode. Default: true.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.borderless_fullscreen",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.borderless_fullscreen"
+      }
+    },
+    {
+      "path": "graphics.default_system_zoom",
+      "title": "Default System Zoom",
+      "description": "Default system-view zoom level (game units). Default: 1750.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 1750,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.default_system_zoom",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.default_system_zoom"
+      }
+    },
+    {
+      "path": "graphics.fr_scale",
+      "title": "Fr Scale",
+      "description": "Scale the system backdrop to hide edge void at extreme zoom. 1.0 = off. Default: 2.0.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 2,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.fr_scale",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.fr_scale"
+      }
+    },
+    {
+      "path": "graphics.free_resize",
+      "title": "Free Resize",
+      "description": "Allow free window resizing (not locked to 16:9). Default: true.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.free_resize",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.free_resize"
+      }
+    },
+    {
+      "path": "graphics.keyboard_zoom_speed",
+      "title": "Keyboard Zoom Speed",
+      "description": "Speed of keyboard-driven zoom (game units/s). Default: 350.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 350,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.keyboard_zoom_speed",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.keyboard_zoom_speed"
+      }
+    },
+    {
+      "path": "graphics.loader_enabled",
+      "title": "Loader Enabled",
+      "description": "Replace LoginSequence background. Default: true.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.loader_enabled",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.loader_enabled"
+      }
+    },
+    {
+      "path": "graphics.loader_image",
+      "title": "Loader Image",
+      "description": "Optional custom loading image path (empty = embedded fallback). Default: empty.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.loader_image",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.loader_image"
+      }
+    },
+    {
+      "path": "graphics.loader_logo_scale",
+      "title": "Loader Logo Scale",
+      "description": "Scale multiplier for loading-screen logos. Default: 1.0.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 1,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.loader_logo_scale",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.loader_logo_scale"
+      }
+    },
+    {
+      "path": "graphics.loader_tip_enabled",
+      "title": "Loader Tip Enabled",
+      "description": "Show community loading tips. Default: true.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.loader_tip_enabled",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.loader_tip_enabled"
+      }
+    },
+    {
+      "path": "graphics.loader_transition",
+      "title": "Loader Transition",
+      "description": "Replace TVC/SlideShow backgrounds. Default: true.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.loader_transition",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.loader_transition"
+      }
+    },
+    {
+      "path": "graphics.loader_transition_black",
+      "title": "Loader Transition Black",
+      "description": "Use the game's black transition background instead of the custom image. Default: false.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.loader_transition_black",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.loader_transition_black"
+      }
+    },
+    {
+      "path": "graphics.show_all_resolutions",
+      "title": "Show All Resolutions",
+      "description": "Expose all display resolutions, not just 16:9. Default: false.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.show_all_resolutions",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.show_all_resolutions"
+      }
+    },
+    {
+      "path": "graphics.system_pan_momentum",
+      "title": "System Pan Momentum",
+      "description": "Initial pan-momentum strength (0–1). Default: 0.4. Requires enable_experimental.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "number"
+      },
+      "default": 0.4,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.system_pan_momentum",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.system_pan_momentum"
+      }
+    },
+    {
+      "path": "graphics.system_pan_momentum_falloff",
+      "title": "System Pan Momentum Falloff",
+      "description": "Momentum decay rate for system-view panning (0–1, higher = slower decay). Default: 0.8.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "number"
+      },
+      "default": 0.8,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.system_pan_momentum_falloff",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.system_pan_momentum_falloff"
+      }
+    },
+    {
+      "path": "graphics.system_zoom_preset_1",
+      "title": "System Zoom Preset 1",
+      "description": "Zoom preset levels 1–5 (game units, low = close, high = far). Defaults: 50–5000.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 50,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.system_zoom_preset_1",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.system_zoom_preset_1"
+      }
+    },
+    {
+      "path": "graphics.system_zoom_preset_2",
+      "title": "System Zoom Preset 2",
+      "description": "Zoom preset F2 for system view",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 500,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.system_zoom_preset_2",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.system_zoom_preset_2"
+      }
+    },
+    {
+      "path": "graphics.system_zoom_preset_3",
+      "title": "System Zoom Preset 3",
+      "description": "Zoom preset F3 for system view",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 1250,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.system_zoom_preset_3",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.system_zoom_preset_3"
+      }
+    },
+    {
+      "path": "graphics.system_zoom_preset_4",
+      "title": "System Zoom Preset 4",
+      "description": "Zoom preset F4 for system view",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 2750,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.system_zoom_preset_4",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.system_zoom_preset_4"
+      }
+    },
+    {
+      "path": "graphics.system_zoom_preset_5",
+      "title": "System Zoom Preset 5",
+      "description": "Zoom preset F5 for system view",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 5000,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.system_zoom_preset_5",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.system_zoom_preset_5"
+      }
+    },
+    {
+      "path": "graphics.transition_time",
+      "title": "Transition Time",
+      "description": "Camera transition duration in seconds. Default: 0.01 (near-instant).",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "number"
+      },
+      "default": 0.01,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.transition_time",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.transition_time"
+      }
+    },
+    {
+      "path": "graphics.ui_scale",
+      "title": "UI Scale",
+      "description": "Base UI scale multiplier. Default: 0.6.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "number"
+      },
+      "default": 0.6,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.ui_scale",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.ui_scale"
+      }
+    },
+    {
+      "path": "graphics.ui_scale_adjust",
+      "title": "UI Scale Adjust",
+      "description": "Step size for PgUp/PgDown UI scale adjustment. Default: 0.05.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "number"
+      },
+      "default": 0.05,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.ui_scale_adjust",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.ui_scale_adjust"
+      }
+    },
+    {
+      "path": "graphics.ui_scale_viewer",
+      "title": "UI Scale Viewer",
+      "description": "Scale multiplier for the object-viewer panel. Default: 1.2.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "number"
+      },
+      "default": 1.2,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.ui_scale_viewer",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.ui_scale_viewer"
+      }
+    },
+    {
+      "path": "graphics.use_presets_as_default",
+      "title": "Use Presets As Default",
+      "description": "Use zoom presets as the initial zoom on system entry. Default: true.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.use_presets_as_default",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.use_presets_as_default"
+      }
+    },
+    {
+      "path": "graphics.zoom",
+      "title": "Zoom",
+      "description": "Maximum camera zoom distance (game units). Default: 5000.",
+      "category": "graphics",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 5000,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "graphics.zoom",
+        "defaultSource": "mods/src/defaultconfig.h:graphics.zoom"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_primary",
+      "title": "Fleet Primary",
+      "description": "Keyboard or mouse binding for fleet primary.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SPACE|MOUSE1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_primary",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_primary",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_queue_add",
+      "title": "Fleet Queue Add",
+      "description": "Keyboard or mouse binding for fleet queue add.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SPACE|MOUSE1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_queue",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_queue_add",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_queue_clear",
+      "title": "Fleet Queue Clear",
+      "description": "Keyboard or mouse binding for fleet queue clear.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-C",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_queue_clear",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_queue_clear",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_queue_toggle",
+      "title": "Fleet Queue Toggle",
+      "description": "Keyboard or mouse binding for fleet queue toggle.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-Q",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_queue",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_queue_toggle",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_recall",
+      "title": "Fleet Recall",
+      "description": "Keyboard or mouse binding for fleet recall.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "R|MOUSE3",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_recall",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_recall",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_recall_cancel",
+      "title": "Fleet Recall Cancel",
+      "description": "Keyboard or mouse binding for fleet recall cancel.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SPACE|MOUSE1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_recall_cancel",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_recall_cancel",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_repair",
+      "title": "Fleet Repair",
+      "description": "Keyboard or mouse binding for fleet repair.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "R|MOUSE3",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_repair",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_repair",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_secondary",
+      "title": "Fleet Secondary",
+      "description": "Keyboard or mouse binding for fleet secondary.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "TAB|MOUSE4",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_secondary",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_secondary",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_service",
+      "title": "Fleet Service",
+      "description": "Keyboard or mouse binding for fleet service.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "NONE",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_service",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.fleet_view_info",
+      "title": "Fleet View Info",
+      "description": "Keyboard or mouse binding for fleet view info.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "V|MOUSE2",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.action_view",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.fleet_view_info",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.focus_search",
+      "title": "Focus Search",
+      "description": "Keyboard or mouse binding for focus search.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-F",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.focus_search",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.focus_search",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.hotkeys_disable",
+      "title": "Hotkeys Disable",
+      "description": "Keyboard or mouse binding for hotkeys disable.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-ALT-MINUS",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_hotkeys_disable",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        },
+        {
+          "path": "shortcuts.set_hotkeys_disble",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        },
+        {
+          "path": "shortcuts.set_hotkeys_disabled",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.hotkeys_disable",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.hotkeys_enable",
+      "title": "Hotkeys Enable",
+      "description": "Keyboard or mouse binding for hotkeys enable.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-ALT-=",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_hotkeys_enable",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        },
+        {
+          "path": "shortcuts.set_hotkeys_enabled",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.hotkeys_enable",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.log_debug",
+      "title": "Log Debug",
+      "description": "Keyboard or mouse binding for log debug.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-SHIFT-F9",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.log_debug",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.log_debug",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.log_error",
+      "title": "Log Error",
+      "description": "Keyboard or mouse binding for log error.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-SHIFT-F11",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.log_error",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.log_error",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.log_info",
+      "title": "Log Info",
+      "description": "Keyboard or mouse binding for log info.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-SHIFT-F8",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.log_info",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.log_info",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.log_off",
+      "title": "Log Off",
+      "description": "Keyboard or mouse binding for log off.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-SHIFT-F12",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.log_off",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.log_off",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.log_trace",
+      "title": "Log Trace",
+      "description": "Keyboard or mouse binding for log trace.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-SHIFT-F7",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.log_trace",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.log_trace",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.log_warn",
+      "title": "Log Warn",
+      "description": "Keyboard or mouse binding for log warn.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-SHIFT-F10",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.log_warn",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.log_warn",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.move_left",
+      "title": "Move Left",
+      "description": "Keyboard or mouse binding for move left.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "LEFT",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.move_left",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.move_left",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.move_right",
+      "title": "Move Right",
+      "description": "Keyboard or mouse binding for move right.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "RIGHT",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.move_right",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.move_right",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.quit",
+      "title": "Quit",
+      "description": "Keyboard or mouse binding for quit.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "F10",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.quit",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.quit",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_chatalliance",
+      "title": "Select Chatalliance",
+      "description": "Keyboard or mouse binding for select chatalliance.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-2",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_chatalliance",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_chatalliance",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_chatglobal",
+      "title": "Select Chatglobal",
+      "description": "Keyboard or mouse binding for select chatglobal.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_chatglobal",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_chatglobal",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_chatprivate",
+      "title": "Select Chatprivate",
+      "description": "Keyboard or mouse binding for select chatprivate.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-3",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_chatprivate",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_chatprivate",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_current",
+      "title": "Select Current",
+      "description": "Keyboard or mouse binding for select current.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-SPACE",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_current",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_current",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship1",
+      "title": "Select Ship1",
+      "description": "Keyboard or mouse binding for select ship1.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship1",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship1",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship2",
+      "title": "Select Ship2",
+      "description": "Keyboard or mouse binding for select ship2.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "2",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship2",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship2",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship3",
+      "title": "Select Ship3",
+      "description": "Keyboard or mouse binding for select ship3.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "3",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship3",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship3",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship4",
+      "title": "Select Ship4",
+      "description": "Keyboard or mouse binding for select ship4.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "4",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship4",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship4",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship5",
+      "title": "Select Ship5",
+      "description": "Keyboard or mouse binding for select ship5.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "5",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship5",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship5",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship6",
+      "title": "Select Ship6",
+      "description": "Keyboard or mouse binding for select ship6.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "6",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship6",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship6",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship7",
+      "title": "Select Ship7",
+      "description": "Keyboard or mouse binding for select ship7.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "7",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship7",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship7",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.select_ship8",
+      "title": "Select Ship8",
+      "description": "Keyboard or mouse binding for select ship8.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "8",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.select_ship8",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.select_ship8",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.set_zoom_default",
+      "title": "Set Zoom Default",
+      "description": "Keyboard or mouse binding for set zoom default.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-=",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_zoom_default",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.set_zoom_default",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.set_zoom_preset1",
+      "title": "Set Zoom Preset1",
+      "description": "Keyboard or mouse binding for set zoom preset1.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-F1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_zoom_preset1",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.set_zoom_preset1",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.set_zoom_preset2",
+      "title": "Set Zoom Preset2",
+      "description": "Keyboard or mouse binding for set zoom preset2.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-F2",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_zoom_preset2",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.set_zoom_preset2",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.set_zoom_preset3",
+      "title": "Set Zoom Preset3",
+      "description": "Keyboard or mouse binding for set zoom preset3.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-F3",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_zoom_preset3",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.set_zoom_preset3",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.set_zoom_preset4",
+      "title": "Set Zoom Preset4",
+      "description": "Keyboard or mouse binding for set zoom preset4.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-F4",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_zoom_preset4",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.set_zoom_preset4",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.set_zoom_preset5",
+      "title": "Set Zoom Preset5",
+      "description": "Keyboard or mouse binding for set zoom preset5.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-F5",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.set_zoom_preset5",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.set_zoom_preset5",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_alliance",
+      "title": "Show Alliance",
+      "description": "Keyboard or mouse binding for show alliance.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "ALT-'",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_alliance",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_alliance",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_alliance_armada",
+      "title": "Show Alliance Armada",
+      "description": "Keyboard or mouse binding for show alliance armada.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-'",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_alliance_armada",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_alliance_armada",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_alliance_help",
+      "title": "Show Alliance Help",
+      "description": "Keyboard or mouse binding for show alliance help.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-'",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_alliance_help",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_alliance_help",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_artifacts",
+      "title": "Show Artifacts",
+      "description": "Keyboard or mouse binding for show artifacts.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-I",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_artifacts",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_artifacts",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_awayteam",
+      "title": "Show Awayteam",
+      "description": "Keyboard or mouse binding for show awayteam.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "T",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_awayteam",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_awayteam",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_bookmarks",
+      "title": "Show Bookmarks",
+      "description": "Keyboard or mouse binding for show bookmarks.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "B",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_bookmarks",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_bookmarks",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_chat",
+      "title": "Show Chat",
+      "description": "Keyboard or mouse binding for show chat.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "C",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_chat",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_chat",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_chatside1",
+      "title": "Show Chatside1",
+      "description": "Keyboard or mouse binding for show chatside1.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "ALT-C",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_chatside1",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_chatside1",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_chatside2",
+      "title": "Show Chatside2",
+      "description": "Keyboard or mouse binding for show chatside2.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "`",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_chatside2",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_chatside2",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_commander",
+      "title": "Show Commander",
+      "description": "Keyboard or mouse binding for show commander.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "O",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_commander",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_commander",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_daily",
+      "title": "Show Daily",
+      "description": "Keyboard or mouse binding for show daily.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "Z",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_daily",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_daily",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_events",
+      "title": "Show Events",
+      "description": "Keyboard or mouse binding for show events.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-E",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_events",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_events",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_exocomp",
+      "title": "Show Exocomp",
+      "description": "Keyboard or mouse binding for show exocomp.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "X",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_exocomp",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_exocomp",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_factions",
+      "title": "Show Factions",
+      "description": "Keyboard or mouse binding for show factions.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "F",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_factions",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_factions",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_galaxy",
+      "title": "Show Galaxy",
+      "description": "Keyboard or mouse binding for show galaxy.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "G",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_galaxy",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_galaxy",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_gifts",
+      "title": "Show Gifts",
+      "description": "Keyboard or mouse binding for show gifts.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "/",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_gifts",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_gifts",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_inventory",
+      "title": "Show Inventory",
+      "description": "Keyboard or mouse binding for show inventory.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "I",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_inventory",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_inventory",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_lookup",
+      "title": "Show Lookup",
+      "description": "Keyboard or mouse binding for show lookup.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "L",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_lookup",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_lookup",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_missions",
+      "title": "Show Missions",
+      "description": "Keyboard or mouse binding for show missions.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "M",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_missions",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_missions",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_officers",
+      "title": "Show Officers",
+      "description": "Keyboard or mouse binding for show officers.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-O",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_officers",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_officers",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_qtrials",
+      "title": "Show Qtrials",
+      "description": "Keyboard or mouse binding for show qtrials.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-Q",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_qtrials",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_qtrials",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_refinery",
+      "title": "Show Refinery",
+      "description": "Keyboard or mouse binding for show refinery.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-F",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_refinery",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_refinery",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_research",
+      "title": "Show Research",
+      "description": "Keyboard or mouse binding for show research.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "U",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_research",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_research",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_scrapyard",
+      "title": "Show Scrapyard",
+      "description": "Keyboard or mouse binding for show scrapyard.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "Y",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_scrapyard",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_scrapyard",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_settings",
+      "title": "Show Settings",
+      "description": "Keyboard or mouse binding for show settings.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-S",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_settings",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_settings",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_ships",
+      "title": "Show Ships",
+      "description": "Keyboard or mouse binding for show ships.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "N",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_ships",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_ships",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_stationexterior",
+      "title": "Show Stationexterior",
+      "description": "Keyboard or mouse binding for show stationexterior.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-G",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_stationexterior",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_stationexterior",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_stationinterior",
+      "title": "Show Stationinterior",
+      "description": "Keyboard or mouse binding for show stationinterior.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-H",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_stationinterior",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_stationinterior",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.show_system",
+      "title": "Show System",
+      "description": "Keyboard or mouse binding for show system.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "H",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.show_system",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.show_system",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.toggle_cargo_armada",
+      "title": "Toggle Cargo Armada",
+      "description": "Keyboard or mouse binding for toggle cargo armada.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "ALT-5",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_cargo_armada",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.toggle_cargo_armada",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.toggle_cargo_default",
+      "title": "Toggle Cargo Default",
+      "description": "Keyboard or mouse binding for toggle cargo default.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "ALT-1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_cargo_default",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.toggle_cargo_default",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.toggle_cargo_hostile",
+      "title": "Toggle Cargo Hostile",
+      "description": "Keyboard or mouse binding for toggle cargo hostile.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "ALT-4",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_cargo_hostile",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.toggle_cargo_hostile",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.toggle_cargo_player",
+      "title": "Toggle Cargo Player",
+      "description": "Keyboard or mouse binding for toggle cargo player.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "ALT-2",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_cargo_player",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.toggle_cargo_player",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.toggle_cargo_station",
+      "title": "Toggle Cargo Station",
+      "description": "Keyboard or mouse binding for toggle cargo station.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "ALT-3",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_cargo_station",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.toggle_cargo_station",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.toggle_preview_locate",
+      "title": "Toggle Preview Locate",
+      "description": "Keyboard or mouse binding for toggle preview locate.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-R",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_preview_locate",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.toggle_preview_locate",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.toggle_preview_recall",
+      "title": "Toggle Preview Recall",
+      "description": "Keyboard or mouse binding for toggle preview recall.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "CTRL-T",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.toggle_preview_recall",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.toggle_preview_recall",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.ui_scale_down",
+      "title": "UI Scale Down",
+      "description": "Keyboard or mouse binding for ui scale down.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "PGDOWN",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.ui_scaledown",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.ui_scale_down",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.ui_scale_up",
+      "title": "UI Scale Up",
+      "description": "Keyboard or mouse binding for ui scale up.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "PGUP",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.ui_scaleup",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.ui_scale_up",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.ui_viewer_scale_down",
+      "title": "UI Viewer Scale Down",
+      "description": "Keyboard or mouse binding for ui viewer scale down.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-PGDOWN",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.ui_scaleviewerdown",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.ui_viewer_scale_down",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.ui_viewer_scale_up",
+      "title": "UI Viewer Scale Up",
+      "description": "Keyboard or mouse binding for ui viewer scale up.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "SHIFT-PGUP",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.ui_scaleviewerup",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.ui_viewer_scale_up",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_in",
+      "title": "Zoom In",
+      "description": "Keyboard or mouse binding for zoom in.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "Q",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_in",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_in",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_max",
+      "title": "Zoom Max",
+      "description": "Keyboard or mouse binding for zoom max.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "MINUS",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_max",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_max",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_min",
+      "title": "Zoom Min",
+      "description": "Keyboard or mouse binding for zoom min.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "BACKSPACE",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_min",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_min",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_out",
+      "title": "Zoom Out",
+      "description": "Keyboard or mouse binding for zoom out.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "E",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_out",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_out",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_preset1",
+      "title": "Zoom Preset1",
+      "description": "Keyboard or mouse binding for zoom preset1.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "F1",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_preset1",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_preset1",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_preset2",
+      "title": "Zoom Preset2",
+      "description": "Keyboard or mouse binding for zoom preset2.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "F2",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_preset2",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_preset2",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_preset3",
+      "title": "Zoom Preset3",
+      "description": "Keyboard or mouse binding for zoom preset3.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "F3",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_preset3",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_preset3",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_preset4",
+      "title": "Zoom Preset4",
+      "description": "Keyboard or mouse binding for zoom preset4.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "F4",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_preset4",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_preset4",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_preset5",
+      "title": "Zoom Preset5",
+      "description": "Keyboard or mouse binding for zoom preset5.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "F5",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_preset5",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_preset5",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.bindings.zoom_reset",
+      "title": "Zoom Reset",
+      "description": "Keyboard or mouse binding for zoom reset.",
+      "category": "input",
+      "control": "keybinding",
+      "valueType": {
+        "kind": "keybinding"
+      },
+      "default": "=",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "shortcuts.zoom_reset",
+          "status": "compatibility",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.bindings.zoom_reset",
+        "defaultSource": "input-action-registry"
+      }
+    },
+    {
+      "path": "input.original_frame_policy",
+      "title": "Original Frame Policy",
+      "description": "Explicit original frame policy: mod, fallthrough_unhandled, fallthrough_all.",
+      "category": "input",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "mod",
+          "fallthrough_unhandled",
+          "fallthrough_all"
+        ]
+      },
+      "default": "mod",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "control.original_frame_policy",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "input.original_frame_policy",
+        "defaultSource": "mods/src/defaultconfig.h:control.original_frame_policy"
+      }
+    },
+    {
+      "path": "input.scopely_shortcuts",
+      "title": "Scopely Shortcuts",
+      "description": "Explicit Scopely shortcut initialization policy: off, native, fallback.",
+      "category": "input",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "off",
+          "native",
+          "fallback"
+        ]
+      },
+      "default": "off",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "input.scopely_shortcuts",
+        "defaultSource": "mods/src/defaultconfig.h:control.scopely_shortcuts"
+      }
+    },
+    {
+      "path": "notifications.abandoned_territory",
+      "title": "Abandoned Territory",
+      "description": "Configure system and audio delivery for the experimental.abandoned_territory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.abandoned_territory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.abandoned_territory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.abandoned_territory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_abandoned_territory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.abandoned_territory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.achievement",
+      "title": "Achievement",
+      "description": "Configure system and audio delivery for the experimental.achievement event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.achievement",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.achievement",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.achievement",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_achievement",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.achievement",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.arena_time_left",
+      "title": "Arena Time Left",
+      "description": "Configure system and audio delivery for the experimental.arena_time_left event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.arena_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.arena_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.arena_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_arena_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.arena_time_left",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.armada_battle_lost",
+      "title": "Armada Battle Lost",
+      "description": "Configure system and audio delivery for the battle.armada_battle_lost event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.armada_battle_lost",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.armada_battle_lost",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.armada_battle_lost",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_armada_battle_lost",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.armada_battle_lost",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.armada_battle_won",
+      "title": "Armada Battle Won",
+      "description": "Configure system and audio delivery for the battle.armada_battle_won event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.armada_battle_won",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.armada_battle_won",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.armada_battle_won",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_armada_battle_won",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.armada_battle_won",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.armada_canceled",
+      "title": "Armada Canceled",
+      "description": "Configure system and audio delivery for the armada.canceled event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "soft"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "soft"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.armada.canceled",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.armada.canceled",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.armada.canceled",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_armada_canceled",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.armada_canceled",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.armada_created",
+      "title": "Armada Created",
+      "description": "Configure system and audio delivery for the armada.created event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.armada.created",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.armada.created",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.armada.created",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_armada_created",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.armada_created",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.armada_incoming_attack",
+      "title": "Armada Incoming Attack",
+      "description": "Configure system and audio delivery for the experimental.armada_incoming_attack event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "alarm"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "alarm"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.armada_incoming_attack",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.armada_incoming_attack",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.armada_incoming_attack",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_armada_incoming_attack",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.armada_incoming_attack",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.armada_player_blocked",
+      "title": "Armada Player Blocked",
+      "description": "Configure system and audio delivery for the experimental.armada_player_blocked event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.armada_player_blocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.armada_player_blocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.armada_player_blocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_armada_player_blocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.armada_player_blocked",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.armada_player_unblocked",
+      "title": "Armada Player Unblocked",
+      "description": "Configure system and audio delivery for the experimental.armada_player_unblocked event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.armada_player_unblocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.armada_player_unblocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.armada_player_unblocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_armada_player_unblocked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.armada_player_unblocked",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.assault_defeat",
+      "title": "Assault Defeat",
+      "description": "Configure system and audio delivery for the battle.assault_defeat event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.assault_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.assault_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.assault_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_assault_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.assault_defeat",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.assault_victory",
+      "title": "Assault Victory",
+      "description": "Configure system and audio delivery for the battle.assault_victory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.assault_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.assault_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.assault_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_assault_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.assault_victory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.chained_event_scored",
+      "title": "Chained Event Scored",
+      "description": "Configure system and audio delivery for the event.chained_event_scored event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "ping"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "ping"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.event.chained_event_scored",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.event.chained_event_scored",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.event.chained_event_scored",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_chained_event_scored",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.chained_event_scored",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.challenge_complete",
+      "title": "Challenge Complete",
+      "description": "Configure system and audio delivery for the experimental.challenge_complete event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.challenge_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.challenge_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.challenge_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_challenge_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.challenge_complete",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.challenge_failed",
+      "title": "Challenge Failed",
+      "description": "Configure system and audio delivery for the experimental.challenge_failed event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.challenge_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.challenge_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.challenge_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_challenge_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.challenge_failed",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.competitor_joined_takeover",
+      "title": "Competitor Joined Takeover",
+      "description": "Configure system and audio delivery for the experimental.competitor_joined_takeover event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.competitor_joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.competitor_joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.competitor_joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_competitor_joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.competitor_joined_takeover",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.cross_alliance_armada_defeat",
+      "title": "Cross Alliance Armada Defeat",
+      "description": "Configure system and audio delivery for the experimental.cross_alliance_armada_defeat event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.cross_alliance_armada_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.cross_alliance_armada_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.cross_alliance_armada_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_cross_alliance_armada_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.cross_alliance_armada_defeat",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.cross_alliance_armada_partial_victory",
+      "title": "Cross Alliance Armada Partial Victory",
+      "description": "Configure system and audio delivery for the experimental.cross_alliance_armada_partial_victory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.cross_alliance_armada_partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.cross_alliance_armada_partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.cross_alliance_armada_partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_cross_alliance_armada_partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.cross_alliance_armada_partial_victory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.cross_alliance_armada_victory",
+      "title": "Cross Alliance Armada Victory",
+      "description": "Configure system and audio delivery for the experimental.cross_alliance_armada_victory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.cross_alliance_armada_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.cross_alliance_armada_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.cross_alliance_armada_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_cross_alliance_armada_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.cross_alliance_armada_victory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.defeat",
+      "title": "Defeat",
+      "description": "Configure system and audio delivery for the battle.defeat event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.defeat",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.diplomacy_updated",
+      "title": "Diplomacy Updated",
+      "description": "Configure system and audio delivery for the experimental.diplomacy_updated event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.diplomacy_updated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.diplomacy_updated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.diplomacy_updated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_diplomacy_updated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.diplomacy_updated",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.dynamic_crisis_completed",
+      "title": "Dynamic Crisis Completed",
+      "description": "Configure system and audio delivery for the experimental.dynamic_crisis_completed event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.dynamic_crisis_completed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.dynamic_crisis_completed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.dynamic_crisis_completed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_dynamic_crisis_completed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.dynamic_crisis_completed",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.dynamic_crisis_failed",
+      "title": "Dynamic Crisis Failed",
+      "description": "Configure system and audio delivery for the experimental.dynamic_crisis_failed event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.dynamic_crisis_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.dynamic_crisis_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.dynamic_crisis_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_dynamic_crisis_failed",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.dynamic_crisis_failed",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.dynamic_crisis_update",
+      "title": "Dynamic Crisis Update",
+      "description": "Configure system and audio delivery for the experimental.dynamic_crisis_update event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.dynamic_crisis_update",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.dynamic_crisis_update",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.dynamic_crisis_update",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_dynamic_crisis_update",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.dynamic_crisis_update",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.faction_discovered",
+      "title": "Faction Discovered",
+      "description": "Configure system and audio delivery for the experimental.faction_discovered event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.faction_discovered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.faction_discovered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.faction_discovered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_faction_discovered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.faction_discovered",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.faction_level_down",
+      "title": "Faction Level Down",
+      "description": "Configure system and audio delivery for the experimental.faction_level_down event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.faction_level_down",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.faction_level_down",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.faction_level_down",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_faction_level_down",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.faction_level_down",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.faction_level_up",
+      "title": "Faction Level Up",
+      "description": "Configure system and audio delivery for the experimental.faction_level_up event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.faction_level_up",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.faction_level_up",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.faction_level_up",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_faction_level_up",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.faction_level_up",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.faction_warning",
+      "title": "Faction Warning",
+      "description": "Configure system and audio delivery for the experimental.faction_warning event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.faction_warning",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.faction_warning",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.faction_warning",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_faction_warning",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.faction_warning",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.faction_weekly_events_complete",
+      "title": "Faction Weekly Events Complete",
+      "description": "Configure system and audio delivery for the experimental.faction_weekly_events_complete event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.faction_weekly_events_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.faction_weekly_events_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.faction_weekly_events_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_faction_weekly_events_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.faction_weekly_events_complete",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.faction_weekly_events_progress",
+      "title": "Faction Weekly Events Progress",
+      "description": "Configure system and audio delivery for the experimental.faction_weekly_events_progress event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.faction_weekly_events_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.faction_weekly_events_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.faction_weekly_events_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_faction_weekly_events_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.faction_weekly_events_progress",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_arrived_at_destination",
+      "title": "Fleet Arrived At Destination",
+      "description": "Configure system and audio delivery for the fleet.arrived_at_destination event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "soft"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "soft"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.fleet.arrived_at_destination",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.fleet.arrived_at_destination",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.fleet.arrived_at_destination",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_arrived_at_destination",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_arrived_at_destination",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_arrived_in_system",
+      "title": "Fleet Arrived In System",
+      "description": "Configure system and audio delivery for the fleet.arrived_in_system event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "arrival"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "arrival"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.fleet.arrived_in_system",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.fleet.arrived_in_system",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.fleet.arrived_in_system",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_arrived_in_system",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_arrived_in_system",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_battle",
+      "title": "Fleet Battle",
+      "description": "Configure system and audio delivery for the battle.fleet_battle event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.fleet_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.fleet_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.fleet_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_battle",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_docked",
+      "title": "Fleet Docked",
+      "description": "Configure system and audio delivery for the fleet.docked event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "soft"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "soft"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.fleet.docked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.fleet.docked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.fleet.docked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_docked",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_docked",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_node_depleted",
+      "title": "Fleet Node Depleted",
+      "description": "Configure system and audio delivery for the fleet.node_depleted event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.fleet.node_depleted",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.fleet.node_depleted",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.fleet.node_depleted",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_node_depleted",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_node_depleted",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_preset_applied",
+      "title": "Fleet Preset Applied",
+      "description": "Configure system and audio delivery for the experimental.fleet_preset_applied event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.fleet_preset_applied",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.fleet_preset_applied",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.fleet_preset_applied",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_preset_applied",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_preset_applied",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_repair_complete",
+      "title": "Fleet Repair Complete",
+      "description": "Configure system and audio delivery for the fleet.repair_complete event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "repair"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "repair"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.fleet.repair_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.fleet.repair_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.fleet.repair_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_repair_complete",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_repair_complete",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.fleet_started_mining",
+      "title": "Fleet Started Mining",
+      "description": "Configure system and audio delivery for the fleet.started_mining event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "ping"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "ping"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.fleet.started_mining",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.fleet.started_mining",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.fleet.started_mining",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_fleet_started_mining",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.fleet_started_mining",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.galactic_anomaly_system_entered",
+      "title": "Galactic Anomaly System Entered",
+      "description": "Configure system and audio delivery for the experimental.galactic_anomaly_system_entered event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.galactic_anomaly_system_entered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.galactic_anomaly_system_entered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.galactic_anomaly_system_entered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_galactic_anomaly_system_entered",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.galactic_anomaly_system_entered",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.incoming_attack_hostile",
+      "title": "Incoming Attack Hostile",
+      "description": "Configure system and audio delivery for the battle.incoming_attack_hostile event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.incoming_attack_hostile",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.incoming_attack_hostile",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.incoming_attack_hostile",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_incoming_attack_hostile",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.incoming_attack_hostile",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.incoming_attack_player",
+      "title": "Incoming Attack Player",
+      "description": "Configure system and audio delivery for the battle.incoming_attack_player event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "alarm"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "alarm"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.incoming_attack_player",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.incoming_attack_player",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.incoming_attack_player",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_incoming_attack_player",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.incoming_attack_player",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.joined_takeover",
+      "title": "Joined Takeover",
+      "description": "Configure system and audio delivery for the experimental.joined_takeover event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_joined_takeover",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.joined_takeover",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.outpost_started_or_ended",
+      "title": "Outpost Started Or Ended",
+      "description": "Configure system and audio delivery for the experimental.outpost_started_or_ended event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.outpost_started_or_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.outpost_started_or_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.outpost_started_or_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_outpost_started_or_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.outpost_started_or_ended",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.partial_victory",
+      "title": "Partial Victory",
+      "description": "Configure system and audio delivery for the battle.partial_victory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_partial_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.partial_victory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.permanent_queue_purchased",
+      "title": "Permanent Queue Purchased",
+      "description": "Configure system and audio delivery for the experimental.permanent_queue_purchased event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.permanent_queue_purchased",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.permanent_queue_purchased",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.permanent_queue_purchased",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_permanent_queue_purchased",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.permanent_queue_purchased",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.queue_for_lease_activated",
+      "title": "Queue For Lease Activated",
+      "description": "Configure system and audio delivery for the experimental.queue_for_lease_activated event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.queue_for_lease_activated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.queue_for_lease_activated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.queue_for_lease_activated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_queue_for_lease_activated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.queue_for_lease_activated",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.queue_for_lease_expired",
+      "title": "Queue For Lease Expired",
+      "description": "Configure system and audio delivery for the experimental.queue_for_lease_expired event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.queue_for_lease_expired",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.queue_for_lease_expired",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.queue_for_lease_expired",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_queue_for_lease_expired",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.queue_for_lease_expired",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.standard",
+      "title": "Standard",
+      "description": "Configure system and audio delivery for the experimental.standard event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "default"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "default"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.standard",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.standard",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.standard",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_standard",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.standard",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.station_battle",
+      "title": "Station Battle",
+      "description": "Configure system and audio delivery for the battle.station_battle event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "alarm"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "alarm"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.station_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.station_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.station_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_station_battle",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.station_battle",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.station_defeat",
+      "title": "Station Defeat",
+      "description": "Configure system and audio delivery for the battle.station_defeat event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.station_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.station_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.station_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_station_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.station_defeat",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.station_victory",
+      "title": "Station Victory",
+      "description": "Configure system and audio delivery for the battle.station_victory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.station_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.station_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.station_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_station_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.station_victory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.strike_defeat",
+      "title": "Strike Defeat",
+      "description": "Configure system and audio delivery for the experimental.strike_defeat event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.strike_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.strike_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.strike_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_strike_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.strike_defeat",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.strike_hit",
+      "title": "Strike Hit",
+      "description": "Configure system and audio delivery for the experimental.strike_hit event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "ping"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "ping"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.strike_hit",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.strike_hit",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.strike_hit",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_strike_hit",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.strike_hit",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.surge_hostile_group_defeated",
+      "title": "Surge Hostile Group Defeated",
+      "description": "Configure system and audio delivery for the experimental.surge_hostile_group_defeated event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.surge_hostile_group_defeated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.surge_hostile_group_defeated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.surge_hostile_group_defeated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_surge_hostile_group_defeated",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.surge_hostile_group_defeated",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.surge_time_left",
+      "title": "Surge Time Left",
+      "description": "Configure system and audio delivery for the experimental.surge_time_left event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.surge_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.surge_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.surge_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_surge_time_left",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.surge_time_left",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.surge_warmup_ended",
+      "title": "Surge Warmup Ended",
+      "description": "Configure system and audio delivery for the experimental.surge_warmup_ended event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.surge_warmup_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.surge_warmup_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.surge_warmup_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_surge_warmup_ended",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.surge_warmup_ended",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.takeover_defeat",
+      "title": "Takeover Defeat",
+      "description": "Configure system and audio delivery for the experimental.takeover_defeat event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "warning"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "warning"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.takeover_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.takeover_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.takeover_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_takeover_defeat",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.takeover_defeat",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.takeover_victory",
+      "title": "Takeover Victory",
+      "description": "Configure system and audio delivery for the experimental.takeover_victory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.takeover_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.takeover_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.takeover_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_takeover_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.takeover_victory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.tournament",
+      "title": "Tournament",
+      "description": "Configure system and audio delivery for the event.tournament event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.event.tournament",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.event.tournament",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.event.tournament",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_tournament",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.tournament",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.treasury_full",
+      "title": "Treasury Full",
+      "description": "Configure system and audio delivery for the experimental.treasury_full event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.treasury_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.treasury_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.treasury_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_treasury_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.treasury_full",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.treasury_progress",
+      "title": "Treasury Progress",
+      "description": "Configure system and audio delivery for the experimental.treasury_progress event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.treasury_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.treasury_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.treasury_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_treasury_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.treasury_progress",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.victory",
+      "title": "Victory",
+      "description": "Configure system and audio delivery for the battle.victory event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.battle.victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.battle.victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.battle.victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_victory",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.victory",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.warchest_full",
+      "title": "Warchest Full",
+      "description": "Configure system and audio delivery for the experimental.warchest_full event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "success"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "success"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.warchest_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.warchest_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.warchest_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_warchest_full",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.warchest_full",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "notifications.warchest_progress",
+      "title": "Warchest Progress",
+      "description": "Configure system and audio delivery for the experimental.warchest_progress event.",
+      "category": "notifications",
+      "control": "notification-policy",
+      "valueType": {
+        "kind": "union",
+        "variants": [
+          {
+            "kind": "boolean",
+            "semantics": {
+              "false": "disabled",
+              "true": "system-only"
+            }
+          },
+          {
+            "kind": "object",
+            "replacement": "whole-value",
+            "fields": {
+              "system": {
+                "kind": "boolean",
+                "default": false
+              },
+              "audio": {
+                "kind": "boolean",
+                "default": false
+              },
+              "sound": {
+                "kind": "enum",
+                "values": [
+                  "none",
+                  "default",
+                  "info",
+                  "success",
+                  "warning",
+                  "alarm",
+                  "arrival",
+                  "soft",
+                  "ping",
+                  "repair"
+                ],
+                "default": "info"
+              }
+            }
+          }
+        ]
+      },
+      "default": false,
+      "expandedDefault": {
+        "system": false,
+        "audio": false,
+        "sound": "info"
+      },
+      "invalidValueBehavior": "warn-and-use-event-default",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "notifications.events.experimental.warchest_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.system.experimental.warchest_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.audio.experimental.warchest_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        },
+        {
+          "path": "notifications.notifications_warchest_progress",
+          "status": "deprecated",
+          "precedence": "canonical-replaces-whole-policy",
+          "removal": "3.0.0"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "notifications.warchest_progress",
+        "defaultSource": "notification-event-catalog"
+      }
+    },
+    {
+      "path": "patches.bufffixhooks",
+      "title": "Bufffixhooks",
+      "description": "Out-of-dock power / buff calculation fixes.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.bufffixhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.bufffixhooks"
+      }
+    },
+    {
+      "path": "patches.chatpatches",
+      "title": "Chatpatches",
+      "description": "Chat-related UI patches.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.chatpatches",
+        "defaultSource": "mods/src/defaultconfig.h:patches.chatpatches"
+      }
+    },
+    {
+      "path": "patches.fleetarrivalhooks",
+      "title": "Fleetarrivalhooks",
+      "description": "Fleet arrival detection from player fleet-state changes.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.fleetarrivalhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.fleetarrivalhooks"
+      }
+    },
+    {
+      "path": "patches.freeresizehooks",
+      "title": "Freeresizehooks",
+      "description": "Free window resize hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.freeresizehooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.freeresizehooks"
+      }
+    },
+    {
+      "path": "patches.game_version",
+      "title": "Game Version",
+      "description": "Capture the game version for sync request headers.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.game_version",
+        "defaultSource": "mods/src/defaultconfig.h:patches.game_version"
+      }
+    },
+    {
+      "path": "patches.hotkeyhooks",
+      "title": "Hotkeyhooks",
+      "description": "Keyboard hotkey injection.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.hotkeyhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.hotkeyhooks"
+      }
+    },
+    {
+      "path": "patches.improveresponsivenesshooks",
+      "title": "Improveresponsivenesshooks",
+      "description": "Input-responsiveness improvements.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.improveresponsivenesshooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.improveresponsivenesshooks"
+      }
+    },
+    {
+      "path": "patches.loadingscreenhooks",
+      "title": "Loadingscreenhooks",
+      "description": "Login loading-screen replacement hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.loadingscreenhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.loadingscreenhooks"
+      }
+    },
+    {
+      "path": "patches.miscpatches",
+      "title": "Miscpatches",
+      "description": "Misc one-off fixes.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.miscpatches",
+        "defaultSource": "mods/src/defaultconfig.h:patches.miscpatches"
+      }
+    },
+    {
+      "path": "patches.objecttracker",
+      "title": "Objecttracker",
+      "description": "In-system object tracking overlay.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.objecttracker",
+        "defaultSource": "mods/src/defaultconfig.h:patches.objecttracker"
+      }
+    },
+    {
+      "path": "patches.panhooks",
+      "title": "Panhooks",
+      "description": "Pan-momentum hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.panhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.panhooks"
+      }
+    },
+    {
+      "path": "patches.resolutionlistfix",
+      "title": "Resolutionlistfix",
+      "description": "Resolution-list population fix; disabled after Unity 6 update.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.resolutionlistfix",
+        "defaultSource": "mods/src/defaultconfig.h:patches.resolutionlistfix"
+      }
+    },
+    {
+      "path": "patches.syncpatches",
+      "title": "Syncpatches",
+      "description": "Data-sync network hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.syncpatches",
+        "defaultSource": "mods/src/defaultconfig.h:patches.syncpatches"
+      }
+    },
+    {
+      "path": "patches.tempcrashfixes",
+      "title": "Tempcrashfixes",
+      "description": "Temporary crash mitigations.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.tempcrashfixes",
+        "defaultSource": "mods/src/defaultconfig.h:patches.tempcrashfixes"
+      }
+    },
+    {
+      "path": "patches.testpatches",
+      "title": "Testpatches",
+      "description": "Test / experimental patches.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.testpatches",
+        "defaultSource": "mods/src/defaultconfig.h:patches.testpatches"
+      }
+    },
+    {
+      "path": "patches.toastbannerhooks",
+      "title": "Toastbannerhooks",
+      "description": "Toast-banner filtering hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.toastbannerhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.toastbannerhooks"
+      }
+    },
+    {
+      "path": "patches.transitionscreenhooks",
+      "title": "Transitionscreenhooks",
+      "description": "In-game transition-screen replacement hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.transitionscreenhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.transitionscreenhooks"
+      }
+    },
+    {
+      "path": "patches.uiscalehooks",
+      "title": "Uiscalehooks",
+      "description": "UI scale override hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.uiscalehooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.uiscalehooks"
+      }
+    },
+    {
+      "path": "patches.zoomhooks",
+      "title": "Zoomhooks",
+      "description": "Camera zoom override hooks.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.zoomhooks",
+        "defaultSource": "mods/src/defaultconfig.h:patches.zoomhooks"
+      }
+    },
+    {
+      "path": "sidecar.logging.jsonl",
+      "title": "JSONL",
+      "description": "Explicit opt-in local JSONL evidence/import feed for offline review and diagnostics. Keep this disabled unless you specifically need local file capture.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.logging.jsonl",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.logging.jsonl"
+      }
+    },
+    {
+      "path": "sidecar.logging.jsonl_recent_logs",
+      "title": "JSONL Recent Logs",
+      "description": "Optional second cap on retained battle-log groups.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 300,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.logging.jsonl_recent_logs",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.logging.jsonl_recent_logs"
+      }
+    },
+    {
+      "path": "sidecar.logging.jsonl_replay_seconds",
+      "title": "JSONL Replay Seconds",
+      "description": "Keep the local sidecar JSONL feed cyclic so replay does not grow unbounded.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 30,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.logging.jsonl_replay_seconds",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.logging.jsonl_replay_seconds"
+      }
+    },
+    {
+      "path": "sidecar.sync.allow_unsafe_tls_without_certificate_validation",
+      "title": "Allow Unsafe TLS Without Certificate Validation",
+      "description": "Configure allow unsafe tls without certificate validation.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.allow_unsafe_tls_without_certificate_validation",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.allow_unsafe_tls_without_certificate_validation"
+      }
+    },
+    {
+      "path": "sidecar.sync.battlelog_enrichment",
+      "title": "Battlelog Enrichment",
+      "description": "Decodes local sidecar battle journals and emits battle.report, catalog.snapshot, and battle.analytics events for Names <-> IDs, catalog snapshots, and Prime CSV parity rows. Legacy [battle_log_decoder].enabled is accepted as an alias, but this is the canonical local Workbench gate.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [
+        {
+          "path": "battle_log_decoder.enabled",
+          "status": "deprecated",
+          "precedence": "canonical-wins"
+        }
+      ],
+      "provenance": {
+        "runtimePath": "sidecar.sync.battlelog_enrichment",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.battlelog_enrichment"
+      }
+    },
+    {
+      "path": "sidecar.sync.battlelogs_realtime",
+      "title": "Battlelogs Realtime",
+      "description": "Sends raw battle capture events to the local sidecar. With this alone, the Workbench may show sparse capture-only battle rows.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.battlelogs_realtime",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.battlelogs_realtime"
+      }
+    },
+    {
+      "path": "sidecar.sync.enabled",
+      "title": "Enabled",
+      "description": "Dedicated local STFC Mod Sidecar delivery. This is the only supported home for sidecar-local HTTP config. Local Battle Workbench reads the sidecar event store through /api/events. Cloud Sync Monitor and Majel/cloud targets are not required for local sidecar ingest.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.enabled",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.enabled"
+      }
+    },
+    {
+      "path": "sidecar.sync.fleet_runtime",
+      "title": "Fleet Runtime",
+      "description": "Configure fleet runtime.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.fleet_runtime",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.fleet_runtime"
+      }
+    },
+    {
+      "path": "sidecar.sync.fleet_runtime_mode",
+      "title": "Fleet Runtime Mode",
+      "description": "Fleet runtime sidecar safety/probe mode: normal, request_only, snapshot_only, or enqueue_no_transport. request_only records requests but skips snapshot reads. snapshot_only reads/builds owned snapshots but skips publish/enqueue. enqueue_no_transport enqueues latest-wins runtime snapshots but suppresses HTTP transport.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "normal",
+          "request_only",
+          "snapshot_only",
+          "enqueue_no_transport"
+        ]
+      },
+      "default": "normal",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.fleet_runtime_mode",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.fleet_runtime_mode"
+      }
+    },
+    {
+      "path": "sidecar.sync.proxy",
+      "title": "Proxy",
+      "description": "Configure proxy.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.proxy",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.proxy"
+      }
+    },
+    {
+      "path": "sidecar.sync.token",
+      "title": "Token",
+      "description": "Configure token.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "secret",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.token",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.token"
+      }
+    },
+    {
+      "path": "sidecar.sync.url",
+      "title": "URL",
+      "description": "Configure url.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.url",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.url"
+      }
+    },
+    {
+      "path": "sidecar.sync.verify_ssl",
+      "title": "Verify SSL",
+      "description": "Configure verify ssl.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.verify_ssl",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.verify_ssl"
+      }
+    },
+    {
+      "path": "sync.allow_unsafe_tls_without_certificate_validation",
+      "title": "Allow Unsafe TLS Without Certificate Validation",
+      "description": "Explicit unsafe TLS override.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.allow_unsafe_tls_without_certificate_validation",
+        "defaultSource": "mods/src/defaultconfig.h:sync.allow_unsafe_tls_without_certificate_validation"
+      }
+    },
+    {
+      "path": "sync.battlelogs",
+      "title": "Battlelogs",
+      "description": "Sync battle-log reports.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.battlelogs",
+        "defaultSource": "mods/src/defaultconfig.h:sync.battlelogs"
+      }
+    },
+    {
+      "path": "sync.battlelogs_realtime",
+      "title": "Battlelogs Realtime",
+      "description": "Export canonical battle feed events to realtime ingest targets.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.battlelogs_realtime",
+        "defaultSource": "mods/src/defaultconfig.h:sync.battlelogs_realtime"
+      }
+    },
+    {
+      "path": "sync.buffs",
+      "title": "Buffs",
+      "description": "Sync buff / Emerald Chain data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.buffs",
+        "defaultSource": "mods/src/defaultconfig.h:sync.buffs"
+      }
+    },
+    {
+      "path": "sync.buildings",
+      "title": "Buildings",
+      "description": "Sync station module data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.buildings",
+        "defaultSource": "mods/src/defaultconfig.h:sync.buildings"
+      }
+    },
+    {
+      "path": "sync.debug",
+      "title": "Debug",
+      "description": "Extra debug logging for sync subsystem.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.debug",
+        "defaultSource": "mods/src/defaultconfig.h:sync.debug"
+      }
+    },
+    {
+      "path": "sync.fleet_runtime",
+      "title": "Fleet Runtime",
+      "description": "Sync low-rate fleet-bar runtime state.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.fleet_runtime",
+        "defaultSource": "mods/src/defaultconfig.h:sync.fleet_runtime"
+      }
+    },
+    {
+      "path": "sync.inventory",
+      "title": "Inventory",
+      "description": "Sync inventory contents.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.inventory",
+        "defaultSource": "mods/src/defaultconfig.h:sync.inventory"
+      }
+    },
+    {
+      "path": "sync.jobs",
+      "title": "Jobs",
+      "description": "Sync active job/build queues.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.jobs",
+        "defaultSource": "mods/src/defaultconfig.h:sync.jobs"
+      }
+    },
+    {
+      "path": "sync.logging",
+      "title": "Logging",
+      "description": "Log raw sync payloads.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.logging",
+        "defaultSource": "mods/src/defaultconfig.h:sync.logging"
+      }
+    },
+    {
+      "path": "sync.missions",
+      "title": "Missions",
+      "description": "Sync mission progress.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.missions",
+        "defaultSource": "mods/src/defaultconfig.h:sync.missions"
+      }
+    },
+    {
+      "path": "sync.officer",
+      "title": "Officer",
+      "description": "Sync officer roster.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.officer",
+        "defaultSource": "mods/src/defaultconfig.h:sync.officer"
+      }
+    },
+    {
+      "path": "sync.proxy",
+      "title": "Proxy",
+      "description": "HTTP proxy for sync requests (empty = none).",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.proxy",
+        "defaultSource": "mods/src/defaultconfig.h:sync.proxy"
+      }
+    },
+    {
+      "path": "sync.research",
+      "title": "Research",
+      "description": "Sync research tree state.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.research",
+        "defaultSource": "mods/src/defaultconfig.h:sync.research"
+      }
+    },
+    {
+      "path": "sync.resolver_cache_ttl",
+      "title": "Resolver Cache Ttl",
+      "description": "DNS resolver cache TTL in seconds. Default: 300 (5 min).",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 300,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.resolver_cache_ttl",
+        "defaultSource": "mods/src/defaultconfig.h:sync.resolver_cache_ttl"
+      }
+    },
+    {
+      "path": "sync.resources",
+      "title": "Resources",
+      "description": "Sync resource amounts.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.resources",
+        "defaultSource": "mods/src/defaultconfig.h:sync.resources"
+      }
+    },
+    {
+      "path": "sync.ships",
+      "title": "Ships",
+      "description": "Sync fleet / ship data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.ships",
+        "defaultSource": "mods/src/defaultconfig.h:sync.ships"
+      }
+    },
+    {
+      "path": "sync.slots",
+      "title": "Slots",
+      "description": "Sync crew-slot assignments.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.slots",
+        "defaultSource": "mods/src/defaultconfig.h:sync.slots"
+      }
+    },
+    {
+      "path": "sync.targets.*.allow_unsafe_tls_without_certificate_validation",
+      "title": "Allow Unsafe TLS Without Certificate Validation",
+      "description": "Explicit unsafe TLS override.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.allow_unsafe_tls_without_certificate_validation",
+        "defaultSource": "mods/src/defaultconfig.h:sync.allow_unsafe_tls_without_certificate_validation"
+      }
+    },
+    {
+      "path": "sync.targets.*.battlelogs",
+      "title": "Battlelogs",
+      "description": "Sync battle-log reports.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.battlelogs",
+        "defaultSource": "mods/src/defaultconfig.h:sync.battlelogs"
+      }
+    },
+    {
+      "path": "sync.targets.*.battlelogs_realtime",
+      "title": "Battlelogs Realtime",
+      "description": "Export canonical battle feed events to realtime ingest targets.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.battlelogs_realtime",
+        "defaultSource": "mods/src/defaultconfig.h:sync.battlelogs_realtime"
+      }
+    },
+    {
+      "path": "sync.targets.*.buffs",
+      "title": "Buffs",
+      "description": "Sync buff / Emerald Chain data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.buffs",
+        "defaultSource": "mods/src/defaultconfig.h:sync.buffs"
+      }
+    },
+    {
+      "path": "sync.targets.*.buildings",
+      "title": "Buildings",
+      "description": "Sync station module data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.buildings",
+        "defaultSource": "mods/src/defaultconfig.h:sync.buildings"
+      }
+    },
+    {
+      "path": "sync.targets.*.fleet_runtime",
+      "title": "Fleet Runtime",
+      "description": "Sync low-rate fleet-bar runtime state.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.fleet_runtime",
+        "defaultSource": "mods/src/defaultconfig.h:sync.fleet_runtime"
+      }
+    },
+    {
+      "path": "sync.targets.*.inventory",
+      "title": "Inventory",
+      "description": "Sync inventory contents.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.inventory",
+        "defaultSource": "mods/src/defaultconfig.h:sync.inventory"
+      }
+    },
+    {
+      "path": "sync.targets.*.jobs",
+      "title": "Jobs",
+      "description": "Sync active job/build queues.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.jobs",
+        "defaultSource": "mods/src/defaultconfig.h:sync.jobs"
+      }
+    },
+    {
+      "path": "sync.targets.*.missions",
+      "title": "Missions",
+      "description": "Sync mission progress.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.missions",
+        "defaultSource": "mods/src/defaultconfig.h:sync.missions"
+      }
+    },
+    {
+      "path": "sync.targets.*.mode",
+      "title": "Mode",
+      "description": "Outbound sync contract used by this target.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "legacy",
+          "majel"
+        ]
+      },
+      "default": "legacy",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.mode",
+        "defaultSource": "SyncTargetConfig::Mode"
+      }
+    },
+    {
+      "path": "sync.targets.*.officer",
+      "title": "Officer",
+      "description": "Sync officer roster.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.officer",
+        "defaultSource": "mods/src/defaultconfig.h:sync.officer"
+      }
+    },
+    {
+      "path": "sync.targets.*.proxy",
+      "title": "Proxy",
+      "description": "HTTP proxy for sync requests (empty = none).",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.proxy",
+        "defaultSource": "mods/src/defaultconfig.h:sync.proxy"
+      }
+    },
+    {
+      "path": "sync.targets.*.research",
+      "title": "Research",
+      "description": "Sync research tree state.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.research",
+        "defaultSource": "mods/src/defaultconfig.h:sync.research"
+      }
+    },
+    {
+      "path": "sync.targets.*.resources",
+      "title": "Resources",
+      "description": "Sync resource amounts.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.resources",
+        "defaultSource": "mods/src/defaultconfig.h:sync.resources"
+      }
+    },
+    {
+      "path": "sync.targets.*.ships",
+      "title": "Ships",
+      "description": "Sync fleet / ship data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.ships",
+        "defaultSource": "mods/src/defaultconfig.h:sync.ships"
+      }
+    },
+    {
+      "path": "sync.targets.*.slots",
+      "title": "Slots",
+      "description": "Sync crew-slot assignments.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.slots",
+        "defaultSource": "mods/src/defaultconfig.h:sync.slots"
+      }
+    },
+    {
+      "path": "sync.targets.*.tech",
+      "title": "Tech",
+      "description": "Sync forbidden tech data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.tech",
+        "defaultSource": "mods/src/defaultconfig.h:sync.tech"
+      }
+    },
+    {
+      "path": "sync.targets.*.token",
+      "title": "Token",
+      "description": "Bearer token (legacy, prefer targets).",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "secret",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.token",
+        "defaultSource": "mods/src/defaultconfig.h:sync.token"
+      }
+    },
+    {
+      "path": "sync.targets.*.traits",
+      "title": "Traits",
+      "description": "Sync officer traits.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.traits",
+        "defaultSource": "mods/src/defaultconfig.h:sync.traits"
+      }
+    },
+    {
+      "path": "sync.targets.*.url",
+      "title": "URL",
+      "description": "Endpoint URL (legacy, prefer targets).",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.url",
+        "defaultSource": "mods/src/defaultconfig.h:sync.url"
+      }
+    },
+    {
+      "path": "sync.targets.*.verify_ssl",
+      "title": "Verify SSL",
+      "description": "Verify TLS certificates on sync requests.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.targets.*.verify_ssl",
+        "defaultSource": "mods/src/defaultconfig.h:sync.verify_ssl"
+      }
+    },
+    {
+      "path": "sync.tech",
+      "title": "Tech",
+      "description": "Sync forbidden tech data.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.tech",
+        "defaultSource": "mods/src/defaultconfig.h:sync.tech"
+      }
+    },
+    {
+      "path": "sync.token",
+      "title": "Token",
+      "description": "Bearer token (legacy, prefer targets).",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "secret",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.token",
+        "defaultSource": "mods/src/defaultconfig.h:sync.token"
+      }
+    },
+    {
+      "path": "sync.traits",
+      "title": "Traits",
+      "description": "Sync officer traits.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.traits",
+        "defaultSource": "mods/src/defaultconfig.h:sync.traits"
+      }
+    },
+    {
+      "path": "sync.url",
+      "title": "URL",
+      "description": "Endpoint URL (legacy, prefer targets).",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "private",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.url",
+        "defaultSource": "mods/src/defaultconfig.h:sync.url"
+      }
+    },
+    {
+      "path": "sync.verify_ssl",
+      "title": "Verify SSL",
+      "description": "Verify TLS certificates on sync requests.",
+      "category": "sync",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sync.verify_ssl",
+        "defaultSource": "mods/src/defaultconfig.h:sync.verify_ssl"
+      }
+    },
+    {
+      "path": "ui.always_skip_reveal_sequence",
+      "title": "Always Skip Reveal Sequence",
+      "description": "Auto-skip the ship/officer reveal animation. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.always_skip_reveal_sequence",
+        "defaultSource": "mods/src/defaultconfig.h:ui.always_skip_reveal_sequence"
+      }
+    },
+    {
+      "path": "ui.auto_confirm_discovery",
+      "title": "Auto Confirm Discovery",
+      "description": "Auto-confirm new system discoveries. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.auto_confirm_discovery",
+        "defaultSource": "mods/src/defaultconfig.h:ui.auto_confirm_discovery"
+      }
+    },
+    {
+      "path": "ui.auto_open_bulk_claim_flyout",
+      "title": "Auto Open Bulk Claim Flyout",
+      "description": "Open the existing Gifts bulk-claim selection flyout automatically. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.auto_open_bulk_claim_flyout",
+        "defaultSource": "mods/src/defaultconfig.h:ui.auto_open_bulk_claim_flyout"
+      }
+    },
+    {
+      "path": "ui.disable_escape_exit",
+      "title": "Disable Escape Exit",
+      "description": "Block the Escape key from closing the game. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_escape_exit",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_escape_exit"
+      }
+    },
+    {
+      "path": "ui.disable_first_popup",
+      "title": "Disable First Popup",
+      "description": "Suppress the first-run welcome popup. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_first_popup",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_first_popup"
+      }
+    },
+    {
+      "path": "ui.disable_galaxy_chat",
+      "title": "Disable Galaxy Chat",
+      "description": "Hide galaxy chat entirely. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_galaxy_chat",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_galaxy_chat"
+      }
+    },
+    {
+      "path": "ui.disable_move_keys",
+      "title": "Disable Move Keys",
+      "description": "Disable WASD movement keys. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_move_keys",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_move_keys"
+      }
+    },
+    {
+      "path": "ui.disable_preview_locate",
+      "title": "Disable Preview Locate",
+      "description": "Disable the \"locate\" preview on fleet-select. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_preview_locate",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_preview_locate"
+      }
+    },
+    {
+      "path": "ui.disable_preview_recall",
+      "title": "Disable Preview Recall",
+      "description": "Disable the \"recall\" preview on fleet-select. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_preview_recall",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_preview_recall"
+      }
+    },
+    {
+      "path": "ui.disable_toast_banners",
+      "title": "Disable Toast Banners",
+      "description": "Suppress all toast banners. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_toast_banners",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_toast_banners"
+      }
+    },
+    {
+      "path": "ui.disable_veil_chat",
+      "title": "Disable Veil Chat",
+      "description": "Hide Veil-sector chat. Default: false.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disable_veil_chat",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disable_veil_chat"
+      }
+    },
+    {
+      "path": "ui.disabled_banner_types",
+      "title": "Disabled Banner Types",
+      "description": "Comma-separated list of toast banner type names to suppress (empty = none).",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.disabled_banner_types",
+        "defaultSource": "mods/src/defaultconfig.h:ui.disabled_banner_types"
+      }
+    },
+    {
+      "path": "ui.escape_exit_timer",
+      "title": "Escape Exit Timer",
+      "description": "Max ms between two Escape presses to count as a double-tap. 0 = disabled (Escape fully blocked). 500 = half-second window.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 0,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.escape_exit_timer",
+        "defaultSource": "mods/src/defaultconfig.h:ui.escape_exit_timer"
+      }
+    },
+    {
+      "path": "ui.extend_donation_max",
+      "title": "Extend Donation Max",
+      "description": "Maximum alliance-donation slider value (percentage). Default: 80.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "integer"
+      },
+      "default": 80,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.extend_donation_max",
+        "defaultSource": "mods/src/defaultconfig.h:ui.extend_donation_max"
+      }
+    },
+    {
+      "path": "ui.extend_donation_slider",
+      "title": "Extend Donation Slider",
+      "description": "Enable the extended donation slider range. Default: true. (Windows only.)",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.extend_donation_slider",
+        "defaultSource": "mods/src/defaultconfig.h:ui.extend_donation_slider"
+      }
+    },
+    {
+      "path": "ui.mission_hud.daily_goals",
+      "title": "Daily Goals",
+      "description": "Configure daily goals.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "auto",
+          "always",
+          "never"
+        ]
+      },
+      "default": "auto",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.mission_hud.daily_goals",
+        "defaultSource": "mods/src/defaultconfig.h:ui.mission_hud.daily_goals"
+      }
+    },
+    {
+      "path": "ui.mission_hud.field_training",
+      "title": "Field Training",
+      "description": "Configure field training.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "auto",
+          "always",
+          "never"
+        ]
+      },
+      "default": "auto",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.mission_hud.field_training",
+        "defaultSource": "mods/src/defaultconfig.h:ui.mission_hud.field_training"
+      }
+    },
+    {
+      "path": "ui.mission_hud.missions",
+      "title": "Missions",
+      "description": "Configure missions.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "auto",
+          "always",
+          "never"
+        ]
+      },
+      "default": "auto",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.mission_hud.missions",
+        "defaultSource": "mods/src/defaultconfig.h:ui.mission_hud.missions"
+      }
+    },
+    {
+      "path": "ui.mission_hud.outposts",
+      "title": "Outposts",
+      "description": "Configure outposts.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "auto",
+          "always",
+          "never"
+        ]
+      },
+      "default": "auto",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.mission_hud.outposts",
+        "defaultSource": "mods/src/defaultconfig.h:ui.mission_hud.outposts"
+      }
+    },
+    {
+      "path": "ui.mission_hud.q_trials",
+      "title": "Q Trials",
+      "description": "Configure q trials.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "auto",
+          "always",
+          "never"
+        ]
+      },
+      "default": "auto",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.mission_hud.q_trials",
+        "defaultSource": "mods/src/defaultconfig.h:ui.mission_hud.q_trials"
+      }
+    },
+    {
+      "path": "ui.show_armada_cargo",
+      "title": "Show Armada Cargo",
+      "description": "Show cargo overlay on armada targets by default. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.show_armada_cargo",
+        "defaultSource": "mods/src/defaultconfig.h:ui.show_armada_cargo"
+      }
+    },
+    {
+      "path": "ui.show_cargo_default",
+      "title": "Show Cargo Default",
+      "description": "Show cargo overlay on all entities by default. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.show_cargo_default",
+        "defaultSource": "mods/src/defaultconfig.h:ui.show_cargo_default"
+      }
+    },
+    {
+      "path": "ui.show_hostile_cargo",
+      "title": "Show Hostile Cargo",
+      "description": "Show cargo overlay on hostile ships. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.show_hostile_cargo",
+        "defaultSource": "mods/src/defaultconfig.h:ui.show_hostile_cargo"
+      }
+    },
+    {
+      "path": "ui.show_player_cargo",
+      "title": "Show Player Cargo",
+      "description": "Show cargo overlay on player ships. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.show_player_cargo",
+        "defaultSource": "mods/src/defaultconfig.h:ui.show_player_cargo"
+      }
+    },
+    {
+      "path": "ui.show_station_cargo",
+      "title": "Show Station Cargo",
+      "description": "Show cargo overlay on stations. Default: true.",
+      "category": "ui",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "ui.show_station_cargo",
+        "defaultSource": "mods/src/defaultconfig.h:ui.show_station_cargo"
+      }
+    }
+  ]
+}

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -425,17 +425,11 @@ select_ship8 = "8"
 # Subgroup: Experimental
 # ----------------------
 
-# ⚠️ EXPERIMENTAL: Moves down the screen
-move_down = "S"
-
 # Moves to the previous officer or ship selection item
 move_left = "LEFT"
 
 # Moves to the next officer or ship selection item
 move_right = "RIGHT"
-
-# ⚠️ EXPERIMENTAL: Moves up the screen
-move_up = "W"
 
 # ⚠️ EXPERIMENTAL: Shows the bookmark->lookup screen
 show_lookup = "L"

--- a/scripts/generate_config_schema.mjs
+++ b/scripts/generate_config_schema.mjs
@@ -173,6 +173,22 @@ function parseExampleConfig() {
   return entries;
 }
 
+function parseBoolConfigMetadata() {
+  const values = new Map();
+  const source = read("mods/src/config_metadata.h");
+  const specPattern =
+    /inline\s+constexpr\s+BoolConfigSpec\s+[A-Za-z0-9_]+\s*\{\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*"[^"]+"\s*,\s*(true|false)\s*,\s*"([^"]*)"/g;
+  for (const match of source.matchAll(specPattern)) {
+    const settingPath = `${match[1]}.${match[2]}`;
+    values.set(settingPath, {
+      value: match[3] === "true",
+      description: match[4],
+      source: `mods/src/config_metadata.h:${settingPath}`,
+    });
+  }
+  return values;
+}
+
 function captureBalancedCall(source, name, startIndex) {
   const open = source.indexOf("(", startIndex + name.length);
   if (open < 0) return null;
@@ -249,6 +265,34 @@ function scanLiteralParserPaths() {
     cursor += name.length;
   }
   return paths;
+}
+
+function scanCustomParserPaths(defaults) {
+  const paths = new Set();
+  const canonicalSources = [
+    "mods/src/config_sidecar.cc",
+    "mods/src/patches/action_queue_repair_config.h",
+  ];
+  const canonicalPattern =
+    /"(advanced\.(?:diagnostics|queue|kirshara_queue)\.[A-Za-z0-9_.]+|sidecar\.(?:sync|logging)\.[A-Za-z0-9_.]+)"/g;
+  for (const relativePath of canonicalSources) {
+    for (const match of read(relativePath).matchAll(canonicalPattern)) {
+      if (defaults.has(match[1])) paths.add(match[1]);
+    }
+  }
+
+  const metadata = read("mods/src/config_metadata.h");
+  const boolSpecPattern =
+    /inline\s+constexpr\s+BoolConfigSpec\s+[A-Za-z0-9_]+\s*\{\s*"([^"]+)"\s*,\s*"([^"]+)"/g;
+  for (const match of metadata.matchAll(boolSpecPattern)) {
+    const settingPath = `${match[1]}.${match[2]}`;
+    if (defaults.has(settingPath)) paths.add(settingPath);
+  }
+  return paths;
+}
+
+function scanRuntimeScalarPaths(defaults = parseDefaultConfig()) {
+  return new Set([...scanLiteralParserPaths(), ...scanCustomParserPaths(defaults)]);
 }
 
 function parseInputBindings() {
@@ -424,6 +468,7 @@ function schemaType(settingPath, value) {
   const enumValues = {
     "input.scopely_shortcuts": ["off", "native", "fallback"],
     "input.original_frame_policy": ["mod", "fallthrough_unhandled", "fallthrough_all"],
+    "advanced.diagnostics.runtime_trace": ["off", "summary", "detailed", "verbose"],
     "sidecar.sync.fleet_runtime_mode": ["normal", "request_only", "snapshot_only", "enqueue_no_transport"],
   };
   if (settingPath.startsWith("ui.mission_hud.")) {
@@ -445,7 +490,9 @@ function sensitivityFor(settingPath) {
 }
 
 function stabilityFor(settingPath) {
-  if (settingPath.startsWith("advanced.diagnostics.")) return "internal";
+  if (settingPath.startsWith("advanced.diagnostics.")
+      || settingPath.startsWith("advanced.kirshara_queue.")
+      || settingPath === "control.allow_key_fallthrough") return "internal";
   if (settingPath.startsWith("patches.")) return "advanced";
   if (settingPath === "control.enable_experimental" || settingPath.startsWith("advanced.queue.")) return "experimental";
   return "stable";
@@ -486,6 +533,12 @@ function constraintsFor(settingPath) {
   if (/^advanced\.diagnostics\.files\.(?:navhook_trace|action_queue_probe)_(?:max_kb|files)$/.test(settingPath)) {
     return { minimum: 1 };
   }
+  if (settingPath === "advanced.diagnostics.runtime_trace_report_interval_ms") {
+    return { minimum: 1000, maximum: 60000 };
+  }
+  if (settingPath === "sidecar.logging.jsonl_replay_seconds" || settingPath === "sidecar.logging.jsonl_recent_logs") {
+    return { minimum: 0 };
+  }
   return {};
 }
 
@@ -496,10 +549,31 @@ function resolveDefaultPath(settingPath) {
   return settingPath;
 }
 
+function makeScalarSetting(settingPath, fallback, description = "") {
+  const constraints = constraintsFor(settingPath);
+  return {
+    path: settingPath,
+    title: titleCase(settingPath.split(".").at(-1)),
+    description: fallback.description || description || `Configure ${titleCase(settingPath.split(".").at(-1)).toLowerCase()}.`,
+    category: settingPath.split(".")[0],
+    control: "scalar",
+    valueType: schemaType(settingPath, fallback.value),
+    ...(Object.keys(constraints).length > 0 ? { constraints } : {}),
+    default: fallback.value,
+    platforms: ["windows", "macos"],
+    apply: applyFor(settingPath),
+    sensitivity: sensitivityFor(settingPath),
+    stability: stabilityFor(settingPath),
+    sourceSupport: ["guffawaffle"],
+    aliases: scalarAliases(settingPath),
+    provenance: { runtimePath: settingPath, defaultSource: fallback.source },
+  };
+}
+
 function buildSchema() {
-  const defaults = parseDefaultConfig();
+  const defaults = new Map([...parseDefaultConfig(), ...parseBoolConfigMetadata()]);
   const example = parseExampleConfig();
-  const parserPaths = scanLiteralParserPaths();
+  const parserPaths = scanRuntimeScalarPaths(defaults);
   const settings = [];
   const seen = new Set();
 
@@ -512,29 +586,21 @@ function buildSchema() {
     seen.add(canonicalPath);
 
     const defaultPath = resolveDefaultPath(canonicalPath);
-    const fallback = defaults.get(defaultPath);
+    const fallback = defaultPath ? defaults.get(defaultPath) : null;
     if (!fallback) {
       throw new Error(`No runtime default was resolved for ${canonicalPath} (looked for ${defaultPath}).`);
     }
 
-    const constraints = constraintsFor(canonicalPath);
-    settings.push({
-      path: canonicalPath,
-      title: titleCase(canonicalPath.split(".").at(-1)),
-      description: fallback.description || entry.description || `Configure ${titleCase(canonicalPath.split(".").at(-1)).toLowerCase()}.`,
-      category: canonicalPath.split(".")[0],
-      control: "scalar",
-      valueType: schemaType(canonicalPath, fallback.value),
-      ...(Object.keys(constraints).length > 0 ? { constraints } : {}),
-      default: fallback.value,
-      platforms: ["windows", "macos"],
-      apply: applyFor(canonicalPath),
-      sensitivity: sensitivityFor(canonicalPath),
-      stability: stabilityFor(canonicalPath),
-      sourceSupport: ["guffawaffle"],
-      aliases: scalarAliases(canonicalPath),
-      provenance: { runtimePath: canonicalPath, defaultSource: fallback.source },
-    });
+    settings.push(makeScalarSetting(canonicalPath, fallback, entry.description));
+  }
+
+  for (const parserPath of parserPaths) {
+    if (seen.has(parserPath)) continue;
+    const defaultPath = resolveDefaultPath(parserPath);
+    const fallback = defaults.get(defaultPath);
+    if (!fallback) throw new Error(`No runtime default was resolved for custom parser path ${parserPath}.`);
+    seen.add(parserPath);
+    settings.push(makeScalarSetting(parserPath, fallback));
   }
 
   settings.push(...parseSyncTargetSettings(defaults), ...parseInputBindings(), ...parseNotificationSettings());
@@ -594,4 +660,12 @@ if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
   }
 }
 
-export { buildSchema, parseDefaultConfig, parseExampleConfig, scanLiteralParserPaths };
+export {
+  buildSchema,
+  parseDefaultConfig,
+  parseBoolConfigMetadata,
+  parseExampleConfig,
+  scanCustomParserPaths,
+  scanLiteralParserPaths,
+  scanRuntimeScalarPaths,
+};

--- a/scripts/generate_config_schema.mjs
+++ b/scripts/generate_config_schema.mjs
@@ -1,0 +1,597 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outputPath = path.join(repoRoot, "docs", "windows-launcher", "config-schema.guffawaffle.v1.json");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8").replaceAll("\r\n", "\n");
+}
+
+function snakeCase(value) {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1_$2")
+    .toLowerCase();
+}
+
+function titleCase(key) {
+  const acronyms = new Set(["api", "dpi", "id", "jsonl", "os", "ssl", "tls", "ui", "url"]);
+  return key
+    .split("_")
+    .map((part) => acronyms.has(part) ? part.toUpperCase() : part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function parseLiteral(raw) {
+  const value = raw.trim().replace(/;$/, "");
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (/^-?\d+$/.test(value)) return Number.parseInt(value, 10);
+  if (/^-?(?:\d+\.\d*|\d*\.\d+)$/.test(value)) return Number.parseFloat(value);
+  if (/^"(?:[^"\\]|\\.)*"$/.test(value)) return JSON.parse(value);
+  throw new Error(`Unsupported C++/TOML scalar literal: ${raw}`);
+}
+
+function parseDefaultConfig() {
+  const lines = read("mods/src/defaultconfig.h").split("\n");
+  const namespaceStack = [];
+  const values = new Map();
+  let comments = [];
+
+  const rootSection = new Map([
+    ["Buffs", "buffs"],
+    ["SystemConfig", "config"],
+    ["Control", "control"],
+    ["Graphics", "graphics"],
+    ["Advanced", "advanced"],
+    ["BattleLogDecoder", "battle_log_decoder"],
+    ["Notifications", "notifications"],
+    ["Patches", "patches"],
+    ["Shortcuts", "shortcuts"],
+    ["Sync", "sync"],
+    ["Sidecar", "sidecar"],
+    ["UI", "ui"],
+  ]);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const namespaceMatch = trimmed.match(/^namespace\s+([A-Za-z0-9_]+)\s*$/);
+    if (namespaceMatch) {
+      namespaceStack.push(namespaceMatch[1]);
+      comments = [];
+      continue;
+    }
+
+    if (/^}\s*\/\/\s*namespace/.test(trimmed)) {
+      namespaceStack.pop();
+      comments = [];
+      continue;
+    }
+
+    if (trimmed.startsWith("///")) {
+      comments.push(trimmed.replace(/^\/\/\/<?\s?/, "").trim());
+      continue;
+    }
+
+    const constantMatch = trimmed.match(
+      /^constexpr\s+(?:bool|int|auto|const\s+char\s*\*)\s+([A-Za-z0-9_]+)\s*=\s*(.+?);\s*(?:\/\/\/?<\s*(.*))?$/,
+    );
+    if (!constantMatch || namespaceStack[0] !== "DefaultConfig" || namespaceStack.length < 2) {
+      if (trimmed && !trimmed.startsWith("#") && !trimmed.startsWith("//")) comments = [];
+      continue;
+    }
+
+    const section = rootSection.get(namespaceStack[1]);
+    if (!section) {
+      comments = [];
+      continue;
+    }
+
+    const nested = namespaceStack.slice(2).map(snakeCase);
+    const settingPath = [section, ...nested, constantMatch[1]].join(".");
+    const description = [...comments, constantMatch[3] ?? ""]
+      .filter(Boolean)
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+
+    // A conditional build override may define the same key twice. The final
+    // declaration is the normal production fallback in defaultconfig.h.
+    values.set(settingPath, {
+      value: parseLiteral(constantMatch[2]),
+      description,
+      source: `mods/src/defaultconfig.h:${settingPath}`,
+    });
+    comments = [];
+  }
+
+  return values;
+}
+
+function stripTomlComment(raw) {
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index < raw.length; index += 1) {
+    const character = raw[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quoted) {
+      escaped = true;
+      continue;
+    }
+    if (character === "\"") quoted = !quoted;
+    if (character === "#" && !quoted) return raw.slice(0, index);
+  }
+  return raw;
+}
+
+function parseExampleConfig() {
+  const entries = [];
+  let section = "";
+  let comments = [];
+
+  for (const [lineIndex, line] of read("example_community_patch_settings.toml").split("\n").entries()) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      comments = [];
+      continue;
+    }
+    if (trimmed.startsWith("#")) {
+      const text = trimmed.replace(/^#+\s?/, "").trim();
+      if (text && !/^[<\[=*>|\-]+$/.test(text) && !/^[*#\s]+$/.test(text)) comments.push(text);
+      continue;
+    }
+
+    const sectionMatch = trimmed.match(/^\[([A-Za-z0-9_.-]+)]$/);
+    if (sectionMatch) {
+      section = sectionMatch[1];
+      comments = [];
+      continue;
+    }
+
+    const settingMatch = stripTomlComment(trimmed).match(/^([A-Za-z0-9_-]+)\s*=\s*(.+?)\s*$/);
+    if (!settingMatch) {
+      throw new Error(`Unsupported reference TOML syntax at line ${lineIndex + 1}: ${line}`);
+    }
+
+    entries.push({
+      path: `${section}.${settingMatch[1]}`,
+      value: parseLiteral(settingMatch[2]),
+      description: comments.join(" ").replace(/\s+/g, " ").trim(),
+      line: lineIndex + 1,
+    });
+    comments = [];
+  }
+
+  return entries;
+}
+
+function captureBalancedCall(source, name, startIndex) {
+  const open = source.indexOf("(", startIndex + name.length);
+  if (open < 0) return null;
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = open; index < source.length; index += 1) {
+    const character = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quoted) {
+      escaped = true;
+      continue;
+    }
+    if (character === "\"") quoted = !quoted;
+    if (quoted) continue;
+    if (character === "(") depth += 1;
+    if (character === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, index);
+    }
+  }
+  throw new Error(`Unbalanced ${name} call`);
+}
+
+function splitArguments(call) {
+  const args = [];
+  let start = 0;
+  let depth = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index < call.length; index += 1) {
+    const character = call[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quoted) {
+      escaped = true;
+      continue;
+    }
+    if (character === "\"") quoted = !quoted;
+    if (quoted) continue;
+    if ("([{<".includes(character)) depth += 1;
+    if ([")", "]", "}", ">"].includes(character)) depth -= 1;
+    if (character === "," && depth === 0) {
+      args.push(call.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  args.push(call.slice(start).trim());
+  return args;
+}
+
+function unquoteCpp(value) {
+  return /^"(?:[^"\\]|\\.)*"$/.test(value) ? JSON.parse(value) : null;
+}
+
+function scanLiteralParserPaths() {
+  const source = read("mods/src/config.cc");
+  const paths = new Set();
+  const name = "get_config_or_default";
+  let cursor = source.indexOf("void Config::Load()");
+  while ((cursor = source.indexOf(name, cursor)) >= 0) {
+    const call = captureBalancedCall(source, name, cursor);
+    const args = splitArguments(call);
+    if (args.length >= 5 && args[0] === "config" && args[1] === "parsed") {
+      const section = unquoteCpp(args[2]);
+      const key = unquoteCpp(args[3]);
+      if (section && key) paths.add(`${section}.${key}`);
+    }
+    cursor += name.length;
+  }
+  return paths;
+}
+
+function parseInputBindings() {
+  const registry = read("mods/src/patches/input_binding/action_registry.cc");
+  const bridge = read("mods/src/patches/input_binding/input_config_bridge.cc");
+  const actions = [];
+  const actionPattern =
+    /InputActionId::([A-Za-z0-9_]+)\s*,\s*"([^"]+)"\s*,\s*"([^"]*)"\s*,\s*TriggerMode::/g;
+  for (const match of registry.matchAll(actionPattern)) {
+    actions.push({ id: match[1], key: match[2], defaultValue: match[3] });
+  }
+
+  const aliasArrays = new Map();
+  const arrayPattern =
+    /constexpr\s+BindingConfigAlias\s+(k[A-Za-z0-9_]+Aliases)\[\]\s*=\s*\{([\s\S]*?)\};/g;
+  for (const match of bridge.matchAll(arrayPattern)) {
+    const aliases = [];
+    const aliasPattern = /\{\s*"([^"]+)"\s*,\s*BindingConfigSourceKind::([A-Za-z0-9_]+)/g;
+    for (const alias of match[2].matchAll(aliasPattern)) {
+      aliases.push({
+        path: `shortcuts.${alias[1]}`,
+        status: alias[2] === "DeprecatedAlias" ? "deprecated" : "compatibility",
+        precedence: "canonical-wins",
+      });
+    }
+    aliasArrays.set(match[1], aliases);
+  }
+
+  const actionAliases = new Map();
+  const switchPattern =
+    /case\s+InputActionId::([A-Za-z0-9_]+)\s*:\s*return\s+(k[A-Za-z0-9_]+Aliases)\s*;/g;
+  for (const match of bridge.matchAll(switchPattern)) {
+    actionAliases.set(match[1], aliasArrays.get(match[2]) ?? []);
+  }
+
+  return actions.map((action) => ({
+    path: `input.bindings.${action.key}`,
+    title: titleCase(action.key),
+    description: `Keyboard or mouse binding for ${titleCase(action.key).toLowerCase()}.`,
+    category: "input",
+    control: "keybinding",
+    valueType: { kind: "keybinding" },
+    default: action.defaultValue,
+    platforms: ["windows", "macos"],
+    apply: "next-session",
+    sensitivity: "public",
+    stability: "stable",
+    sourceSupport: ["guffawaffle"],
+    aliases: actionAliases.get(action.id) ?? [],
+    provenance: { runtimePath: `input.bindings.${action.key}`, defaultSource: "input-action-registry" },
+  }));
+}
+
+function parseNotificationSettings() {
+  const source = read("mods/src/patches/notification_catalog.h");
+  const settings = [];
+  const entryPattern =
+    /NotificationEventCatalogEntry\{\s*NotificationKind::([A-Za-z0-9_]+)\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"\s*,\s*"([^"]+)"[\s\S]*?NotificationSound::([A-Za-z0-9_]+)\s*\}/g;
+
+  for (const match of source.matchAll(entryPattern)) {
+    const [, , canonicalKey, runtimeName, legacyCategory, legacyKey, sound] = match;
+    const aliases = [
+      `notifications.events.${legacyCategory}.${legacyKey}`,
+      `notifications.system.${legacyCategory}.${legacyKey}`,
+      `notifications.audio.${legacyCategory}.${legacyKey}`,
+      `notifications.notifications_${canonicalKey}`,
+    ].map((aliasPath) => ({
+      path: aliasPath,
+      status: "deprecated",
+      precedence: "canonical-replaces-whole-policy",
+      removal: "3.0.0",
+    }));
+
+    settings.push({
+      path: `notifications.${canonicalKey}`,
+      title: titleCase(canonicalKey),
+      description: `Configure system and audio delivery for the ${runtimeName} event.`,
+      category: "notifications",
+      control: "notification-policy",
+      valueType: {
+        kind: "union",
+        variants: [
+          { kind: "boolean", semantics: { false: "disabled", true: "system-only" } },
+          {
+            kind: "object",
+            replacement: "whole-value",
+            fields: {
+              system: { kind: "boolean", default: false },
+              audio: { kind: "boolean", default: false },
+              sound: {
+                kind: "enum",
+                values: ["none", "default", "info", "success", "warning", "alarm", "arrival", "soft", "ping", "repair"],
+                default: snakeCase(sound),
+              },
+            },
+          },
+        ],
+      },
+      default: false,
+      expandedDefault: { system: false, audio: false, sound: snakeCase(sound) },
+      invalidValueBehavior: "warn-and-use-event-default",
+      platforms: ["windows", "macos"],
+      apply: "next-session",
+      sensitivity: "public",
+      stability: runtimeName.startsWith("experimental.") ? "experimental" : "stable",
+      sourceSupport: ["guffawaffle"],
+      aliases,
+      provenance: { runtimePath: `notifications.${canonicalKey}`, defaultSource: "notification-event-catalog" },
+    });
+  }
+
+  if (settings.length === 0) throw new Error("No notification catalog entries were discovered.");
+  return settings;
+}
+
+function parseSyncTargetSettings(defaults) {
+  const configHeader = read("mods/src/config.h");
+  const optionKeys = [...configHeader.matchAll(
+    /SyncConfig::Option\{SyncConfig::Type::[A-Za-z0-9_]+,\s*"[^"]+",\s*"([^"]+)"/g,
+  )].map((match) => match[1]);
+  const keys = [
+    "url",
+    "token",
+    "proxy",
+    "verify_ssl",
+    "allow_unsafe_tls_without_certificate_validation",
+    ...optionKeys,
+  ];
+
+  const uniqueKeys = [...new Set(keys)];
+  const settings = uniqueKeys.map((key) => {
+    const fallback = defaults.get(`sync.${key}`);
+    if (!fallback) throw new Error(`No sync target default was found for ${key}.`);
+    const settingPath = `sync.targets.*.${key}`;
+    return {
+      path: settingPath,
+      title: titleCase(key),
+      description: fallback.description || `Configure ${titleCase(key).toLowerCase()} for this sync target.`,
+      category: "sync",
+      control: "scalar",
+      valueType: schemaType(settingPath, fallback.value),
+      default: fallback.value,
+      platforms: ["windows", "macos"],
+      apply: "next-session",
+      sensitivity: sensitivityFor(settingPath),
+      stability: "stable",
+      sourceSupport: ["guffawaffle"],
+      aliases: [],
+      provenance: { runtimePath: settingPath, defaultSource: fallback.source },
+    };
+  });
+
+  settings.push({
+    path: "sync.targets.*.mode",
+    title: "Mode",
+    description: "Outbound sync contract used by this target.",
+    category: "sync",
+    control: "scalar",
+    valueType: { kind: "enum", values: ["legacy", "majel"] },
+    default: "legacy",
+    platforms: ["windows", "macos"],
+    apply: "next-session",
+    sensitivity: "public",
+    stability: "stable",
+    sourceSupport: ["guffawaffle"],
+    aliases: [],
+    provenance: { runtimePath: "sync.targets.*.mode", defaultSource: "SyncTargetConfig::Mode" },
+  });
+  return settings;
+}
+
+function schemaType(settingPath, value) {
+  const enumValues = {
+    "input.scopely_shortcuts": ["off", "native", "fallback"],
+    "input.original_frame_policy": ["mod", "fallthrough_unhandled", "fallthrough_all"],
+    "sidecar.sync.fleet_runtime_mode": ["normal", "request_only", "snapshot_only", "enqueue_no_transport"],
+  };
+  if (settingPath.startsWith("ui.mission_hud.")) {
+    return { kind: "enum", values: ["auto", "always", "never"] };
+  }
+  if (enumValues[settingPath]) return { kind: "enum", values: enumValues[settingPath] };
+  if (typeof value === "boolean") return { kind: "boolean" };
+  if (typeof value === "number") return { kind: Number.isInteger(value) ? "integer" : "number" };
+  if (typeof value === "string") return { kind: "string" };
+  if (Array.isArray(value)) return { kind: "array" };
+  throw new Error(`Unsupported schema value: ${JSON.stringify(value)}`);
+}
+
+function sensitivityFor(settingPath) {
+  const leaf = settingPath.split(".").at(-1);
+  if (leaf === "token") return "secret";
+  if (["url", "proxy", "loader_image", "root"].includes(leaf)) return "private";
+  return "public";
+}
+
+function stabilityFor(settingPath) {
+  if (settingPath.startsWith("advanced.diagnostics.")) return "internal";
+  if (settingPath.startsWith("patches.")) return "advanced";
+  if (settingPath === "control.enable_experimental" || settingPath.startsWith("advanced.queue.")) return "experimental";
+  return "stable";
+}
+
+function applyFor(settingPath) {
+  return settingPath.startsWith("patches.") ? "restart-required" : "next-session";
+}
+
+function scalarAliases(settingPath) {
+  const aliases = {
+    "input.original_frame_policy": [
+      { path: "control.original_frame_policy", status: "deprecated", precedence: "canonical-wins" },
+    ],
+    "sidecar.sync.battlelog_enrichment": [
+      { path: "battle_log_decoder.enabled", status: "deprecated", precedence: "canonical-wins" },
+    ],
+    "advanced.diagnostics.ship_identity": [
+      { path: "sidecar.probes.ship_identity", status: "deprecated", precedence: "canonical-wins" },
+    ],
+    "advanced.diagnostics.battle_log_decoder": [
+      { path: "sidecar.probes.battle_log_decoder", status: "deprecated", precedence: "canonical-wins" },
+    ],
+    "advanced.diagnostics.battle_catalog": [
+      { path: "sidecar.probes.battle_catalog", status: "deprecated", precedence: "canonical-wins" },
+    ],
+    "advanced.diagnostics.debug": [
+      { path: "sidecar.diagnostics.debug", status: "deprecated", precedence: "canonical-wins" },
+    ],
+    "advanced.diagnostics.logging": [
+      { path: "sidecar.diagnostics.logging", status: "deprecated", precedence: "canonical-wins" },
+    ],
+  };
+  return aliases[settingPath] ?? [];
+}
+
+function constraintsFor(settingPath) {
+  if (/^advanced\.diagnostics\.files\.(?:navhook_trace|action_queue_probe)_(?:max_kb|files)$/.test(settingPath)) {
+    return { minimum: 1 };
+  }
+  return {};
+}
+
+function resolveDefaultPath(settingPath) {
+  if (settingPath === "input.scopely_shortcuts") return "control.scopely_shortcuts";
+  if (settingPath === "input.original_frame_policy") return "control.original_frame_policy";
+  if (settingPath.startsWith("sync.targets.*.")) return `sync.${settingPath.split(".").at(-1)}`;
+  return settingPath;
+}
+
+function buildSchema() {
+  const defaults = parseDefaultConfig();
+  const example = parseExampleConfig();
+  const parserPaths = scanLiteralParserPaths();
+  const settings = [];
+  const seen = new Set();
+
+  for (const entry of example) {
+    if (entry.path.startsWith("notifications.") || entry.path.startsWith("shortcuts.")) continue;
+    if (entry.path === "battle_log_decoder.enabled") continue;
+
+    const canonicalPath = entry.path.replace(/^sync\.targets\.[^.]+\./, "sync.targets.*.");
+    if (seen.has(canonicalPath)) continue;
+    seen.add(canonicalPath);
+
+    const defaultPath = resolveDefaultPath(canonicalPath);
+    const fallback = defaults.get(defaultPath);
+    if (!fallback) {
+      throw new Error(`No runtime default was resolved for ${canonicalPath} (looked for ${defaultPath}).`);
+    }
+
+    const constraints = constraintsFor(canonicalPath);
+    settings.push({
+      path: canonicalPath,
+      title: titleCase(canonicalPath.split(".").at(-1)),
+      description: fallback.description || entry.description || `Configure ${titleCase(canonicalPath.split(".").at(-1)).toLowerCase()}.`,
+      category: canonicalPath.split(".")[0],
+      control: "scalar",
+      valueType: schemaType(canonicalPath, fallback.value),
+      ...(Object.keys(constraints).length > 0 ? { constraints } : {}),
+      default: fallback.value,
+      platforms: ["windows", "macos"],
+      apply: applyFor(canonicalPath),
+      sensitivity: sensitivityFor(canonicalPath),
+      stability: stabilityFor(canonicalPath),
+      sourceSupport: ["guffawaffle"],
+      aliases: scalarAliases(canonicalPath),
+      provenance: { runtimePath: canonicalPath, defaultSource: fallback.source },
+    });
+  }
+
+  settings.push(...parseSyncTargetSettings(defaults), ...parseInputBindings(), ...parseNotificationSettings());
+  settings.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+
+  const paths = new Set(settings.map((setting) => setting.path));
+  const missingParserPaths = [...parserPaths]
+    .filter((parserPath) => !paths.has(parserPath))
+    .filter((parserPath) => ![
+      "battle_log_decoder.emit_feed",
+      "battle_log_decoder.emit_segments",
+    ].includes(parserPath));
+  if (missingParserPaths.length > 0) {
+    throw new Error(`Parser paths missing from generated schema: ${missingParserPaths.sort().join(", ")}`);
+  }
+
+  return {
+    schemaVersion: "1.0.0",
+    schemaId: "stfc-community-mod.config-schema",
+    source: {
+      id: "guffawaffle",
+      repository: "Guffawaffle/stfc-mod",
+      persistence: {
+        runtimeFormat: "toml",
+        writeMode: "sparse",
+        authority: "mod-runtime-parser",
+      },
+    },
+    contract: {
+      aliasPrecedence: "canonical-wins",
+      invalidScalarBehavior: "warn-and-use-runtime-default",
+      unknownKeyBehavior: "preserve",
+      supportedAdapters: ["scalar", "keybinding", "notification-policy"],
+    },
+    settings,
+  };
+}
+
+if (path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  const check = process.argv.includes("--check");
+  const schema = buildSchema();
+  const generated = `${JSON.stringify(schema, null, 2)}\n`;
+  if (check) {
+    if (!fs.existsSync(outputPath)) {
+      console.error(`Generated config schema is missing: ${path.relative(repoRoot, outputPath)}`);
+      process.exit(1);
+    }
+    const existing = fs.readFileSync(outputPath, "utf8").replaceAll("\r\n", "\n");
+    if (existing !== generated) {
+      console.error("Generated config schema is stale. Run: node scripts/generate_config_schema.mjs");
+      process.exit(1);
+    }
+    console.log(`Config schema is current (${schema.settings.length} settings).`);
+  } else {
+    fs.writeFileSync(outputPath, generated, "utf8");
+    console.log(`Wrote ${path.relative(repoRoot, outputPath)} (${schema.settings.length} settings).`);
+  }
+}
+
+export { buildSchema, parseDefaultConfig, parseExampleConfig, scanLiteralParserPaths };

--- a/scripts/test_config_schema.mjs
+++ b/scripts/test_config_schema.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSchema,
+  parseDefaultConfig,
+  parseExampleConfig,
+  scanLiteralParserPaths,
+} from "./generate_config_schema.mjs";
+
+test("default and example inventories are non-empty", () => {
+  assert.ok(parseDefaultConfig().size > 150);
+  assert.ok(parseExampleConfig().length > 250);
+});
+
+test("every literal generic parser path is represented", () => {
+  const schemaPaths = new Set(buildSchema().settings.map((setting) => setting.path));
+  for (const parserPath of scanLiteralParserPaths()) {
+    assert.ok(schemaPaths.has(parserPath), `missing parser path: ${parserPath}`);
+  }
+});
+
+test("schema has three unified control adapters", () => {
+  const schema = buildSchema();
+  const controls = new Set(schema.settings.map((setting) => setting.control));
+  assert.deepEqual([...controls].sort(), ["keybinding", "notification-policy", "scalar"]);
+});
+
+test("every setting has unique launcher and provenance metadata", () => {
+  const schema = buildSchema();
+  const paths = new Set();
+  for (const setting of schema.settings) {
+    assert.ok(!paths.has(setting.path), `duplicate setting path: ${setting.path}`);
+    paths.add(setting.path);
+    assert.ok(setting.title);
+    assert.ok(setting.description);
+    assert.ok(setting.category);
+    assert.ok(setting.valueType.kind);
+    assert.ok(setting.platforms.length > 0);
+    assert.ok(setting.apply);
+    assert.ok(setting.sensitivity);
+    assert.ok(setting.stability);
+    assert.ok(setting.provenance.runtimePath);
+    assert.ok(setting.provenance.defaultSource);
+    for (const alias of setting.aliases) assert.ok(alias.precedence);
+  }
+});
+
+test("notification policies replace deprecated values as a whole", () => {
+  const schema = buildSchema();
+  const incoming = schema.settings.find((setting) => setting.path === "notifications.incoming_attack_player");
+  assert.equal(incoming.control, "notification-policy");
+  assert.equal(incoming.default, false);
+  assert.equal(incoming.invalidValueBehavior, "warn-and-use-event-default");
+  assert.ok(incoming.aliases.length >= 4);
+  assert.ok(incoming.aliases.every((alias) => alias.precedence === "canonical-replaces-whole-policy"));
+});
+
+test("keybindings derive defaults and aliases from runtime registries", () => {
+  const schema = buildSchema();
+  const disable = schema.settings.find((setting) => setting.path === "input.bindings.hotkeys_disable");
+  assert.equal(disable.default, "CTRL-ALT-MINUS");
+  assert.ok(disable.aliases.some((alias) => alias.path === "shortcuts.set_hotkeys_disble"
+    && alias.status === "deprecated"));
+});
+
+test("sensitivity and restart metadata cover risky settings", () => {
+  const schema = buildSchema();
+  const token = schema.settings.find((setting) => setting.path === "sync.token");
+  const targetToken = schema.settings.find((setting) => setting.path === "sync.targets.*.token");
+  const patch = schema.settings.find((setting) => setting.path === "patches.zoomhooks");
+  assert.equal(token.sensitivity, "secret");
+  assert.equal(targetToken.sensitivity, "secret");
+  assert.equal(patch.apply, "restart-required");
+});
+
+test("deprecated sidecar observability paths are aliases, not duplicate settings", () => {
+  const schema = buildSchema();
+  const paths = new Set(schema.settings.map((setting) => setting.path));
+  assert.ok(!paths.has("battle_log_decoder.enabled"));
+  const enrichment = schema.settings.find((setting) => setting.path === "sidecar.sync.battlelog_enrichment");
+  assert.ok(enrichment.aliases.some((alias) => alias.path === "battle_log_decoder.enabled"));
+  const shipIdentity = schema.settings.find((setting) => setting.path === "advanced.diagnostics.ship_identity");
+  assert.ok(shipIdentity.aliases.some((alias) => alias.path === "sidecar.probes.ship_identity"));
+});

--- a/scripts/test_config_schema.mjs
+++ b/scripts/test_config_schema.mjs
@@ -5,19 +5,22 @@ import test from "node:test";
 
 import {
   buildSchema,
+  parseBoolConfigMetadata,
   parseDefaultConfig,
   parseExampleConfig,
-  scanLiteralParserPaths,
+  scanRuntimeScalarPaths,
 } from "./generate_config_schema.mjs";
 
 test("default and example inventories are non-empty", () => {
   assert.ok(parseDefaultConfig().size > 150);
+  assert.ok(parseBoolConfigMetadata().has("control.allow_key_fallthrough"));
   assert.ok(parseExampleConfig().length > 250);
 });
 
-test("every literal generic parser path is represented", () => {
+test("every discovered runtime scalar parser path is represented", () => {
+  const defaults = parseDefaultConfig();
   const schemaPaths = new Set(buildSchema().settings.map((setting) => setting.path));
-  for (const parserPath of scanLiteralParserPaths()) {
+  for (const parserPath of scanRuntimeScalarPaths(defaults)) {
     assert.ok(schemaPaths.has(parserPath), `missing parser path: ${parserPath}`);
   }
 });
@@ -31,6 +34,7 @@ test("schema has three unified control adapters", () => {
 test("every setting has unique launcher and provenance metadata", () => {
   const schema = buildSchema();
   const paths = new Set();
+  const aliasOwners = new Map();
   for (const setting of schema.settings) {
     assert.ok(!paths.has(setting.path), `duplicate setting path: ${setting.path}`);
     paths.add(setting.path);
@@ -44,7 +48,12 @@ test("every setting has unique launcher and provenance metadata", () => {
     assert.ok(setting.stability);
     assert.ok(setting.provenance.runtimePath);
     assert.ok(setting.provenance.defaultSource);
-    for (const alias of setting.aliases) assert.ok(alias.precedence);
+    for (const alias of setting.aliases) {
+      assert.ok(alias.precedence);
+      assert.ok(!aliasOwners.has(alias.path),
+        `alias ${alias.path} is claimed by both ${aliasOwners.get(alias.path)} and ${setting.path}`);
+      aliasOwners.set(alias.path, setting.path);
+    }
   }
 });
 
@@ -84,4 +93,30 @@ test("deprecated sidecar observability paths are aliases, not duplicate settings
   assert.ok(enrichment.aliases.some((alias) => alias.path === "battle_log_decoder.enabled"));
   const shipIdentity = schema.settings.find((setting) => setting.path === "advanced.diagnostics.ship_identity");
   assert.ok(shipIdentity.aliases.some((alias) => alias.path === "sidecar.probes.ship_identity"));
+});
+
+test("hidden runtime settings remain machine-readable but internal", () => {
+  const schema = buildSchema();
+  for (const settingPath of [
+    "advanced.diagnostics.runtime_trace",
+    "advanced.diagnostics.runtime_trace_report_interval_ms",
+    "advanced.queue.queue_repair_enabled",
+    "advanced.kirshara_queue.course_target_completion",
+    "control.allow_key_fallthrough",
+  ]) {
+    const setting = schema.settings.find((candidate) => candidate.path === settingPath);
+    assert.ok(setting, `missing hidden runtime setting: ${settingPath}`);
+    assert.ok(["internal", "experimental"].includes(setting.stability));
+  }
+});
+
+test("every reference setting is canonical or represented by an alias", () => {
+  const schema = buildSchema();
+  const canonicalPaths = new Set(schema.settings.map((setting) => setting.path));
+  const aliasPaths = new Set(schema.settings.flatMap((setting) => setting.aliases.map((alias) => alias.path)));
+  for (const entry of parseExampleConfig()) {
+    const normalized = entry.path.replace(/^sync\.targets\.[^.]+\./, "sync.targets.*.");
+    assert.ok(canonicalPaths.has(normalized) || aliasPaths.has(normalized),
+      `reference setting is neither canonical nor an alias: ${entry.path}`);
+  }
 });


### PR DESCRIPTION
Closes #176

## What changed

- generates a versioned `guffawaffle` launcher schema from runtime-owned C++ defaults and catalogs
- unifies scalar, keybinding, and notification-policy controls under one metadata envelope
- includes 332 canonical settings with types/defaults, platform/apply behavior, sensitivity, stability, aliases, precedence, source identity, and provenance
- includes hidden runtime/science settings as `internal` or `experimental` so diagnostics remains complete while the player UI can omit them
- derives dynamic `sync.targets.*`, input aliases, notification sounds, and whole-policy replacement semantics from their authoritative runtime tables
- checks in the deterministic JSON artifact and fails CI when parser/catalog/reference coverage drifts
- removes the advertised but unimplemented `shortcuts.move_up` and `shortcuts.move_down` ghost controls
- documents the NetniV/Guffawaffle release-source boundary and retains sparse TOML as the runtime/interchange contract

## Why

The Windows launcher needs a searchable settings model without hand-copying C++ defaults into C#. Source-specific schemas also prevent the launcher from assuming Guffawaffle capabilities apply to a NetniV artifact.

The anchor review found that public-reference coverage alone omitted intentionally hidden runtime controls. The completed contract scans literal and custom-reader parser paths, includes those settings with non-player stability tiers, and verifies every reference setting is canonical or an explicit alias.

## Validation

- `node --test scripts/test_config_schema.mjs` — 10/10 passed
- `node scripts/generate_config_schema.mjs --check` — current, 332 settings
- `xmake build stfc-mod-tests`
- `xmake run stfc-mod-tests` — 326/326 cases, 4,472 assertions
- `node --check` for both scripts
- `git diff --check`

## PM notes

- release-source/install migration behavior recorded on #175
- source-capability/editor behavior recorded on #177
- NetniV mode retains TOML as a hard compatibility boundary
- Lex handoff frame: `frame-1785139720323-f8189dda-0e62-4d7c-9f4a-c8cdb56af177`