### PR TITLE
Fix Armada victory notification routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 
 ### Fixes
 
+- Routed generic Armada victory and defeat results through their dedicated
+  notification policies while preserving generic battle fallbacks
 - Added a Windows modifier-state fallback for Shift/Ctrl/Alt so `ALT-*` chords
   do not fall through as plain keys when Unity drops the modifier state
 - Fixed `Key::HasAlt()` checking RightShift instead of RightAlt

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ notification, or use an inline table when you also want audio:
 victory = true
 defeat = true
 armada_battle_won = true
+armada_battle_lost = true
 armada_created = true
 fleet_arrived_in_system = true
 fleet_node_depleted = true

--- a/README.md
+++ b/README.md
@@ -151,10 +151,9 @@ notification, or use an inline table when you also want audio:
 [notifications]
 victory = true
 defeat = true
+armada_battle_won = true
 armada_created = true
-armada_canceled = true
 fleet_arrived_in_system = true
-fleet_arrived_at_destination = true
 fleet_node_depleted = true
 fleet_repair_complete = true
 ```
@@ -171,7 +170,6 @@ default sound:
 ```toml
 [notifications]
 fleet_arrived_in_system = { system = true, audio = true, sound = "arrival" }
-fleet_started_mining = { system = false, audio = true, sound = "ping" }
 fleet_node_depleted = { system = true, audio = true, sound = "warning" }
 fleet_repair_complete = { system = false, audio = true, sound = "repair" }
 ```

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -33,6 +33,46 @@ Risk classes are also defined there: R0 static, R1 passive runtime, R2 managed l
 
 ## Entries
 
+### Generic battle-result toast classification for Armada notifications
+
+- Owner / file: `mods/src/patches/notification_service.cc` and
+  `mods/src/patches/battle_notify_parser.cc`, reached through the existing
+  `ToastObserver` hooks in `mods/src/patches/parts/disable_banners.cc`.
+- Intended question: can `armada_battle_won` follow current armada result
+  production without adding another native hook or breaking the established
+  generic `victory` fallback?
+- Static evidence: the canonical 2026-07-30 corpus (`dump.cs` SHA-256
+  `0e3ab23ea6c0b7697485e45b4aaa5c8002597ed377a56854a8478c8aca89f205`)
+  retains `ToastState.ArmadaBattleWon = 18` and
+  `ToastState.ArmadaBattleLost = 19`, but current-client disassembly of
+  `ToastBattleResultObserver.CreateToastForBattle(string,
+  IBattleResultHeader)` at RVA `0x140F120` routes `BattleType.ArmadaMarauder`
+  (`8`) and `BattleType.ArmadaMta` (`11`) through the ordinary
+  `Victory`/`Defeat` (`10`/`11`) creation branch. `BattleResultHeader` exposes
+  the authoritative `IsArmadaBattle` property at RVA `0x1775FC0`.
+- Risk class: R4 native interpretation within an existing product hook.
+- Confidence rung: static relationship plus generic battle-payload runtime
+  evidence; armada-specific state correlation awaits artifact smoke.
+- Runtime evidence: retained 2026-07-30 logs show the existing
+  `BattleResultHeader` parser and `Defeat` delivery path completing
+  successfully. VIP feedback independently reports that `victory` delivers
+  while `armada_battle_won` does not, consistent with the static producer
+  relationship.
+- Payload confidence: the existing generic battle parser already reads this
+  toast payload. The new classification reads only the current
+  `BattleResultHeader.IsArmadaBattle` property under the same SEH boundary and
+  fails closed to generic routing.
+- Original/trampoline confidence: unchanged; no new hook or original call was
+  introduced.
+- Flag / rollback path: disabling `armada_battle_won` preserves the prior
+  `victory`/`defeat` selection. Removing the contextual classifier fully
+  restores the former exact-toast-state routing.
+- Status: release candidate. When the armada-specific policy is enabled it
+  specializes a generic armada result; otherwise the established generic
+  policy remains the fallback.
+- Next action: smoke an Armada victory with a production artifact and retain
+  the resulting `battle.armada_battle_won` queue/delivery evidence.
+
 ### Static Inventory Snapshot - 2026-05-23
 
 This inventory records source-level seams from a static-only review. It does not claim new runtime observation, payload confidence, original/trampoline confidence, or product-safe status. "Operationally relied on" below means the seam is part of current product code paths; it is not a new confidence rung and is not evidence from this pass.

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -38,9 +38,9 @@ Risk classes are also defined there: R0 static, R1 passive runtime, R2 managed l
 - Owner / file: `mods/src/patches/notification_service.cc` and
   `mods/src/patches/battle_notify_parser.cc`, reached through the existing
   `ToastObserver` hooks in `mods/src/patches/parts/disable_banners.cc`.
-- Intended question: can `armada_battle_won` follow current armada result
-  production without adding another native hook or breaking the established
-  generic `victory` fallback?
+- Intended question: can `armada_battle_won` and `armada_battle_lost` follow
+  current armada result production without adding another native hook or
+  breaking the established generic `victory`/`defeat` fallbacks?
 - Static evidence: the canonical 2026-07-30 corpus (`dump.cs` SHA-256
   `0e3ab23ea6c0b7697485e45b4aaa5c8002597ed377a56854a8478c8aca89f205`)
   retains `ToastState.ArmadaBattleWon = 18` and
@@ -51,27 +51,31 @@ Risk classes are also defined there: R0 static, R1 passive runtime, R2 managed l
   `Victory`/`Defeat` (`10`/`11`) creation branch. `BattleResultHeader` exposes
   the authoritative `IsArmadaBattle` property at RVA `0x1775FC0`.
 - Risk class: R4 native interpretation within an existing product hook.
-- Confidence rung: static relationship plus generic battle-payload runtime
-  evidence; armada-specific state correlation awaits artifact smoke.
+- Confidence rung: state-correlated for both Armada victory and defeat.
 - Runtime evidence: retained 2026-07-30 logs show the existing
   `BattleResultHeader` parser and `Defeat` delivery path completing
-  successfully. VIP feedback independently reports that `victory` delivers
-  while `armada_battle_won` does not, consistent with the static producer
-  relationship.
+  successfully. On 2026-07-31, an Armada victory on the release build logged
+  `source=battle.armada_battle_won title='Armada Victory!'`, played the
+  configured Armada audio policy, flushed and displayed the parsed battle
+  summary, and requested the WinRT notification. The human confirmed that the
+  notification appeared. A separate Armada defeat smoke on the same release
+  build also produced the configured `armada_battle_lost` notification and
+  warning audio.
 - Payload confidence: the existing generic battle parser already reads this
   toast payload. The new classification reads only the current
   `BattleResultHeader.IsArmadaBattle` property under the same SEH boundary and
   fails closed to generic routing.
 - Original/trampoline confidence: unchanged; no new hook or original call was
   introduced.
-- Flag / rollback path: disabling `armada_battle_won` preserves the prior
-  `victory`/`defeat` selection. Removing the contextual classifier fully
-  restores the former exact-toast-state routing.
-- Status: release candidate. When the armada-specific policy is enabled it
-  specializes a generic armada result; otherwise the established generic
-  policy remains the fallback.
-- Next action: smoke an Armada victory with a production artifact and retain
-  the resulting `battle.armada_battle_won` queue/delivery evidence.
+- Flag / rollback path: disabling the matching `armada_battle_won` or
+  `armada_battle_lost` policy preserves the prior `victory`/`defeat` selection.
+  Removing the contextual classifier fully restores the former exact-toast-state
+  routing.
+- Status: Armada victory and defeat are release-promoted and runtime-validated.
+  When the matching Armada policy is enabled it specializes a generic Armada
+  result; otherwise the established generic policy remains the fallback.
+- Next action: revalidate the classifier after relevant battle-result producer
+  or `BattleResultHeader` changes.
 
 ### Standard Recruit custom-quantity submission and failure callbacks
 

--- a/docs/NOTIFICATION_ARCHITECTURE.md
+++ b/docs/NOTIFICATION_ARCHITECTURE.md
@@ -9,6 +9,11 @@ canonical root key and fallback sound. `notification_policy.cc` resolves the
 canonical `false` / `true` / inline-table value or, when no canonical value is
 present, the deprecated compatibility inputs.
 
+The complete catalog is a compatibility and research surface. The smaller
+`kPublicNotificationKinds` allowlist owns which release-supported events appear
+in release examples and fresh generated configs. Adding a catalog entry does
+not promote it to that public surface.
+
 Notification producers consume only the resolved event policy. The old system
 and audio masters are compatibility gates for deprecated inputs and must not be
 checked in producer or delivery code.

--- a/docs/NOTIFICATION_CONFIG_RETHINK.md
+++ b/docs/NOTIFICATION_CONFIG_RETHINK.md
@@ -15,6 +15,7 @@ Every release-supported event has one meaningful root key:
 [notifications]
 victory = true
 armada_battle_won = { system = true, audio = true, sound = "success" }
+armada_battle_lost = { system = true, audio = true, sound = "warning" }
 armada_created = false
 fleet_arrived_in_system = { system = true, audio = true, sound = "arrival" }
 fleet_repair_complete = true

--- a/docs/NOTIFICATION_CONFIG_RETHINK.md
+++ b/docs/NOTIFICATION_CONFIG_RETHINK.md
@@ -3,18 +3,18 @@
 Issue #185 replaces the duplicated notification settings with one event-first
 policy surface under `[notifications]`.
 
-The TOML remains the power-user and compatibility surface. A future launcher UI
-should read and write the same event catalog rather than inventing another
-notification schema.
+The TOML remains the power-user and compatibility surface. Release examples and
+fresh configs expose the explicit release-supported event allowlist rather than
+treating every retained catalog mapping as proven.
 
 ## Canonical values
 
-Every supported event has one meaningful root key:
+Every release-supported event has one meaningful root key:
 
 ```toml
 [notifications]
 victory = true
