### PR TITLE
Migrate cache actions to the Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,8 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_NOLOGO: true
 
+# actions/cache@v5 uses Node.js 24 and requires Actions Runner 2.327.1+.
+# Every job in this workflow selects a GitHub-hosted runner label.
 jobs:
   provider-contract:
     runs-on: ubuntu-latest
@@ -67,7 +69,7 @@ jobs:
           "dir=$dir" >> $env:GITHUB_OUTPUT
 
       - name: Restore xmake package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.xmake-package-dir.outputs.dir }}
           key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-win-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'win-proxy-dll/xmake.lua', 'xmake-packages/**/*.lua') }}
@@ -303,7 +305,7 @@ jobs:
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
 
       - name: Restore xmake package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.xmake-package-dir.outputs.dir }}
           key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-mac-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'macos-dylib/xmake.lua', 'macos-loader/xmake.lua', 'macos-launcher/xmake.lua', 'xmake-packages/**/*.lua') }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -12,6 +12,8 @@ concurrency:
 env:
   XMAKE_PACKAGE_CACHE_VERSION: v1
 
+# actions/cache@v5 uses Node.js 24 and requires Actions Runner 2.327.1+.
+# Every job in this workflow selects a GitHub-hosted runner label.
 jobs:
   analyze-cpp:
     name: Analyze (C/C++)
@@ -40,7 +42,7 @@ jobs:
           "dir=$dir" >> $env:GITHUB_OUTPUT
 
       - name: Restore xmake package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.xmake-package-dir.outputs.dir }}
           key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-win-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'win-proxy-dll/xmake.lua', 'xmake-packages/**/*.lua') }}
@@ -91,7 +93,7 @@ jobs:
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
 
       - name: Restore xmake package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.xmake-package-dir.outputs.dir }}
           key: xmake-packages-${{ env.XMAKE_PACKAGE_CACHE_VERSION }}-mac-${{ runner.arch }}-${{ hashFiles('xmake.lua', 'mods/xmake.lua', 'tests/xmake.lua', 'macos-dylib/xmake.lua', 'macos-loader/xmake.lua', 'macos-launcher/xmake.lua', 'xmake-packages/**/*.lua') }}


### PR DESCRIPTION
Closes #205

## What changed

- upgrade all four `actions/cache@v4` call sites in Build and CodeQL to `actions/cache@v5`
- preserve every cache path, key, and restore-key prefix unchanged
- document the Node 24 runtime and Actions Runner `2.327.1+` minimum beside both workflows
- document that the workflows select GitHub-hosted runner labels

## Why

`actions/cache@v4` targets Node 20 and now emits a deprecation annotation when GitHub forces JavaScript actions onto Node 24. The official v5 release uses Node 24 and requires Actions Runner 2.327.1 or newer.

Official compatibility note: https://github.com/actions/cache#whats-new

## Runner evidence

- the repository currently reports zero registered self-hosted runners
- every `runs-on` value in these workflows is a GitHub-hosted image label
- the exact branch will run the full Build matrix and a manually dispatched CodeQL workflow before merge

## Local validation

- actionlint passes after ignoring only its stale catalog warnings for the current `windows-2025-vs2026` and `macos-26` hosted labels
- focused Prettier check passes
- no workflow references `actions/cache@v4`
- `git diff --check` passes

## Merge gate

Draft until full Build and CodeQL runs pass without the Node 20 cache annotation and an independent reviewer returns PASS on the exact signed head.