### PR TITLE
Make the canonical IL2CPP corpus path unambiguous

### DIFF
--- a/manifests/capabilities/global.stfc-mod-private.corpus-status.json
+++ b/manifests/capabilities/global.stfc-mod-private.corpus-status.json
@@ -1,0 +1,44 @@
+{
+  "manifestVersion": "axf/v0",
+  "id": "global.stfc-mod-private.corpus-status",
+  "summary": "Identify the canonical IL2CPP research corpus and warn about stale or divergent duplicate artifact trees",
+  "provider": "stfc",
+  "adapterType": "cli",
+  "executionTarget": {
+    "launcher": {
+      "command": "node",
+      "args": []
+    },
+    "target": {
+      "path": "scripts/axf/corpus-status.mjs",
+      "relativeTo": "workspace"
+    }
+  },
+  "argsSchema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  },
+  "outputModes": [
+    "json"
+  ],
+  "sideEffects": "read",
+  "scope": "global",
+  "lifecycleState": "active",
+  "defaults": {},
+  "policies": [
+    "require_workspace_binding"
+  ],
+  "owner": "module:stfc",
+  "argMap": {},
+  "warnings": [
+    "Raw IL2CPP research must use tools/il2cpp-dump/dump.cs and tools/il2cpp-dump/script.json.",
+    ".ax-priv/tools/Il2CppDumper is a plausible legacy tool-artifact tree and is never a canonical research input."
+  ],
+  "details": [
+    "Reports canonical artifact and index metadata without returning source bodies.",
+    "Fingerprints same-named artifacts under the legacy tree and classifies them as identical, stale, divergent-newer, or legacy-only.",
+    "Rejects symlinked corpus files and path components instead of hashing targets outside the declared corpus roots.",
+    "Use global.stfc-mod-private.dump-refresh to regenerate the canonical corpus."
+  ]
+}

--- a/manifests/families/stfc-mod-private.family.json
+++ b/manifests/families/stfc-mod-private.family.json
@@ -1891,9 +1891,17 @@
         "stats": {},
         "max-namespaces": {}
       },