-incoming_attack_player = { system = true, audio = true, sound = "alarm" }
+armada_battle_won = { system = true, audio = true, sound = "success" }
 armada_created = false
 fleet_arrived_in_system = { system = true, audio = true, sound = "arrival" }
 fleet_repair_complete = true
@@ -39,9 +39,9 @@ as diagnostics.
 
 ## Defaults and master switches
 
-Every canonical event defaults to `false`. A newly generated config contains all
-canonical event keys and no notification master switches or nested channel/event
-tables.
+Every event defaults to `false`. A newly generated config contains the public
+release-supported event keys and no notification master switches or nested
+channel/event tables.
 
 The old `notifications_enabled` and `notifications_audio_enabled` settings are
 not canonical master switches. They remain hidden compatibility gates, default

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -232,78 +232,17 @@ fr_scale = 2.0
 # Deprecated notification keys and nested tables remain accepted through 2.x and
 # are scheduled for removal in 3.0.0.
 
-# Battle notifications (fully parsed with player/ship detail)
+# Release-supported battle notifications
 victory = false
 defeat = false
-partial_victory = false
-station_victory = false
-station_defeat = false
-station_battle = false
-incoming_attack_player = false
-incoming_attack_hostile = false
-fleet_battle = false
 armada_battle_won = false
