### PR TITLE
Add reproducible protobuf corpus refresh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 *.cmd text eol=crlf
 *.ps1 text eol=lf
 *.sh text eol=lf
+tools/protobuf/*.patch text eol=lf whitespace=-blank-at-eol,-blank-at-eof
 
 *.png binary
 *.jpg binary

--- a/docs/PROTOBUF_REFRESH.md
+++ b/docs/PROTOBUF_REFRESH.md
@@ -1,0 +1,53 @@
+# Protobuf corpus refresh
+
+The tracked schemas in `mods/src/prime/proto` are a curated, package-aggregated
+view of protobuf types reachable in the STFC IL2CPP client. Refreshes therefore
+use a two-stage workflow:
+
+1. `scripts/Invoke-ProtobufRefresh.ps1` downloads a hash-pinned Protodec source
+   revision, applies the checked-in STFC compatibility patch, and extracts
+   candidate schemas directly from the installed `GameAssembly.dll` and
+   `global-metadata.dat`.
+2. `scripts/Compare-ProtobufCorpus.ps1` compares the candidates with the
+   tracked corpus by top-level and nested protobuf type, field number, wire
+   type/cardinality, enum value, and oneof membership. It writes a JSON report
+   containing source versions and hashes.
+
+Run from the repository root:
+
+```powershell
+.\scripts\Invoke-ProtobufRefresh.ps1
+```
+
+Protodec currently requires a .NET 10 SDK. Use `-GamePath`, `-UnityVersion`,
+`-DotNetPath`, or `-OutputRoot` when auto-detection does not match the local
+environment.
+
+Candidate files and reports are written under `.cache/protobuf-refresh`; the
+script never overwrites tracked schemas. Promote actionable additions and shape
+changes after review, then run the comparator again. A clean promotion has zero
+actionable changes. Pass `-FailOnActionableChanges` when using the refresh as a
+validation gate.
+
+`field-not-emitted`, `type-not-emitted`, and `type-incomplete` are retention
+observations, not automatic removals. IL2CPP metadata can omit inherited or
+unreachable generated members, so deleting tracked declarations based only on
+those observations would be unsafe.
+
+## 2026-07-30 refresh
+
+Source client: Unity `6000.0.59f2`.
+
+Promoted changes:
+
+- 9 `ClientModifierType` values.
+- 9 fields across `ApmFiltersStatus`, `EventMetadata`, `UserProfileSettings`,
+  and nested `BuffSpec.Attributes`.
+- 1 nested `EntityGroup.Type` value for the server `Tracker` model.
+- 9 new schema declarations covering dynamic translations, tournament
+  bundles, event-card metadata, event/news/leaderboard response holders, and
+  the server `Tracker` model.
+
+The post-promotion comparison covers 790 extracted and 803 tracked declarations
+and reports zero actionable changes. Its 81 retained observations remain
+documented in the generated JSON report for future audits.

--- a/mods/src/prime/proto/Digit.PrimePlatform.Content.proto
+++ b/mods/src/prime/proto/Digit.PrimePlatform.Content.proto
@@ -186,3 +186,10 @@ message BundleStyle {
   BundleBorderShapeType borderShapeType = 1;
 }
 
+message DynamicTranslationsContainer {
+  repeated TranslationSection sections = 1;
+}
+
+message TournamentBundlesResponse {
+  repeated Bundle bundles = 1;
+}

--- a/mods/src/prime/proto/Digit.PrimePlatform.Models.proto
+++ b/mods/src/prime/proto/Digit.PrimePlatform.Models.proto
@@ -141,6 +141,8 @@ message EventMetadata {
   repeated CTADeeplinkRange ctaDeeplinkRanges = 43;
   int32 battlePassOrder = 44;
   int64 ctaDeeplinkRangesFallbackCta = 45;
+  EventCardStyle cardStyle = 46;
+  string autojoinFactionEvent = 47;
 }
 
 message EventModel {
@@ -250,6 +252,8 @@ message AllianceGamesChangesNotification {
 
 message ApmFiltersStatus {
   bool apmRequired = 1;
+  string telemetryJwt = 2;
+  int64 telemetryJwtExpiresAt = 3;
 }
 
 message ApmFiltersNotification {
@@ -433,3 +437,37 @@ message PromoCodeRedeem {
   Digit.PrimePlatform.Content.Order order = 3;
 }
 
+enum EventCardRarity {
+  EVENTCARDRARITY_COMMON = 0;
+  EVENTCARDRARITY_UNCOMMON = 1;
+  EVENTCARDRARITY_RARE = 2;
+  EVENTCARDRARITY_EPIC = 3;
+  EVENTCARDRARITY_LEGENDARY = 4;
+  EVENTCARDRARITY_COMMONSEASONAL = 5;
+  EVENTCARDRARITY_UNCOMMONSEASONAL = 6;
+  EVENTCARDRARITY_RARESEASONAL = 7;
+  EVENTCARDRARITY_EPICSEASONAL = 8;
+  EVENTCARDRARITY_LEGENDARYSEASONAL = 9;
+}
+
+message EventCardStyle {
+  EventCardRarity rarity = 1;
+}
+
+message EventNotificationResponse {
+  repeated EventNotification tournamentNotifications = 1;
+}
+
+message GameNewsVideoHolder {
+  repeated GameNewsModel newsItems = 1;
+}
+
+message LeaderboardRankingResponse {
+  repeated EventRank ranks = 1;
+  string configId = 2;
+}
+
+message LeaderboardsModelResponse {
+  repeated EventModel tournaments = 1;
+  repeated int32 categories = 2;
+}

--- a/mods/src/prime/proto/Digit.PrimeServer.Models.proto
+++ b/mods/src/prime/proto/Digit.PrimeServer.Models.proto
@@ -491,6 +491,15 @@ enum ClientModifierType {
   CLIENTMODIFIERTYPE_MODPVECHESTLOOTMULTIPLIERWOKTOKEN = 78016;
   CLIENTMODIFIERTYPE_MODM80TRANSOGENLOOT = 80002;
   CLIENTMODIFIERTYPE_MODM80TRANSOGENEPICLOOT = 80003;
+  CLIENTMODIFIERTYPE_MODCARGOCAPPING = 93100;
+  CLIENTMODIFIERTYPE_MODPROTECTEDCARGOCAPPING = 93101;
+  CLIENTMODIFIERTYPE_MODFPPOSALL = 83;
+  CLIENTMODIFIERTYPE_MODADDRANDSTATE = 221;
+  CLIENTMODIFIERTYPE_MODAPEXARMOR = 67001;
+  CLIENTMODIFIERTYPE_MODAPEXBARRIERSHRED = 76001;
+  CLIENTMODIFIERTYPE_MODCOMBATTECHNOLOGICALDISTINCTIVENESSREWARDS = 252;
+  CLIENTMODIFIERTYPE_MODAPEXISOMATTERAMOUNT = 65004;
+  CLIENTMODIFIERTYPE_MODSOLOOUTPOSTDUSTLOOT = 84004;
   CLIENTMODIFIERTYPE_MODNONE = -1000;
   CLIENTMODIFIERTYPE_SHIPDAMAGEPERROUND = -1;
   CLIENTMODIFIERTYPE_SHIPABSORPTION = -2;
@@ -2276,6 +2285,8 @@ message Attributes {
   int32 grade = 12;
   int64 moduleId = 13;
   int32 shipManagementDisplay = 14;
+  repeated int32 battleTypes = 15;
+  repeated BattleUnitState multiState = 16;
 }
 
   int64 buffId = 1;
@@ -3355,6 +3366,7 @@ enum Type {
   TYPE_GALACTICANOMALYBUFFSPECS = 8501;
   TYPE_DYNAMICGALAXYDATASYNC = 8502;
   TYPE_CROSSALLIANCEARMADAS = 87001;
+  TYPE_TRACKER = 9301;
 }
 
   Type type = 1;
@@ -5102,6 +5114,9 @@ message DisplayDynamicScrappingRewardsResponse {
 message UserProfileSettings {
   bool anonymousPurchases = 1;
   bool disabledArmadaPushNotifications = 2;
+  bool autojoinFactionEventFederation = 3;
+  bool autojoinFactionEventKlingon = 4;
+  bool autojoinFactionEventRomulan = 5;
 }
 
 message UserProfilesResponse {
@@ -5189,6 +5204,11 @@ message WaveDefenseChallengeDataResponse {
 
 message ActiveWormholesResponse {
   repeated Wormhole wormholes = 1;
+}
+
+message Tracker {
+  int32 counter = 1;
+  int32 limit = 2;
 }
 
 // Moved from stfc.proto -- needs to be here to prevent compile loops

--- a/scripts/Compare-ProtobufCorpus.ps1
+++ b/scripts/Compare-ProtobufCorpus.ps1
@@ -1,0 +1,370 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string]$CandidatePath,
+
+  [Parameter(Mandatory)]
+  [string]$TrackedPath,
+
+  [Parameter(Mandatory)]
+  [string]$ReportPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Normalize-Identifier([string]$Value) {
+  return ($Value -replace '_', '').ToLowerInvariant()
+}
+
+function Get-MatchingBrace([string]$Text, [int]$OpenIndex) {
+  $depth = 0
+  for ($index = $OpenIndex; $index -lt $Text.Length; $index++) {
+    switch ($Text[$index]) {
+      '{' { $depth++ }
+      '}' {
+        $depth--
+        if ($depth -eq 0) {
+          return $index
+        }
+      }
+    }
+  }
+  throw "Unbalanced protobuf declaration at character $OpenIndex"
+}
+
+function Get-ProtobufDefinitions([string]$Text, [string]$Source, [string]$ParentName = '') {
+  $definitions = [System.Collections.Generic.List[object]]::new()
+  $cursor = 0
+  $depth = 0
+
+  while ($cursor -lt $Text.Length) {
+    if ($Text[$cursor] -eq '{') {
+      $depth++
+      $cursor++
+      continue
+    }
+    if ($Text[$cursor] -eq '}') {
+      $depth--
+      $cursor++
+      continue
+    }
+
+    if ($depth -eq 0) {
+      $remaining = $Text.Substring($cursor)
+      $match = [regex]::Match($remaining, '(?m)^[ \t]*(message|enum)\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{')
+      if ($match.Success) {
+        $absoluteStart = $cursor + $match.Index
+        for ($scan = $cursor; $scan -lt $absoluteStart; $scan++) {
+          if ($Text[$scan] -eq '{') { $depth++ }
+          elseif ($Text[$scan] -eq '}') { $depth-- }
+        }
+        if ($depth -ne 0) {
+          $cursor = $absoluteStart + $match.Length
+          continue
+        }
+
+        $openIndex = $absoluteStart + $match.Value.LastIndexOf('{')
+        $closeIndex = Get-MatchingBrace $Text $openIndex
+        $kind = $match.Groups[1].Value
+        $name = $match.Groups[2].Value
+        $qualifiedName = $(if ([string]::IsNullOrWhiteSpace($ParentName)) { $name } else { "$ParentName.$name" })
+        $body = $Text.Substring($openIndex + 1, $closeIndex - $openIndex - 1)
+        $definitions.Add([pscustomobject]@{
+          Kind = $kind
+          Name = $name
+          QualifiedName = $qualifiedName
+          Body = $body
+          Source = $Source
+        })
+        if ($kind -eq 'message') {
+          foreach ($nestedDefinition in @(Get-ProtobufDefinitions $body $Source $qualifiedName)) {
+            $definitions.Add($nestedDefinition)
+          }
+        }
+        $cursor = $closeIndex + 1
+        continue
+      }
+    }
+
+    $cursor++
+  }
+
+  return $definitions
+}
+
+function Get-MessageFields([string]$Body) {
+  $fields = @{}
+  $depth = 0
+  $oneOfDepth = -1
+  $oneOfName = $null
+  $nestedDepth = -1
+
+  foreach ($line in ($Body -split "`r?`n")) {
+    $trimmed = ($line -replace '//.*$', '').Trim()
+    if ($trimmed -match '^(message|enum)\s+[A-Za-z_][A-Za-z0-9_]*\s*\{') {
+      $nestedDepth = $depth + 1
+    } elseif ($nestedDepth -lt 0 -and $trimmed -match '^oneof\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{') {
+      $oneOfName = Normalize-Identifier $matches[1]
+      $oneOfDepth = $depth + 1
+    }
+
+    $fieldDepthAccepted = $nestedDepth -lt 0 -and
+      ($depth -eq 0 -or ($oneOfDepth -gt 0 -and $depth -eq $oneOfDepth))
+    if ($fieldDepthAccepted -and
+        $trimmed -match '^(?:(optional|required|repeated)\s+)?(.+?)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(\d+)(?:\s*\[[^\]]+\])?\s*;') {
+      $label = $(if ($matches[1]) { $matches[1].ToLowerInvariant() } else { 'singular' })
+      $type = (($matches[2] -replace '\s+', '') -replace '^\.', '').ToLowerInvariant()
+      $type = [regex]::Replace($type, '(?:\b[a-z_][a-z0-9_]*\.)+([a-z_][a-z0-9_]*)', '$1')
+      $id = [int]$matches[4]
+      $fields[$id] = [pscustomobject]@{
+        Id = $id
+        Name = Normalize-Identifier $matches[3]
+        Type = $type
+        Label = $label
+        OneOf = $(if ($oneOfDepth -gt 0 -and $depth -eq $oneOfDepth) { $oneOfName } else { $null })
+      }
+    }
+
+    $opens = ([regex]::Matches($trimmed, '\{')).Count
+    $closes = ([regex]::Matches($trimmed, '\}')).Count
+    $depth += $opens - $closes
+    if ($nestedDepth -gt 0 -and $depth -lt $nestedDepth) {
+      $nestedDepth = -1
+    }
+    if ($oneOfDepth -gt 0 -and $depth -lt $oneOfDepth) {
+      $oneOfDepth = -1
+      $oneOfName = $null
+    }
+  }
+
+  return $fields
+}
+
+function Get-EnumValues([string]$Body) {
+  $values = @{}
+  foreach ($match in [regex]::Matches($Body, '(?m)^[ \t]*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(-?\d+)')) {
+    $id = [int64]$match.Groups[2].Value
+    $values[$id] = Normalize-Identifier $match.Groups[1].Value
+  }
+  return $values
+}
+
+function Get-Namespace([string]$Text) {
+  $match = [regex]::Match($Text, 'option\s+csharp_namespace\s*=\s*"([^"]*)"\s*;')
+  if ($match.Success) {
+    return $match.Groups[1].Value
+  }
+  $package = [regex]::Match($Text, '(?m)^[ \t]*package\s+([^;]+)\s*;')
+  if ($package.Success) {
+    return $package.Groups[1].Value.Trim()
+  }
+  return ''
+}
+
+function Add-CorpusFile([hashtable]$Corpus, [System.IO.FileInfo]$File) {
+  $text = Get-Content -LiteralPath $File.FullName -Raw
+  $namespace = Get-Namespace $text
+  foreach ($definition in Get-ProtobufDefinitions $text $File.FullName) {
+    $key = "$(Normalize-Identifier $namespace).$(Normalize-Identifier $definition.QualifiedName)"
+    $values = $(if ($definition.Kind -eq 'enum') {
+      Get-EnumValues $definition.Body
+    } else {
+      Get-MessageFields $definition.Body
+    })
+    if ($Corpus.ContainsKey($key)) {
+      throw "Duplicate protobuf declaration '$($definition.QualifiedName)' in namespace '$namespace'."
+    }
+    $Corpus[$key] = [pscustomobject]@{
+      Namespace = $namespace
+      Kind = $definition.Kind
+      Name = $definition.QualifiedName
+      SimpleName = $definition.Name
+      Source = $definition.Source
+      Complete = $definition.Body -notmatch '=\s*\?\s*;'
+      Values = $values
+    }
+  }
+}
+
+$candidateCorpus = @{}
+$trackedCorpus = @{}
+Get-ChildItem -LiteralPath $CandidatePath -Filter '*.proto' -File | ForEach-Object {
+  Add-CorpusFile $candidateCorpus $_
+}
+Get-ChildItem -LiteralPath $TrackedPath -Filter '*.proto' -File | ForEach-Object {
+  Add-CorpusFile $trackedCorpus $_
+}
+
+$trackedNamespaces = @{}
+foreach ($trackedType in $trackedCorpus.Values) {
+  $trackedNamespaces[(Normalize-Identifier $trackedType.Namespace)] = $true
+}
+foreach ($key in @($candidateCorpus.Keys)) {
+  if (-not $trackedNamespaces.ContainsKey((Normalize-Identifier $candidateCorpus[$key].Namespace))) {
+    $candidateCorpus.Remove($key)
+  }
+}
+
+$changes = [System.Collections.Generic.List[object]]::new()
+$matchedTrackedKeys = @{}
+foreach ($key in ($candidateCorpus.Keys | Sort-Object)) {
+  $candidate = $candidateCorpus[$key]
+  $trackedKey = $key
+  $tracked = $(if ($trackedCorpus.ContainsKey($key)) {
+    $trackedCorpus[$key]
+  } else {
+    $sameName = @($trackedCorpus.GetEnumerator() | Where-Object {
+      (Normalize-Identifier $_.Value.Name) -eq (Normalize-Identifier $candidate.Name)
+    })
+    if ($sameName.Count -eq 1) {
+      $trackedKey = $sameName[0].Key
+      $sameName[0].Value
+    } else {
+      $null
+    }
+  })
+
+  if ($null -eq $tracked) {
+    $changes.Add([pscustomobject]@{
+      Change = 'type-added'
+      Namespace = $candidate.Namespace
+      Type = $candidate.Name
+      Detail = $candidate.Kind
+    })
+    continue
+  }
+  $matchedTrackedKeys[$trackedKey] = $true
+
+  if ($candidate.Kind -ne $tracked.Kind) {
+    $changes.Add([pscustomobject]@{
+      Change = 'type-kind-changed'
+      Namespace = $candidate.Namespace
+      Type = $candidate.Name
+      Detail = "$($tracked.Kind) -> $($candidate.Kind)"
+    })
+    continue
+  }
+
+  foreach ($id in ($candidate.Values.Keys | Sort-Object)) {
+    if (-not $tracked.Values.ContainsKey($id)) {
+      $changes.Add([pscustomobject]@{
+        Change = $(if ($candidate.Kind -eq 'enum') { 'enum-value-added' } else { 'field-added' })
+        Namespace = $candidate.Namespace
+        Type = $candidate.Name
+        Detail = "id=$id"
+      })
+      continue
+    }
+
+    $candidateValue = $candidate.Values[$id]
+    $trackedValue = $tracked.Values[$id]
+    if ($candidate.Kind -eq 'enum') {
+      $enumName = Normalize-Identifier $candidate.SimpleName
+      $candidateComparable = $(if ($candidateValue.StartsWith($enumName)) {
+        $candidateValue.Substring($enumName.Length)
+      } else {
+        $candidateValue
+      })
+      $trackedComparable = $(if ($trackedValue.StartsWith($enumName)) {
+        $trackedValue.Substring($enumName.Length)
+      } else {
+        $trackedValue
+      })
+      if ($candidateComparable -ne $trackedComparable) {
+        $changes.Add([pscustomobject]@{
+          Change = 'enum-value-renamed'
+          Namespace = $candidate.Namespace
+          Type = $candidate.Name
+          Detail = "id=$id $trackedValue -> $candidateValue"
+        })
+      }
+    } elseif ($candidateValue.Type -ne $trackedValue.Type -or
+              $candidateValue.Label -ne $trackedValue.Label -or
+              $candidateValue.OneOf -ne $trackedValue.OneOf) {
+      $changes.Add([pscustomobject]@{
+        Change = 'field-shape-changed'
+        Namespace = $candidate.Namespace
+        Type = $candidate.Name
+        Detail = "id=$id $($trackedValue.Label) $($trackedValue.Type) -> $($candidateValue.Label) $($candidateValue.Type)"
+      })
+    } elseif ($candidateValue.Name -ne $trackedValue.Name) {
+      $changes.Add([pscustomobject]@{
+        Change = 'field-renamed'
+        Namespace = $candidate.Namespace
+        Type = $candidate.Name
+        Detail = "id=$id $($trackedValue.Name) -> $($candidateValue.Name)"
+      })
+    }
+  }
+
+  if (-not $candidate.Complete) {
+    $changes.Add([pscustomobject]@{
+      Change = 'type-incomplete'
+      Namespace = $candidate.Namespace
+      Type = $candidate.Name
+      Detail = 'One or more field numbers were unavailable in IL2CPP metadata; removals were suppressed.'
+    })
+    continue
+  }
+
+  foreach ($id in ($tracked.Values.Keys | Sort-Object)) {
+    if ($candidate.Values.ContainsKey($id)) {
+      continue
+    }
+    if ($candidate.Kind -eq 'enum' -and $id -eq 0 -and
+        $tracked.Values[$id] -eq "$(Normalize-Identifier $tracked.SimpleName)none") {
+      continue
+    }
+    $changes.Add([pscustomobject]@{
+      Change = $(if ($candidate.Kind -eq 'enum') { 'enum-value-not-emitted' } else { 'field-not-emitted' })
+      Namespace = $candidate.Namespace
+      Type = $candidate.Name
+      Detail = "id=$id; absence may reflect inheritance or unreachable generated members"
+    })
+  }
+}
+
+foreach ($key in ($trackedCorpus.Keys | Sort-Object)) {
+  if (-not $matchedTrackedKeys.ContainsKey($key)) {
+    $tracked = $trackedCorpus[$key]
+    $changes.Add([pscustomobject]@{
+      Change = 'type-not-emitted'
+      Namespace = $tracked.Namespace
+      Type = $tracked.Name
+      Detail = 'Retained schema type was not reachable from current generated messages.'
+    })
+  }
+}
+
+$report = [ordered]@{
+  generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+  candidatePath = [System.IO.Path]::GetFullPath($CandidatePath)
+  trackedPath = [System.IO.Path]::GetFullPath($TrackedPath)
+  candidateTypeCount = $candidateCorpus.Count
+  trackedTypeCount = $trackedCorpus.Count
+  changeCount = $changes.Count
+  actionableChangeCount = @($changes | Where-Object Change -notin @(
+    'field-not-emitted',
+    'enum-value-not-emitted',
+    'type-incomplete',
+    'type-not-emitted'
+  )).Count
+  changesByKind = [ordered]@{}
+  changes = $changes
+}
+foreach ($group in ($changes | Group-Object Change | Sort-Object Name)) {
+  $report.changesByKind[$group.Name] = $group.Count
+}
+
+$reportDirectory = Split-Path -Parent $ReportPath
+if ($reportDirectory) {
+  New-Item -ItemType Directory -Force -Path $reportDirectory | Out-Null
+}
+$report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $ReportPath -Encoding utf8NoBOM
+
+Write-Host "Compared $($candidateCorpus.Count) extracted types with $($trackedCorpus.Count) tracked types."
+Write-Host "Detected $($report.actionableChangeCount) actionable changes and $($changes.Count - $report.actionableChangeCount) retention observations."
+$report.changesByKind.GetEnumerator() | ForEach-Object {
+  Write-Host ("  {0}: {1}" -f $_.Key, $_.Value)
+}

--- a/scripts/Invoke-ProtobufRefresh.ps1
+++ b/scripts/Invoke-ProtobufRefresh.ps1
@@ -1,0 +1,164 @@
+[CmdletBinding()]
+param(
+  [string]$GamePath = 'C:\Games\Star Trek Fleet Command\default\game',
+  [string]$UnityVersion,
+  [string]$OutputRoot,
+  [string]$DotNetPath,
+  [switch]$FailOnActionableChanges
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+  $OutputRoot = Join-Path $repoRoot '.cache\protobuf-refresh'
+}
+$OutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+
+$gameAssembly = Join-Path $GamePath 'GameAssembly.dll'
+$metadata = Join-Path $GamePath 'prime_Data\il2cpp_data\Metadata\global-metadata.dat'
+$unityPlayer = Join-Path $GamePath 'UnityPlayer.dll'
+foreach ($required in @($gameAssembly, $metadata, $unityPlayer)) {
+  if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+    throw "Missing required game file: $required"
+  }
+}
+if ([string]::IsNullOrWhiteSpace($UnityVersion)) {
+  $productVersion = (Get-Item -LiteralPath $unityPlayer).VersionInfo.ProductVersion
+  if ($productVersion -notmatch '^(\d+\.\d+\.\d+[abfp]\d+)') {
+    throw "Could not derive the Unity version from UnityPlayer.dll: $productVersion"
+  }
+  $UnityVersion = $matches[1]
+}
+
+$protodecCommit = '52ddf82ca90d277e56fe1fb0d27d6766136cf442'
+$archiveHash = '750B000ECEEA3D6242A7E6953F6357F7AA7D0B47716305137EFFF3F1A095E33C'
+$toolRoot = Join-Path $OutputRoot "protodec-$protodecCommit"
+$archivePath = Join-Path $OutputRoot "$protodecCommit.zip"
+$sourceRoot = Join-Path $toolRoot "protodec-$protodecCommit"
+$patchPath = Join-Path $repoRoot 'tools\protobuf\protodec-stfc.patch'
+$candidateRoot = Join-Path $OutputRoot 'candidates'
+
+New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
+
+if (-not (Test-Path -LiteralPath $archivePath -PathType Leaf)) {
+  $archiveUri = "https://github.com/Xpl0itR/Protodec/archive/$protodecCommit.zip"
+  Write-Host "Downloading pinned Protodec $protodecCommit"
+  Invoke-WebRequest -Uri $archiveUri -OutFile $archivePath
+}
+
+$actualArchiveHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash
+if ($actualArchiveHash -ne $archiveHash) {
+  throw "Protodec archive hash mismatch. Expected $archiveHash, got $actualArchiveHash"
+}
+
+$resolvedToolRoot = [System.IO.Path]::GetFullPath($toolRoot)
+$outputPrefix = $OutputRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+if (-not $resolvedToolRoot.StartsWith($outputPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "Refusing to recreate tool source outside the output root: $resolvedToolRoot"
+}
+if (Test-Path -LiteralPath $resolvedToolRoot) {
+  Remove-Item -LiteralPath $resolvedToolRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $resolvedToolRoot | Out-Null
+Expand-Archive -LiteralPath $archivePath -DestinationPath $resolvedToolRoot
+
+$patchHash = (Get-FileHash -LiteralPath $patchPath -Algorithm SHA256).Hash
+$previousGitCeiling = $env:GIT_CEILING_DIRECTORIES
+$env:GIT_CEILING_DIRECTORIES = $repoRoot
+Push-Location $sourceRoot
+try {
+  & git apply --unsafe-paths --check $patchPath 2>$null
+  if ($LASTEXITCODE -ne 0) {
+    throw 'The STFC compatibility patch no longer applies cleanly to the pinned Protodec source.'
+  }
+  & git apply --unsafe-paths --whitespace=nowarn $patchPath
+  if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to apply the STFC compatibility patch to Protodec.'
+  }
+} finally {
+  Pop-Location
+  $env:GIT_CEILING_DIRECTORIES = $previousGitCeiling
+}
+
+if ([string]::IsNullOrWhiteSpace($DotNetPath)) {
+  $cachedDotNet = Join-Path $repoRoot '.cache\dotnet10\dotnet.exe'
+  $DotNetPath = $(if (Test-Path -LiteralPath $cachedDotNet) { $cachedDotNet } else { 'dotnet' })
+}
+if (Test-Path -LiteralPath $DotNetPath -PathType Leaf) {
+  $DotNetPath = (Resolve-Path -LiteralPath $DotNetPath).Path
+}
+
+$sdkList = & $DotNetPath --list-sdks
+$dotNet10Sdk = $sdkList | ForEach-Object {
+  if ($_ -match '^(10\.\d+\.\d+)') { [version]$matches[1] }
+} | Sort-Object -Descending | Select-Object -First 1
+if ($LASTEXITCODE -ne 0 -or $null -eq $dotNet10Sdk) {
+  throw 'Protodec currently requires a .NET 10 SDK. Pass -DotNetPath or install .NET 10.'
+}
+
+$toolGlobalJson = [ordered]@{
+  sdk = [ordered]@{
+    version = $dotNet10Sdk.ToString()
+    rollForward = 'latestPatch'
+    allowPrerelease = $false
+  }
+}
+$toolGlobalJson | ConvertTo-Json -Depth 3 |
+  Set-Content -LiteralPath (Join-Path $sourceRoot 'global.json') -Encoding utf8NoBOM
+
+Write-Host 'Building the pinned STFC-compatible Protodec'
+Push-Location $sourceRoot
+try {
+  & $DotNetPath build 'src\protodec\protodec.csproj' -c Release
+  if ($LASTEXITCODE -ne 0) {
+    throw 'Protodec build failed.'
+  }
+} finally {
+  Pop-Location
+}
+
+$resolvedOutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+$resolvedCandidates = [System.IO.Path]::GetFullPath($candidateRoot)
+if (-not $resolvedCandidates.StartsWith($resolvedOutputRoot + [System.IO.Path]::DirectorySeparatorChar,
+                                        [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "Refusing to replace candidate directory outside output root: $resolvedCandidates"
+}
+if (Test-Path -LiteralPath $resolvedCandidates) {
+  Remove-Item -LiteralPath $resolvedCandidates -Recurse -Force
+}
+New-Item -ItemType Directory -Path $resolvedCandidates | Out-Null
+
+$protodecDll = Join-Path $sourceRoot 'bin\protodec\Release\net10.0\protodec.dll'
+Write-Host 'Extracting protobuf candidates from the installed game'
+& $DotNetPath $protodecDll il2cpp $gameAssembly $metadata $UnityVersion $resolvedCandidates --log-level Error
+if ($LASTEXITCODE -ne 0) {
+  throw 'Protobuf extraction failed.'
+}
+
+$comparisonScript = Join-Path $PSScriptRoot 'Compare-ProtobufCorpus.ps1'
+& $comparisonScript -CandidatePath $resolvedCandidates `
+                    -TrackedPath (Join-Path $repoRoot 'mods\src\prime\proto') `
+                    -ReportPath (Join-Path $OutputRoot 'protobuf-refresh-report.json')
+if ($LASTEXITCODE -ne 0) {
+  throw 'Protobuf corpus comparison failed.'
+}
+
+$reportPath = Join-Path $OutputRoot 'protobuf-refresh-report.json'
+$report = Get-Content -LiteralPath $reportPath -Raw | ConvertFrom-Json -AsHashtable
+$report.source = [ordered]@{
+  unityVersion = $UnityVersion
+  gameAssemblySha256 = (Get-FileHash -LiteralPath $gameAssembly -Algorithm SHA256).Hash
+  globalMetadataSha256 = (Get-FileHash -LiteralPath $metadata -Algorithm SHA256).Hash
+  protodecCommit = $protodecCommit
+  protodecArchiveSha256 = $archiveHash
+  stfcPatchSha256 = $patchHash
+}
+$report | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $reportPath -Encoding utf8NoBOM
+
+Write-Host "Candidates: $resolvedCandidates"
+Write-Host "Report:     $reportPath"
+if ($FailOnActionableChanges -and $report.actionableChangeCount -ne 0) {
+  throw "The protobuf refresh found $($report.actionableChangeCount) actionable schema changes."
+}

--- a/tools/protobuf/protodec-stfc.patch
+++ b/tools/protobuf/protodec-stfc.patch
@@ -1,0 +1,139 @@
+diff --git a/src/LibProtodec/ProtodecContext.cs b/src/LibProtodec/ProtodecContext.cs
+index e11389b..79fc8d3 100644
+--- a/src/LibProtodec/ProtodecContext.cs
++++ b/src/LibProtodec/ProtodecContext.cs
+@@ -84,7 +84,8 @@ public class ProtodecContext
+ 
+         List<ICilField> idFields = messageClass.GetFields()
+                                                .AsValueEnumerable()
+-                                               .Where(static field => field is { IsPublic: true, IsStatic: true, IsLiteral: true })
++                                               .Where(static field => field is
++                                                   { IsPublic: true, IsStatic: true, IsLiteral: true, ConstantValue: int })
+                                                .ToList();
+ 
+         List<ICilProperty> properties = messageClass.GetProperties()
+@@ -94,10 +95,7 @@ public class ProtodecContext
+ 
+         for (int pi = 0, fi = 0; pi < properties.Count; pi++)
+         {
+-            ICilProperty property     = properties[pi];
+-            ICilType     propertyType = property.Type;
+-
+-            using IDisposable? __ = Logger?.BeginScopeParsingProperty(property.Name, propertyType.FullName);
++            ICilProperty property = properties[pi];
+ 
+             if (IsEnabled(options, CilParserOptions.RequireGeneratedCodeAttributeForProperties) && !HasGeneratedCodeAttribute(property.CustomAttributes, "protoc"))
+             {
+@@ -111,6 +109,10 @@ public class ProtodecContext
+                 continue;
+             }
+ 
++            ICilType propertyType = property.Type;
++
++            using IDisposable? __ = Logger?.BeginScopeParsingProperty(property.Name, propertyType.FullName);
++
+             // only OneOf enums are defined nested directly in the message class
+             if (propertyType.IsEnum && propertyType.DeclaringType?.Name == messageClass.Name)
+             {
+@@ -141,9 +143,18 @@ public class ProtodecContext
+                 Name       = TranslateMessageFieldName(property.Name),
+                 IsObsolete = HasObsoleteAttribute(property.CustomAttributes),
+                 HasHasProp = msgFieldHasHasProp
++                          || propertyType.FullName.StartsWith("System.Nullable`1", StringComparison.Ordinal)
+             };
+ 
+-            if (idFields.Count <= fi)
++            ICilField? namedIdField = idFields.AsValueEnumerable().SingleOrDefault(field =>
++                field.Name.Equals($"{property.Name}FieldNumber", StringComparison.OrdinalIgnoreCase));
++
++            if (namedIdField is not null)
++            {
++                field.Id = (int)namedIdField.ConstantValue!;
++                message.Fields.Add(field.Id.Value, field);
++            }
++            else if (idFields.Count <= fi)
+             {
+                 Logger?.LogFailedToLocateIdField();
+                 message.UnkFields.Add(field);
+@@ -208,6 +219,49 @@ public class ProtodecContext
+         return @enum;
+     }
+ 
++    private Enum ParseDataEnum(ICilType dataEnum, ICilType valuesClass, CilParserOptions options)
++    {
++        using IDisposable? _ = Logger?.BeginScopeParsingEnum(dataEnum.FullName);
++
++        if (_parsed.TryGetValue(dataEnum.FullName, out TopLevel? parsedEnum))
++        {
++            Logger?.LogParsedEnum(parsedEnum.Name);
++            return (Enum)parsedEnum;
++        }
++
++        ICilTypeNameProvider enumTypeName = TranslateTypeName(dataEnum);
++        Enum @enum = new()
++        {
++            Name       = enumTypeName.Name,
++            IsObsolete = HasObsoleteAttribute(dataEnum.CustomAttributes)
++        };
++        _parsed.Add(dataEnum.FullName, @enum);
++
++        Protobuf protobuf = GetProtobuf(dataEnum, @enum, enumTypeName.Namespace, options);
++
++        foreach (ICilField enumField in valuesClass.GetFields().AsValueEnumerable().Where(static field =>
++                     field is { IsPublic: true, IsStatic: true, IsLiteral: true, ConstantValue: int }))
++        {
++            EnumField field = new()
++            {
++                Id         = (int)enumField.ConstantValue!,
++                Name       = TranslateEnumFieldName(enumField.CustomAttributes, enumField.Name, @enum.Name),
++                IsObsolete = HasObsoleteAttribute(enumField.CustomAttributes)
++            };
++
++            @enum.Fields.Add(field);
++        }
++
++        if (@enum.Fields.AsValueEnumerable().All(static field => field.Id != 0))
++        {
++            protobuf.Edition = "2023";
++            @enum.IsClosed   = true;
++        }
++
++        Logger?.LogParsedEnum(@enum.Name);
++        return @enum;
++    }
++
+     public virtual Service ParseService(ICilType serviceClass, CilParserOptions options = CilParserOptions.None)
+     {
+         Guard.IsTrue(serviceClass.IsClass);
+@@ -354,6 +408,10 @@ public class ProtodecContext
+         switch (type.GenericTypeArguments.Count)
+         {
+             case 1:
++                if (type.FullName.StartsWith("System.Nullable`1", StringComparison.Ordinal))
++                {
++                    return ParseFieldType(type.GenericTypeArguments[0], options, referencingProtobuf);
++                }
+                 return new Repeated(
+                     ParseFieldType(type.GenericTypeArguments[0], options, referencingProtobuf));
+             case 2:
+@@ -375,7 +433,19 @@ public class ProtodecContext
+             }
+             else
+             {
+-                fieldType = ParseMessage(type, options);
++                ICilType? valuesClass = type.GetNestedTypes().AsValueEnumerable().SingleOrDefault(static nested =>
++                    nested.Name == "Values"
++                 && nested.GetFields().AsValueEnumerable().Any(static field =>
++                        field is { IsPublic: true, IsStatic: true, IsLiteral: true, ConstantValue: int }));
++
++                if (valuesClass is not null)
++                {
++                    fieldType = ParseDataEnum(type, valuesClass, options);
++                }
++                else
++                {
++                    fieldType = ParseMessage(type, options);
++                }
+             }
+         }
+ 


### PR DESCRIPTION
## Summary

- add a reproducible, hash-pinned Protodec workflow for extracting protobuf definitions from the installed IL2CPP client
- add a semantic corpus comparator covering top-level and nested messages/enums, field tags and shapes, oneofs, and retention-only observations
- refresh the tracked corpus with the current client’s schema additions
- document the workflow, provenance, and interpretation of incomplete/unreachable metadata

## Why

The protobuf corpus had previously required an ad hoc refresh, making it difficult to distinguish real schema changes from extraction gaps. The new workflow recreates the patched extractor from pinned source on every run, records source hashes, and can fail validation when actionable changes remain.

The review pass also found that the initial comparator only inspected top-level declarations. Nested declarations are now audited as first-class schema types; this surfaced and promoted two `BuffSpec.Attributes` fields and the server `EntityGroup.Type::TRACKER` value.

## Impact

The tracked protobufs now match the installed Unity `6000.0.59f2` client for all actionable declarations reachable through IL2CPP metadata. No C++ consumer changes were required. Missing or incomplete extractor output is retained as an observation rather than treated as an unsafe deletion.

## Validation

- Lexrunner final plan on the PR base: all 4 required gates passed
  - protobuf refresh/comparison: 790 extracted vs. 803 tracked declarations, 0 actionable changes
  - core `mods` build
  - Windows release `stfc-community-mod` build
  - staged and unstaged diff checks
- repository AXF review contract passed
  - 12/12 hook modules validated
  - 0 new unmanaged gameplay seams; 0 stale baselines
  - 326 test cases and 4,472 assertions passed
- PowerShell parser validation passed for both maintenance scripts
