### PR TITLE
fix: restore unlimited donation slider

### DIFF
--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -722,7 +722,7 @@ disable_veil_chat = false
 # Subgroup: Donations
 # -------------------
 
-# Extend donation slider to max value for next Alliance level
+# Extend donation slider to max value for next Alliance level; set to 0 for unlimited
 extend_donation_max = 80
 
 # Extend donation slider enable

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -39,22 +39,26 @@
  * Intercepts the donation slider cap to allow larger donations.
  * Original method: sets the maximum slider value (hard-coded to 50 for donations).
  * Our modification: when extend_donation_slider is enabled and the caller is a
- *   donation popup with cap == 50, replaces it with the user's configured max
- *   (or returns -1 for unlimited if max <= 0).
+ *   donation popup with cap == 50, replaces it with the user's configured max.
+ *   A non-positive configured max preserves the popup's initial unlimited value.
  */
-int64_t InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, int64_t a2)
+void InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, int64_t a2)
 {
+  if (!a1) {
+    return;
+  }
+
   if (a1->IsDonationUse && a2 == 50 && Config::Get().extend_donation_slider) {
     const auto max = Config::Get().extend_donation_max;
     if (max > 0) {
       a2 = max;
     } else {
-      return -1;
+      // Leave the initial unlimited value in place instead of applying the game's donation cap.
+      return;
     }
   }
 
-  int64_t standard = original(a1, a2);
-  return standard;
+  original(a1, a2);
 }
 
 // ─── Bundle Cooldown Bypass ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- restore `extend_donation_max = 0` as the unlimited donation-slider setting
- align the detour with the live `void InventoryForPopup::set_MaxItemsToUse(long)` signature
- document the zero-value behavior in the example configuration

## Root cause

Donation popups begin with an unlimited maximum, then the game applies its artificial 50-item cap through `set_MaxItemsToUse`. The old hook used the wrong return type and attempted to return `-1` instead of deliberately preserving the popup's initial value. With a configured maximum of zero, the hook now skips the game's cap setter entirely.

## User impact

Players can enable `extend_donation_slider` and set `extend_donation_max = 0` to donate without the artificial slider limit. Positive configured limits and all non-donation call paths continue to call through normally.

## Validation

- refreshed IL2CPP corpus confirms the live setter returns `void`
- Windows release `mods` target built successfully
- full Windows release DLL linked successfully
- blocking AXF review contract passed
- 326 doctest cases and 4,472 assertions passed
- hook-support and gameplay-seam scanners passed
- `git diff --check` passed

Adapted from netniV/stfc-mod#209 for the fork's current `main` branch.