-armada_battle_lost = false
-assault_victory = false
-assault_defeat = false
 
-# Armada notifications (parsed with alliance/owner detail)
+# Release-supported Armada notifications
 armada_created = false
-armada_canceled = false
 
-# Event notifications (best-effort text resolution)
-tournament = false
-chained_event_scored = false
-
-# Toast-backed notifications that may expose generic or placeholder text
-standard = false
-faction_warning = false
-faction_level_up = false
-faction_level_down = false
-faction_discovered = false
-armada_incoming_attack = false
-diplomacy_updated = false
-joined_takeover = false
-competitor_joined_takeover = false
-abandoned_territory = false
-takeover_victory = false
-takeover_defeat = false
-treasury_progress = false
-treasury_full = false
-achievement = false
-challenge_complete = false
-challenge_failed = false
-strike_hit = false
-strike_defeat = false
-warchest_progress = false
-warchest_full = false
-arena_time_left = false
-fleet_preset_applied = false
-surge_warmup_ended = false
-surge_hostile_group_defeated = false
-surge_time_left = false
-queue_for_lease_activated = false
-queue_for_lease_expired = false
-permanent_queue_purchased = false
-outpost_started_or_ended = false
-cross_alliance_armada_victory = false
-cross_alliance_armada_defeat = false
-cross_alliance_armada_partial_victory = false
-faction_weekly_events_progress = false
-faction_weekly_events_complete = false
-armada_player_blocked = false
-armada_player_unblocked = false
-dynamic_crisis_update = false
-dynamic_crisis_failed = false
-dynamic_crisis_completed = false
-galactic_anomaly_system_entered = false
-
-# Fleet-state derived notifications
+# Release-supported fleet-state notifications
 fleet_arrived_in_system = false