-      "warnings": [],
-      "details": [],
-      "examples": []
+      "warnings": [
+        "Raw IL2CPP research must use tools/il2cpp-dump; .ax-priv/tools/Il2CppDumper is a non-canonical legacy artifact tree."
+      ],
+      "details": [
+        "This compatibility command reports dump/index freshness against installed game binaries.",
+        "Run global.stfc-mod-private.corpus-status before raw searches to detect stale, identical, divergent, or legacy-only duplicate artifact trees."
+      ],
+      "examples": [
+        "ax dump-status",
+        "axf run global.stfc-mod-private.corpus-status --json"
+      ]
     },
     "dump-refresh": {
       "summary": "Regenerate dump.cs, rebuild indexes, and track research corpus changes",

--- a/scripts/axf/README.md
+++ b/scripts/axf/README.md
@@ -24,6 +24,7 @@ global.stfc-mod-private.status
 global.stfc-mod-private.pure-tests
 global.stfc-mod-private.battle-log
 global.stfc-mod-private.cycle
+global.stfc-mod-private.corpus-status
 ```
 
 Raw CLI execution is for provider development and manual debugging only.
@@ -115,3 +116,22 @@ source bodies are never returned.
 The dump query commands currently run the existing Python dump tools from
 `/mnt/d/dev/stfc-mod/.ax-priv` and use that reference cache. The pure decoder
 validation path is native to `/srv/stfc-mod`.
+
+## Canonical IL2CPP Corpus
+
+Raw human and agent searches must use:
+
+```text
+tools/il2cpp-dump/dump.cs
+tools/il2cpp-dump/script.json
+```
+
+The matching query index is `.ax-priv/cache/stfc.db`. Files under
+`.ax-priv/tools/Il2CppDumper/` are private tool artifacts, not research inputs,
+even when their names look authoritative.
+
+Run `global.stfc-mod-private.corpus-status` before raw dump research. It reports
+the canonical paths and index metadata, fingerprints plausible legacy copies,
+and classifies each copy as identical, stale, divergent-newer, or legacy-only.
+The command never returns dump contents. Use `global.stfc-mod-private.dump-refresh`
+to regenerate the canonical corpus.

--- a/scripts/axf/corpus-status.mjs
+++ b/scripts/axf/corpus-status.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream, lstatSync, realpathSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const CORPUS_FILES = ["dump.cs", "script.json"];
+
+async function sha256File(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
+function isContained(root, path) {
+  const relation = relative(root, path);
+  return (
+    relation === "" || (!relation.startsWith(`..${sep}`) && relation !== "..")
+  );
+}
+
+function inspectPhysicalPath(path, { repoRoot, allowedRoot }) {
+  if (!isContained(repoRoot, allowedRoot) || !isContained(allowedRoot, path)) {
+    return { exists: false, error: "path-outside-allowed-root" };
+  }
+
+  try {
+    const repoStat = lstatSync(repoRoot);
+    if (
+      repoStat.isSymbolicLink() ||
+      !repoStat.isDirectory() ||
+      realpathSync(repoRoot) !== repoRoot
+    ) {
+      return { exists: false, error: "unsafe-repository-root" };
+    }
+  } catch {
+    return { exists: false, error: "repository-root-unavailable" };
+  }
+
+  const segments = relative(repoRoot, path).split(sep).filter(Boolean);
+  let current = repoRoot;
+  for (const [index, segment] of segments.entries()) {
+    current = join(current, segment);
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch (error) {
+      if (error?.code === "ENOENT") return { exists: false };
+      return { exists: false, error: "path-inspection-failed" };
+    }
+    if (stat.isSymbolicLink()) {
+      return { exists: false, error: "symlink-not-allowed" };
+    }
+    const isTarget = index === segments.length - 1;
+    if (!isTarget && !stat.isDirectory()) {
+      return { exists: false, error: "path-component-not-directory" };
+    }
+    if (isTarget && !stat.isFile()) {
+      return { exists: false, error: "not-a-file" };
+    }
+    if (isTarget) return { exists: true, stat };
+  }
+
+  return { exists: false, error: "not-a-file" };
+}
+
+async function inspectFile(path, { hash = true, repoRoot, allowedRoot } = {}) {
+  const physical = inspectPhysicalPath(path, { repoRoot, allowedRoot });
+  if (!physical.exists) {
+    return {
+      path,
+      exists: false,
+      sizeBytes: null,
+      modifiedAt: null,
+      sha256: null,
+      ...(physical.error ? { error: physical.error } : {}),
+    };
+  }
+
+  return {
+    path,
+    exists: true,
+    sizeBytes: physical.stat.size,
+    modifiedAt: physical.stat.mtime.toISOString(),
+    sha256: hash ? await sha256File(path) : null,
+  };
+}
+
+function classifyDuplicate(canonical, candidate) {
+  if (!candidate.exists) return null;
+  if (!canonical.exists) return "legacy-only";
+  if (candidate.sha256 === canonical.sha256) return "identical-copy";
+  return Date.parse(candidate.modifiedAt) <= Date.parse(canonical.modifiedAt)
+    ? "stale-copy"
+    : "divergent-newer-copy";
+}
+
+function duplicateWarning(name, relation, canonicalPath, candidatePath) {
+  const prefix = `${candidatePath} is a plausible duplicate of ${canonicalPath}`;
+  switch (relation) {
+    case "identical-copy":
+      return `${prefix}. It is currently identical, but raw research must use the canonical ${name} path.`;
+    case "stale-copy":
+      return `${prefix} and is stale. Do not use it as current research evidence.`;
+    case "divergent-newer-copy":
+      return `${prefix} and is newer but content-divergent. Reconcile it before treating either update as current evidence.`;
+    case "legacy-only":
+      return `${candidatePath} exists while the canonical ${name} is missing. Restore the canonical corpus before research.`;
+    default:
+      return null;
+  }
+}
+
+export async function inspectCorpus(options = {}) {
+  const repoRoot = resolve(options.repoRoot ?? REPO_ROOT);
+  const canonicalRoot = resolve(
+    options.canonicalRoot ?? join(repoRoot, "tools", "il2cpp-dump"),
+  );
+  const legacyRoot = resolve(
+    options.legacyRoot ?? join(repoRoot, ".ax-priv", "tools", "Il2CppDumper"),
+  );
+  const indexPath = resolve(
+    options.indexPath ?? join(repoRoot, ".ax-priv", "cache", "stfc.db"),
+  );
+
+  const canonical = {};
+  const legacy = {};
+  const duplicates = [];
+  const warnings = [];
+  const inspectionErrors = [];
+
+  for (const name of CORPUS_FILES) {
+    canonical[name] = await inspectFile(join(canonicalRoot, name), {
+      repoRoot,
+      allowedRoot: canonicalRoot,
+    });
+    legacy[name] = await inspectFile(join(legacyRoot, name), {
+      repoRoot,
+      allowedRoot: legacyRoot,
+    });
+    for (const entry of [canonical[name], legacy[name]]) {
+      if (!entry.error) continue;
+      inspectionErrors.push(entry);
+      warnings.push(
+        `${entry.path} was not inspected because its path is unsafe (${entry.error}).`,
+      );
+    }
+    const relation = classifyDuplicate(canonical[name], legacy[name]);
+    if (!relation) continue;
+    duplicates.push({
+      artifact: name,
+      relation,
+      canonicalPath: canonical[name].path,
+      candidatePath: legacy[name].path,
+      canonicalSha256: canonical[name].sha256,
+      candidateSha256: legacy[name].sha256,
+    });
+    warnings.push(
+      duplicateWarning(name, relation, canonical[name].path, legacy[name].path),
+    );
+  }
+
+  const missingCanonical = CORPUS_FILES.filter(
+    (name) => !canonical[name].exists,
+  );
+  if (missingCanonical.length > 0) {
+    warnings.unshift(
+      `Canonical corpus is incomplete at ${canonicalRoot}; missing: ${missingCanonical.join(", ")}.`,
+    );
+  }
+
+  const index = await inspectFile(indexPath, {
+    hash: false,
+    repoRoot,
+    allowedRoot: dirname(indexPath),
+  });
+  if (index.error) {
+    inspectionErrors.push(index);
+    warnings.push(
+      `${index.path} was not inspected because its path is unsafe (${index.error}).`,
+    );
+  }
+  if (!index.exists) {
+    warnings.push(`The canonical dump index is missing at ${indexPath}.`);
+  }
+
+  const canonicalReady = missingCanonical.length === 0;
+  const pathsSafe = inspectionErrors.length === 0;
+  return {
+    ok: canonicalReady && pathsSafe,
+    state: !pathsSafe
+      ? "unsafe-path"
+      : canonicalReady
+        ? duplicates.length > 0
+          ? "duplicate-warning"
+          : "ready"
+        : "canonical-missing",
+    guidance: {
+      canonicalRoot,
+      canonicalDump: join(canonicalRoot, "dump.cs"),
+      canonicalMetadata: join(canonicalRoot, "script.json"),
+      canonicalIndex: indexPath,
+      rawSearchRoot: canonicalRoot,
+      statusCapability: "global.stfc-mod-private.corpus-status",
+      refreshCapability: "global.stfc-mod-private.dump-refresh",
+    },
+    canonical,
+    legacyCandidates: legacy,
+    index,
+    duplicateCandidates: duplicates,
+    warnings,
+  };
+}
+
+async function main() {
+  try {
+    if (process.argv.length > 2) {
+      throw new Error("corpus-status does not accept path overrides");
+    }
+    const data = await inspectCorpus();
+    process.stdout.write(`${JSON.stringify({ ok: data.ok, data })}\n`);
+    process.exitCode = 0;
+  } catch (error) {
+    process.stdout.write(
+      `${JSON.stringify({
+        ok: false,
+        error: {
+          message: error instanceof Error ? error.message : String(error),
+        },
+      })}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/axf/corpus-status.test.mjs
+++ b/scripts/axf/corpus-status.test.mjs
@@ -1,0 +1,231 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { inspectCorpus } from "./corpus-status.mjs";
+
+const roots = [];
+
+function fixture() {
+  const repoRoot = mkdtempSync(join(tmpdir(), "stfc-corpus-status-"));
+  roots.push(repoRoot);
+  const canonicalRoot = join(repoRoot, "tools", "il2cpp-dump");
+  const legacyRoot = join(repoRoot, ".ax-priv", "tools", "Il2CppDumper");
+  const indexPath = join(repoRoot, ".ax-priv", "cache", "stfc.db");
+  mkdirSync(canonicalRoot, { recursive: true });
+  mkdirSync(legacyRoot, { recursive: true });
+  mkdirSync(join(repoRoot, ".ax-priv", "cache"), { recursive: true });
+  return { repoRoot, canonicalRoot, legacyRoot, indexPath };
+}
+
+function writeCanonical(paths, suffix = "current") {
+  writeFileSync(
+    join(paths.canonicalRoot, "dump.cs"),
+    `canonical-dump-${suffix}\n`,
+  );
+  writeFileSync(
+    join(paths.canonicalRoot, "script.json"),
+    JSON.stringify({ corpus: suffix }),
+  );
+  writeFileSync(paths.indexPath, `sqlite-index-${suffix}\n`);
+}
+
+function installPublicScript(paths) {
+  const scriptDir = join(paths.repoRoot, "scripts", "axf");
+  mkdirSync(scriptDir, { recursive: true });
+  const scriptPath = join(scriptDir, "corpus-status.mjs");
+  copyFileSync(join(import.meta.dirname, "corpus-status.mjs"), scriptPath);
+  return scriptPath;
+}
+
+function invokePublicScript(paths) {
+  const result = spawnSync(process.execPath, [installPublicScript(paths)], {
+    cwd: paths.repoRoot,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0);
+  return JSON.parse(result.stdout);
+}
+
+test.afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reports the tracked dump root as the only canonical raw-search path", async () => {
+  const paths = fixture();
+  writeCanonical(paths);
+
+  const result = await inspectCorpus({ repoRoot: paths.repoRoot });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.state, "ready");
+  assert.equal(result.guidance.canonicalRoot, paths.canonicalRoot);
+  assert.equal(result.guidance.rawSearchRoot, paths.canonicalRoot);
+  assert.equal(result.guidance.canonicalIndex, paths.indexPath);
+  assert.deepEqual(result.duplicateCandidates, []);
+  assert.deepEqual(result.warnings, []);
+});
+
+test("missing canonical artifacts fail closed even when a legacy copy exists", async () => {
+  const paths = fixture();
+  writeFileSync(join(paths.legacyRoot, "dump.cs"), "legacy-only\n");
+
+  const result = await inspectCorpus({ repoRoot: paths.repoRoot });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.state, "canonical-missing");
+  assert.deepEqual(
+    result.duplicateCandidates.map((entry) => [entry.artifact, entry.relation]),
+    [["dump.cs", "legacy-only"]],
+  );
+  assert.match(result.warnings.join("\n"), /Restore the canonical corpus/);
+});
+
+test("classifies content-divergent older legacy artifacts as stale", async () => {
+  const paths = fixture();
+  writeCanonical(paths);
+  const legacyDump = join(paths.legacyRoot, "dump.cs");
+  const legacyMetadata = join(paths.legacyRoot, "script.json");
+  writeFileSync(legacyDump, "old-dump\n");
+  writeFileSync(legacyMetadata, JSON.stringify({ corpus: "old" }));
+  const oldTime = new Date("2025-01-01T00:00:00.000Z");
+  utimesSync(legacyDump, oldTime, oldTime);
+  utimesSync(legacyMetadata, oldTime, oldTime);
+
+  const result = await inspectCorpus({ repoRoot: paths.repoRoot });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.state, "duplicate-warning");
+  assert.deepEqual(
+    result.duplicateCandidates.map((entry) => entry.relation),
+    ["stale-copy", "stale-copy"],
+  );
+  assert.match(result.warnings.join("\n"), /must use|Do not use/);
+});
+
+test("identical legacy copies still warn because the path is non-canonical", async () => {
+  const paths = fixture();
+  writeCanonical(paths);
+  writeFileSync(join(paths.legacyRoot, "dump.cs"), "canonical-dump-current\n");
+  writeFileSync(
+    join(paths.legacyRoot, "script.json"),
+    JSON.stringify({ corpus: "current" }),
+  );
+
+  const result = await inspectCorpus({ repoRoot: paths.repoRoot });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    result.duplicateCandidates.map((entry) => entry.relation),
+    ["identical-copy", "identical-copy"],
+  );
+  assert.match(
+    result.warnings.join("\n"),
+    /raw research must use the canonical/,
+  );
+});
+
+test("newer divergent legacy copies are surfaced without leaking file bodies", async () => {
+  const paths = fixture();
+  writeCanonical(paths);
+  const privateBody = "private-legacy-source-body";
+  const legacyDump = join(paths.legacyRoot, "dump.cs");
+  writeFileSync(legacyDump, privateBody);
+  const future = new Date("2030-01-01T00:00:00.000Z");
+  utimesSync(legacyDump, future, future);
+
+  const result = await inspectCorpus({ repoRoot: paths.repoRoot });
+  const serialized = JSON.stringify(result);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.duplicateCandidates[0].relation, "divergent-newer-copy");
+  assert.match(result.warnings.join("\n"), /Reconcile it/);
+  assert.equal(serialized.includes(privateBody), false);
+});
+
+test("missing index is reported separately from canonical artifact readiness", async () => {
+  const paths = fixture();
+  writeCanonical(paths);
+  rmSync(paths.indexPath);
+
+  const result = await inspectCorpus({ repoRoot: paths.repoRoot });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.index.exists, false);
+  assert.match(result.warnings.join("\n"), /canonical dump index is missing/);
+});
+
+test("the public capability rejects path overrides", () => {
+  const result = spawnSync(
+    process.execPath,
+    [join(import.meta.dirname, "corpus-status.mjs"), "--repo-root", "/tmp"],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 1);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    ok: false,
+    error: {
+      message: "corpus-status does not accept path overrides",
+    },
+  });
+});
+
+test("the public capability refuses a symlinked canonical artifact", () => {
+  const paths = fixture();
+  const outsideRoot = mkdtempSync(join(tmpdir(), "stfc-corpus-outside-"));
+  roots.push(outsideRoot);
+  const privateBody = "outside-canonical-private-body";
+  const outsideDump = join(outsideRoot, "outside-dump.cs");
+  writeFileSync(outsideDump, privateBody);
+  symlinkSync(outsideDump, join(paths.canonicalRoot, "dump.cs"));
+  writeFileSync(
+    join(paths.canonicalRoot, "script.json"),
+    JSON.stringify({ corpus: "current" }),
+  );
+  writeFileSync(paths.indexPath, "sqlite-index-current\n");
+
+  const envelope = invokePublicScript(paths);
+  const serialized = JSON.stringify(envelope);
+
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.data.state, "unsafe-path");
+  assert.equal(envelope.data.canonical["dump.cs"].sha256, null);
+  assert.equal(envelope.data.canonical["dump.cs"].error, "symlink-not-allowed");
+  assert.equal(serialized.includes(privateBody), false);
+});
+
+test("the public capability refuses a symlinked legacy path component", () => {
+  const paths = fixture();
+  writeCanonical(paths);
+  const outsideRoot = mkdtempSync(join(tmpdir(), "stfc-corpus-outside-"));
+  roots.push(outsideRoot);
+  const privateBody = "outside-legacy-private-body";
+  writeFileSync(join(outsideRoot, "dump.cs"), privateBody);
+  rmSync(paths.legacyRoot, { recursive: true });
+  symlinkSync(outsideRoot, paths.legacyRoot);
+
+  const envelope = invokePublicScript(paths);
+  const serialized = JSON.stringify(envelope);
+
+  assert.equal(envelope.ok, false);
+  assert.equal(envelope.data.state, "unsafe-path");
+  assert.equal(envelope.data.legacyCandidates["dump.cs"].sha256, null);
+  assert.equal(
+    envelope.data.legacyCandidates["dump.cs"].error,
+    "symlink-not-allowed",
+  );
+  assert.equal(serialized.includes(privateBody), false);
+});