-fleet_arrived_at_destination = false
-fleet_started_mining = false
 fleet_node_depleted = false
-fleet_docked = false
 fleet_repair_complete = false
 
 #  <[=====================================================]>

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -236,6 +236,7 @@ fr_scale = 2.0
 victory = false
 defeat = false
 armada_battle_won = false
+armada_battle_lost = false
 
 # Release-supported Armada notifications
 armada_created = false

--- a/mods/src/config_release_validation.cc
+++ b/mods/src/config_release_validation.cc
@@ -268,8 +268,11 @@ ExampleConfigValidationResult ValidateExampleConfig(const toml::table& config)
     require_path(config, path, result);
   }
 
-  for (const auto& spec : notification_event_catalog()) {
-    require_path(config, std::string("notifications.") + std::string(spec.canonical_key), result);
+  for (const auto kind : public_notification_kinds()) {
+    const auto* spec = notification_catalog_entry(kind);
+    if (spec) {
+      require_path(config, std::string("notifications.") + std::string(spec->canonical_key), result);
+    }
   }
 
   validate_input_binding_coverage(config, result);

--- a/mods/src/patches/battle_notify_parser.cc
+++ b/mods/src/patches/battle_notify_parser.cc
@@ -261,3 +261,23 @@ std::string battle_notify_parse(Toast* toast)
   auto bsd = build_battle_data(data);
   return bsd.format_body();
 }
+
+bool battle_notify_is_armada(Toast* toast)
+{
+  if (!toast) {
+    return false;
+  }
+
+  auto* data = toast->get_Data();
+  if (!data) {
+    return false;
+  }
+
+  bool is_armada = false;
+  if (!seh_call([&] { is_armada = reinterpret_cast<BattleResultHeader*>(data)->IsArmadaBattle; })) {
+    spdlog::warn("[Notify] SEH: IsArmadaBattle crashed");
+    return false;
+  }
+
+  return is_armada;
+}

--- a/mods/src/patches/battle_notify_parser.h
+++ b/mods/src/patches/battle_notify_parser.h
@@ -22,3 +22,12 @@ struct Toast;
  * @return Formatted "Name (Ship) vs Name (Ship)" string, or empty.
  */
 std::string battle_notify_parse(Toast* toast);
+
+/**
+ * @brief Identify whether a generic victory/defeat toast describes an armada battle.
+ *
+ * Current clients retain dedicated armada toast states but produce ordinary
+ * Victory/Defeat states for armada-marauder and multi-target-armada results.
+ * Returns false when the payload is absent or cannot be read safely.
+ */
+bool battle_notify_is_armada(Toast* toast);

--- a/mods/src/patches/notification_catalog.h
+++ b/mods/src/patches/notification_catalog.h
@@ -303,9 +303,9 @@ static_assert([] {
 // release-supported surface.
 inline constexpr std::array kPublicNotificationKinds{
     NotificationKind::BattleVictory,         NotificationKind::BattleDefeat,
-    NotificationKind::BattleArmadaBattleWon, NotificationKind::ArmadaCreated,
-    NotificationKind::FleetArrivedInSystem,  NotificationKind::FleetNodeDepleted,
-    NotificationKind::FleetRepairComplete,
+    NotificationKind::BattleArmadaBattleWon, NotificationKind::BattleArmadaBattleLost,
+    NotificationKind::ArmadaCreated,         NotificationKind::FleetArrivedInSystem,
+    NotificationKind::FleetNodeDepleted,     NotificationKind::FleetRepairComplete,
 };
 
 static_assert([] {

--- a/mods/src/patches/notification_catalog.h
+++ b/mods/src/patches/notification_catalog.h
@@ -298,8 +298,35 @@ static_assert([] {
   return true;
 }());
 
+// The complete catalog remains available for compatibility and private
+// experiments, but fresh/generated configs advertise only this explicitly
+// release-supported surface.
+inline constexpr std::array kPublicNotificationKinds{
+    NotificationKind::BattleVictory,         NotificationKind::BattleDefeat,
+    NotificationKind::BattleArmadaBattleWon, NotificationKind::ArmadaCreated,
+    NotificationKind::FleetArrivedInSystem,  NotificationKind::FleetNodeDepleted,
+    NotificationKind::FleetRepairComplete,
+};
+
+static_assert([] {
+  for (size_t index = 0; index < kPublicNotificationKinds.size(); ++index) {
+    if (static_cast<size_t>(kPublicNotificationKinds[index]) >= kNotificationKindCount) {
+      return false;
+    }
+    for (size_t other = index + 1; other < kPublicNotificationKinds.size(); ++other) {
+      if (kPublicNotificationKinds[index] == kPublicNotificationKinds[other]) {
+        return false;
+      }
+    }
+  }
+  return true;
+}());
+
 inline constexpr std::span<const NotificationEventCatalogEntry> notification_event_catalog()
 { return kNotificationEventCatalog; }
+
+inline constexpr std::span<const NotificationKind> public_notification_kinds()
+{ return kPublicNotificationKinds; }
 
 inline constexpr const NotificationEventCatalogEntry* notification_catalog_entry(const NotificationKind kind)
 {

--- a/mods/src/patches/notification_policy.cc
+++ b/mods/src/patches/notification_policy.cc
@@ -743,8 +743,11 @@ void notification_policy_load(const toml::table& config, toml::table& runtime_co
 void notification_policy_prepare_generated_config(toml::table& user_config)
 {
   toml::table notifications;
-  for (const auto& spec : kNotificationEventCatalog) {
-    notifications.insert_or_assign(std::string(spec.canonical_key), false);
+  for (const auto kind : kPublicNotificationKinds) {
+    const auto* spec = notification_catalog_entry(kind);
+    if (spec) {
+      notifications.insert_or_assign(std::string(spec->canonical_key), false);
+    }
   }
   user_config.insert_or_assign("notifications", std::move(notifications));
 }
@@ -811,6 +814,21 @@ std::optional<NotificationKind> notification_kind_from_toast_state(int state)
   const auto it =
       std::ranges::find_if(kNotificationEventCatalog, [state](const auto& spec) { return spec.toast_state == state; });
   return it == kNotificationEventCatalog.end() ? std::nullopt : std::optional{it->kind};
+}
+
+std::optional<NotificationKind> notification_kind_for_battle_context(int state, bool is_armada_battle,
+                                                                     bool armada_policy_enabled)
+{
+  if (is_armada_battle && armada_policy_enabled) {
+    if (state == Victory) {
+      return NotificationKind::BattleArmadaBattleWon;
+    }
+    if (state == Defeat) {
+      return NotificationKind::BattleArmadaBattleLost;
+    }
+  }
+
+  return notification_kind_from_toast_state(state);
 }
 
 const char* notification_kind_name(NotificationKind kind)

--- a/mods/src/patches/notification_policy.h
+++ b/mods/src/patches/notification_policy.h
@@ -33,6 +33,8 @@ void notification_policy_write_runtime_snapshot(toml::table& runtime_config);
 [[nodiscard]] bool                      notification_policy_any_audio_enabled();
 [[nodiscard]] bool notification_policy_delivery_equivalent(NotificationKind left, NotificationKind right);
 [[nodiscard]] std::optional<NotificationKind>  notification_kind_from_toast_state(int state);
+[[nodiscard]] std::optional<NotificationKind>  notification_kind_for_battle_context(int state, bool is_armada_battle,
+                                                                                    bool armada_policy_enabled);
 [[nodiscard]] const char*                      notification_kind_name(NotificationKind kind);
 [[nodiscard]] const char*                      notification_canonical_key(NotificationKind kind);
 [[nodiscard]] const char*                      notification_sound_name(NotificationSound sound);

--- a/mods/src/patches/notification_service.cc
+++ b/mods/src/patches/notification_service.cc
@@ -840,12 +840,21 @@ void notification_handle_generic_toast(Toast* toast, int state, const char* titl
 #elif STFCMOD_PLATFORM_OTHER
   return; // No notification delivery on unsupported non-Windows platforms yet
 #else
-  const auto kind = notification_kind_from_toast_state(state);
+  const auto armada_kind           = state == Victory  ? std::optional{NotificationKind::BattleArmadaBattleWon}
+                                     : state == Defeat ? std::optional{NotificationKind::BattleArmadaBattleLost}
+                                                       : std::nullopt;
+  const auto armada_policy_enabled = armada_kind.has_value() && notification_delivery_enabled(armada_kind.value());
+  const auto is_armada_battle      = armada_policy_enabled && battle_notify_is_armada(toast);
+  const auto kind = notification_kind_for_battle_context(state, is_armada_battle, armada_policy_enabled);
   if (!kind.has_value() || !notification_delivery_enabled(kind.value())) {
     return;
   }
 
-  if (!title) {
+  const auto* selected_spec  = notification_catalog_entry(kind.value());
+  const auto* selected_title = is_armada_battle && selected_spec
+                                   ? notification_toast_title(selected_spec->toast_state)
+                                   : title;
+  if (!selected_title) {
     if (AdvancedDiagnosticsSettings().notification_skip_logging) {
       spdlog::debug("[Notify] No title mapping for toast state {}, skipping", state);
     }
@@ -868,7 +877,7 @@ void notification_handle_generic_toast(Toast* toast, int state, const char* titl
     }
   }
 
-  spdlog::debug("[Notify] {} — {}", title, body);
-  notification_emit(kind.value(), title, body.c_str());
+  spdlog::debug("[Notify] {} — {}", selected_title, body);
+  notification_emit(kind.value(), selected_title, body.c_str());
 #endif
 }

--- a/mods/src/prime/BattleResultHeader.h
+++ b/mods/src/prime/BattleResultHeader.h
@@ -58,6 +58,7 @@ public:
   __declspec(property(get = __get_PlayerShipHullId)) long PlayerShipHullId;
   __declspec(property(get = __get_EnemyShipHullId)) long EnemyShipHullId;
   __declspec(property(get = __get_BattleType)) BattleType Type;
+  __declspec(property(get = __get_IsArmadaBattle)) bool IsArmadaBattle;
 
   Il2CppObject* get_PlayerUserProfile()
   {
@@ -101,5 +102,11 @@ public:
   {
     static auto property = get_class_helper().GetProperty("BattleType");
     return *property.Get<BattleType>(this);
+  }
+
+  bool __get_IsArmadaBattle()
+  {
+    static auto property = get_class_helper().GetProperty("IsArmadaBattle");
+    return *property.Get<bool>(this);
   }
 };

--- a/tests/src/test_config_release_validation.cc
+++ b/tests/src/test_config_release_validation.cc
@@ -129,19 +129,24 @@ TEST_CASE("example config does not reintroduce abandoned ghost or manual refresh
   CHECK(config["advanced"]["queue"]["thin_queue_protection"].value<bool>().value_or(false));
 }
 
-TEST_CASE("example config exposes only the canonical notification event surface")
+TEST_CASE("example config exposes only the public supported notification event surface")
 {
   const auto  source        = read_text_file("example_community_patch_settings.toml");
   const auto  config        = toml::parse(source);
   const auto* notifications = config["notifications"].as_table();
 
   REQUIRE(notifications != nullptr);
-  CHECK(notifications->size() == notification_event_catalog().size());
-  for (const auto& spec : notification_event_catalog()) {
-    REQUIRE(notifications->contains(spec.canonical_key));
-    CHECK(notifications->get(spec.canonical_key)->value<bool>().value_or(true) == false);
+  CHECK(notifications->size() == public_notification_kinds().size());
+  for (const auto kind : public_notification_kinds()) {
+    const auto* spec = notification_catalog_entry(kind);
+    REQUIRE(spec != nullptr);
+    REQUIRE(notifications->contains(spec->canonical_key));
+    CHECK(notifications->get(spec->canonical_key)->value<bool>().value_or(true) == false);
   }
 
+  CHECK_FALSE(notifications->contains("partial_victory"));
+  CHECK_FALSE(notifications->contains("armada_battle_lost"));
+  CHECK_FALSE(notifications->contains("standard"));
   CHECK(source.find("notifications_enabled") == std::string::npos);
   CHECK(source.find("notifications_audio_enabled") == std::string::npos);
   CHECK(source.find("[notifications.system") == std::string::npos);

--- a/tests/src/test_config_release_validation.cc
+++ b/tests/src/test_config_release_validation.cc
@@ -145,7 +145,6 @@ TEST_CASE("example config exposes only the public supported notification event s
   }
 
   CHECK_FALSE(notifications->contains("partial_victory"));
-  CHECK_FALSE(notifications->contains("armada_battle_lost"));
   CHECK_FALSE(notifications->contains("standard"));
   CHECK(source.find("notifications_enabled") == std::string::npos);
   CHECK(source.find("notifications_audio_enabled") == std::string::npos);

--- a/tests/src/test_config_schema.cc
+++ b/tests/src/test_config_schema.cc
@@ -579,7 +579,7 @@ notify_banner_types = "IncomingAttack"
         runtime["notifications"]["provenance"]["incoming_attack_player"]["ignored_sources_truncated"].value_or(false));
   }
 
-  TEST_CASE("fresh generated notification config contains only canonical disabled events")
+  TEST_CASE("fresh generated notification config contains only public supported disabled events")
   {
     toml::table generated;
     generated.insert_or_assign("notifications", toml::table{{"notifications_enabled", true}});
@@ -588,12 +588,16 @@ notify_banner_types = "IncomingAttack"
 
     const auto* notifications = generated["notifications"].as_table();
     REQUIRE(notifications != nullptr);
-    CHECK(notifications->size() == notification_event_catalog().size());
-    for (const auto& spec : notification_event_catalog()) {
-      const auto* node = notifications->get(spec.canonical_key);
+    CHECK(notifications->size() == public_notification_kinds().size());
+    for (const auto kind : public_notification_kinds()) {
+      const auto* spec = notification_catalog_entry(kind);
+      REQUIRE(spec != nullptr);
+      const auto* node = notifications->get(spec->canonical_key);
       REQUIRE(node != nullptr);
       CHECK(node->value<bool>().value_or(true) == false);
     }
+    CHECK_FALSE(notifications->contains("partial_victory"));
+    CHECK_FALSE(notifications->contains("armada_battle_lost"));
     CHECK_FALSE(notifications->contains("notifications_enabled"));
     CHECK_FALSE(notifications->contains("system"));
     CHECK_FALSE(notifications->contains("audio"));

--- a/tests/src/test_config_schema.cc
+++ b/tests/src/test_config_schema.cc
@@ -597,7 +597,6 @@ notify_banner_types = "IncomingAttack"
       CHECK(node->value<bool>().value_or(true) == false);
     }
     CHECK_FALSE(notifications->contains("partial_victory"));
-    CHECK_FALSE(notifications->contains("armada_battle_lost"));
     CHECK_FALSE(notifications->contains("notifications_enabled"));
     CHECK_FALSE(notifications->contains("system"));
     CHECK_FALSE(notifications->contains("audio"));

--- a/tests/src/test_notifications_and_dedupe.cc
+++ b/tests/src/test_notifications_and_dedupe.cc
@@ -74,6 +74,28 @@ TEST_SUITE("bounded_ttl_deduper")
 
 TEST_SUITE("notification_toast_policy")
 {
+  TEST_CASE("enabled armada policy specializes generic battle result states")
+  {
+    CHECK(notification_kind_for_battle_context(Victory, true, true)
+          == std::optional{NotificationKind::BattleArmadaBattleWon});
+    CHECK(notification_kind_for_battle_context(Defeat, true, true)
+          == std::optional{NotificationKind::BattleArmadaBattleLost});
+  }
+
+  TEST_CASE("generic victory and defeat remain fallback policies")
+  {
+    CHECK(notification_kind_for_battle_context(Victory, false, true) == std::optional{NotificationKind::BattleVictory});
+    CHECK(notification_kind_for_battle_context(Defeat, false, true) == std::optional{NotificationKind::BattleDefeat});
+    CHECK(notification_kind_for_battle_context(Victory, true, false) == std::optional{NotificationKind::BattleVictory});
+    CHECK(notification_kind_for_battle_context(Defeat, true, false) == std::optional{NotificationKind::BattleDefeat});
+  }
+
+  TEST_CASE("non-battle toast routing is unchanged by armada context")
+  {
+    CHECK(notification_kind_for_battle_context(ArmadaCreated, true, true)
+          == std::optional{NotificationKind::ArmadaCreated});
+  }
+
   TEST_CASE("v1.1.4 toast states have distinct configurable event identities")
   {
     const std::array cases{


### PR DESCRIPTION
## What changed

- classify ordinary `Victory`/`Defeat` battle-result toasts using `BattleResultHeader.IsArmadaBattle`
- route an Armada result through `armada_battle_won`/`armada_battle_lost` when that specific policy is enabled
- preserve the existing generic `victory`/`defeat` policy as the fallback when the Armada-specific policy is disabled
- give reclassified results the Armada-specific notification title
- replace the exhaustive release config surface with an explicit eight-event public allowlist
- retain the complete notification catalog and parser compatibility for existing/private configurations
- document the current-client producer behavior and rollback path in the native seam ledger

## Root cause

The current client retains dedicated Armada toast enum values, but `ToastBattleResultObserver.CreateToastForBattle` routes Armada Marauder and multi-target Armada results through the ordinary `Victory`/`Defeat` states. The prior exact-state lookup therefore never selected `armada_battle_won`.

## User impact

`armada_battle_won = true` and inline-table policies can now receive Armada victories without requiring users to enable every generic victory. Existing users who rely on `victory` continue to receive the generic fallback when the Armada-specific policy is not enabled.

Fresh and example configs now advertise only the release-supported notification set; unadvertised catalog entries remain compatible but are no longer presented as proven features.

## Validation

- blocking AXF review contract: passed
  - hook-support tier validation
  - gameplay seam scanner: no new unmanaged findings
  - `git diff --check`
  - pure tests: 329/329 cases, 4270/4270 assertions
- Windows release build: passed
- current-client IL2CPP corpus and targeted disassembly reviewed

## Runtime follow-up

A production artifact still needs one real Armada-victory smoke to retain the resulting `battle.armada_battle_won` queue/delivery evidence.