### PR DESCRIPTION
Closes #188

## What changed

- add the read-only `global.stfc-mod-private.corpus-status` AXF capability
- make `tools/il2cpp-dump/{dump.cs,script.json}` the explicit raw-search corpus and `.ax-priv/cache/stfc.db` its index
- fingerprint plausible same-name artifacts under `.ax-priv/tools/Il2CppDumper` and classify them as identical, stale, divergent-newer, or legacy-only
- warn from `dump-status` guidance and document the canonical paths
- reject public path overrides, symlinked corpus entries, and symlinked path components; never emit corpus source bodies

## Why

A plausible legacy artifact tree could attract direct `rg` searches and silently mix stale RVAs with the current indexed corpus. The status surface now makes the authoritative path and any duplicate relationship explicit.

## Validation

- `node --test scripts/axf/*.test.mjs` (26/26)
- public zero-argument CLI tests for canonical-file and legacy-directory symlink escapes
- AXF `doctor --json` (73 capabilities, 0 issues)
- AXF list/inspect/run discovery and launch-plan smoke
- clean worktree reports structured `canonical-missing` guidance without a transport failure
- `node --check`, `jq empty`, focused Prettier check, and `git diff --check`

## Merge gate

Draft until hosted checks pass and an independent reviewer returns a PASS on the exact signed head.