### PR TITLE
Extend tagged chest purchase sliders to 160

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ This project is maintained solely at my own cost of time, energy and money. Any 
 - Enable/Disable hotkeys (community mod or scopely)
 - Let unhandled hotkeys fall through to the game's original input path
 - Enable extended donation slider (alliance)
+- Extend tagged custom chest-purchase sliders up to the verified ceiling of 160 on Windows
+  (`[ui].extend_chest_purchase_max`; `0` disables). Two recruit chests accepted 160 and rejected 161; oversized
+  configured values are clamped, while a higher native game ceiling is preserved.
 - Fleet-bar arrival notifications for player ships
 - In-game audio cues for notification events
 - Show alternative cargo screens for:

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -33,6 +33,93 @@ Risk classes are also defined there: R0 static, R1 passive runtime, R2 managed l
 
 ## Entries
 
+### Standard Recruit custom-quantity submission and failure callbacks
+
+- Owner / file: completed temporary discovery record in
+  `docs/probes/20260730-standard-recruit-transaction-limit-discovery.md`.
+- Intended question: is the observed Standard Recruit inclusive ceiling of 160 present in client-visible bundle,
+  feature-config, request, or failure data?
+- Static evidence: the client-side feature-config method returns a generic/faction custom-quantity cap or fallback
+  50. Disassembly of the showcase and shop-manager request path forwards quantity without comparing it to 160. The
+  named generated `Bundle` fields expose purchase state and custom-quantity eligibility but no maximum custom
+  quantity.
+- Risk class: R2 managed log-only.
+- Confidence rung: payload understood.
+- Runtime evidence: the submission detour logged quantity 161 and Standard Recruit bundle ID `145512548`; its named
+  metadata exposed no maximum. Neither premium-purchase failure callback executed; the common loot-chest failure
+  handler captured both 161 and 520 as platform error 24, `InvalidBundleQuantity`, with message
+  `Can not purchase chosen quantity`. HTTP code, category, transaction ID, and request URL were empty, and no accepted
+  maximum was present. Human tests remain authoritative for the observed 159/160 success and 161 failure boundary.
+- Payload confidence: typed managed submission and loot-chest failure parameters; code 24 maps directly to the
+  current-client `PlatformError.ReponseCodes.InvalidBundleQuantity` enum.
+- Original/trampoline confidence: both retained probe seams executed and called their originals once with unchanged
+  arguments.
+- Flag / rollback path: temporary descriptors, detours, install blocks, and manifest module removed after capture.
+- Status: completed discovery evidence, not a feature or release surface.
+- Next action: revalidate the empirical boundary after relevant game updates or test a materially different
+  non-recruit chest category; do not infer a universal maximum from recruit chests.
+
+### Runtime Unity UI composition from `InventoryUseRowWidget.SetWidgetData()`
+
+- Owner / file: completed temporary capability proof recorded in
+  `docs/probes/20260730-runtime-unity-ui-injection.md`.
+- Intended question: can the injected mod compose a visible, arbitrarily positioned text object on an active game
+  canvas using the current client's Unity UI runtime?
+- Static evidence: the current corpus exposes `UnityEngine.Object.Instantiate(Object, Transform, bool)`,
+  `GameObject.GetComponent(Type)`, `Transform` parenting/sibling methods, `RectTransform` layout setters,
+  `TextLocalizer.OverrideLocalizedText(string)`, and `TMP_Text.set_fontSize(float)`. An existing popup-owned text
+  object supplies a compatible font, material, and renderer.
+- Risk class: R5 behavioral.
+- Confidence rung: runtime observed.
+- Runtime evidence: on 2026-07-30, a Windows release build cloned the Standard Recruit popup's amount text object,
+  reparented and centered it on the active root canvas, and displayed mod-authored purple-backed text. The human
+  supplied a screenshot confirming the visible result; the runtime logged
+  `[ChestPurchaseSlider] displayed experimental-limit in-game notice`.
+- Payload confidence: understood only for the tested popup-owned `TextLocalizer`, widget, and canvas relationship.
+- Original/trampoline confidence: the already registered chest-row detour returned successfully before composition;
+  the proof added no new detour.
+- Flag / rollback path: the prototype composition path was removed after its visual proof; only the evidence record
+  remains.
+- Status: ability proven possible in the current client, explicitly not product-safe. Object lifecycle, managed
+  rooting, scene/canvas replacement, deduplication, scaling, clipping, layering, raycast/input behavior, copied
+  component side effects, UI-thread assumptions, and future symbol drift remain unproven.
+- Next action: define and validate a bounded lifecycle contract before generalizing this into a reusable mod UI
+  service or shipping any screen element based on it.
+
+### `Digit.Prime.Inventories.InventoryUseRowWidget.SetWidgetData()`
+
+- Owner / file: release-supported bounded patch in `mods/src/patches/parts/misc.cc`; probe record in
+  `docs/probes/20260730-chest-purchase-slider-extension.md`.
+- Intended question: can the client-side quantity ceiling for explicitly tagged chest-purchase rows be raised
+  without changing donation, artifact-conversion, or ordinary inventory-use sliders?
+- Static evidence: the 2026-07-30 corpus retains `InventoryUseRowWidget.SetWidgetData()` at RVA `0x11A2890`,
+  `InventoryForPopup.IsChestPurchase` at offset `0x90`, and `InventoryForPopup.MaxItemsToUse` at offset `0x20`.
+  `InventoryManager.GetChestsMaxPurchaseCustomQuantity()` selects a generic or faction-store feature-config ceiling
+  and falls back to 50. Current-client disassembly shows the row renderer checking the chest tag after the context's
+  ceiling has been assigned, making this narrower than any global slider mutation.
+- Risk class: R5 behavioral.
+- Confidence rung: state-correlated.
+- Runtime evidence: a 2026-07-30 Windows release cycle resolved and installed the single hook
+  (`installed=1 failed=0 skipped=0 total=1`) and the client completed boot without a seam-related crash. An eligible
+  custom-quantity chest then logged `[ChestPurchaseSlider] extended quantity ceiling from 50 to 123`, and the human
+  confirmed that the rendered slider reached 123 without confirming a purchase. A later release cycle at the final
+  `0 = disabled` contract reported `installed=0 failed=0 skipped=1 total=1`, after which restoring 999 installed the
+  hook again and the same tagged row logged `[ChestPurchaseSlider] extended quantity ceiling from 50 to 999`.
+- Payload confidence: typed managed widget and typed `InventoryForPopup` context only; no opaque callback payload.
+- Original/trampoline confidence: observed returning successfully for the tested tagged chest row after the guarded
+  context adjustment.
+- Config / rollback path: `[ui].extend_chest_purchase_max`, Windows-only and default 160. Set it to 0 to skip the
+  hook and retain native behavior. Values from 1 through 160 are exposed and larger configured values clamp to 160.
+  A future native ceiling above the configured value wins and emits an explicit diagnostic.
+- End-to-end boundary: a Standard Recruit Chest purchase at 999 was rejected with the game's generic
+  purchase-failure dialog, while follow-up tests succeeded at 159 and 160 and failed at 161 despite sufficient claim
+  resources. Discovery logging captured the loot-chest service rejection as platform error 24,
+  `InvalidBundleQuantity`, with no maximum in its payload. A different recruit chest subsequently accepted 160 and
+  rejected 161 as well. This establishes a repeated empirical recruit-chest boundary, not a universal or
+  client-discoverable limit.
+- Status: runtime-observed, state-correlated, and release-promoted with a configurable, enforced 0-160 UI ceiling.
+- Next action: revalidate after relevant game updates or test a materially different non-recruit chest category.
+
 ### Static Inventory Snapshot - 2026-05-23
 
 This inventory records source-level seams from a static-only review. It does not claim new runtime observation, payload confidence, original/trampoline confidence, or product-safe status. "Operationally relied on" below means the seam is part of current product code paths; it is not a new confidence rung and is not evidence from this pass.

--- a/docs/probes/20260730-chest-purchase-slider-extension.md
+++ b/docs/probes/20260730-chest-purchase-slider-extension.md
@@ -1,0 +1,143 @@
+# Probe: Chest purchase slider extension
+
+- Status: release-promoted
+- Owner: Guffawaffle / stfc-mod
+- Date: 2026-07-30 through 2026-07-31
+- Related patch label: chest-purchase-slider-experiment
+- Related timeline refresh ID: 2026-07-30 current-client corpus
+- Related diff report: N/A
+- Native seam ledger entry: `Digit.Prime.Inventories.InventoryUseRowWidget.SetWidgetData()`
+
+## Question
+
+Can the client-side quantity ceiling for explicitly tagged chest-purchase rows be raised without changing any other
+inventory, donation, or artifact-conversion slider?
+
+## Static Evidence
+
+- Symbol: `Digit.Prime.Inventories.InventoryUseRowWidget.SetWidgetData`
+- Method signature: `void SetWidgetData()`, RVA `0x11A2890` in the 2026-07-30 corpus.
+- String/script/config evidence:
+  - `InventoryForPopup` retains the dedicated `IsChestPurchase` property and backing field at offset `0x90`.
+  - `InventoryForPopup.MaxItemsToUse` is a signed 64-bit value at offset `0x20`.
+  - `InventoryManager.GetChestsMaxPurchaseCustomQuantity` returns the generic or faction-store feature-config cap,
+    with a fallback of 50.
+  - Current-client disassembly shows `InventoryUseRowWidget.SetWidgetData` checking `IsChestPurchase` before
+    configuring the chest row and reading `MaxItemsToUse`.
+- Old/new diff context: this is a new release-supported patch; no prior chest-purchase slider hook exists.
+- Why this target is the narrowest candidate: the row is already fully tagged before `SetWidgetData` runs, allowing
+  the experiment to gate on the game's own chest-purchase discriminator. Earlier setters run before that tag exists,
+  while a global `UnityEngine.UI.Slider` hook would affect unrelated UI.
+
+## Risk
+
+- Risk class: R5
+- Confidence rung: state-correlated
+- Payload confidence: typed managed `InventoryUseRowWidget` and its typed `InventoryForPopup` context only; no
+  callback or opaque payload is interpreted.
+- Original/trampoline confidence: runtime-observed returning successfully; the original is called once after the
+  guarded context adjustment.
+- Behavior change expected: yes
+
+## Implementation Plan
+
+- Module/file: `mods/src/patches/parts/misc.cc`
+- Config or compile guard: `[ui].extend_chest_purchase_max`, Windows-only, default 160; non-positive values disable
+  the hook, values from 1 through 160 are exposed, and larger configured values clamp to 160.
+- Hook descriptor name: `InventoryUseRowWidget.SetWidgetData`
+- Target assembly: `Assembly-CSharp`
+- Target namespace: `Digit.Prime.Inventories`
+- Target class: `InventoryUseRowWidget`
+- Target method: `SetWidgetData`
+- Install path: `InstallMiscPatches`
+- Log tag or event kind: `ChestPurchaseSlider`
+
+Registry requirements:
+
+- Use `HookDescriptor`.
+- Use `HookModuleHealth`.
+- Use `HOOK_REGISTRY_SPUD_STATIC_DETOUR`.
+- Do not use raw `SPUD_STATIC_DETOUR`.
+
+## Disable Path
+
+- Flag or code path to disable: set `[ui].extend_chest_purchase_max = 0`.
+- File/entry to delete if it crashes: remove the one guarded install block and hook body from `misc.cc`.
+- Expected boot log when disabled: `ChestPurchaseSliderHooks` reports the hook skipped because the configured
+  maximum is non-positive.
+
+## Human Smoke Test
+
+Goal:
+
+Verify that an eligible chest-purchase quantity slider reaches the configured higher ceiling while donation,
+artifact-conversion, and ordinary inventory-use sliders retain their native ceilings.
+
+Steps:
+
+1. Set `extend_chest_purchase_max = 160`.
+2. Start the client and open an eligible multi-purchase chest popup.
+3. Move the quantity slider to its maximum without confirming a purchase.
+4. Open one donation or ordinary inventory-use popup and confirm its ceiling is unchanged.
+5. Disable the flag, restart, and confirm the native chest ceiling returns.
+
+Expected log marker/event:
+
+`ChestPurchaseSliderHooks` installs one hook; `ChestPurchaseSlider` logs the native and effective ceilings when
+it changes a tagged context.
+
+Stop immediately if:
+
+The client crashes or hangs, an untagged slider changes, the chest row becomes unusable, or disabling the flag does
+not restore native behavior.
+
+Report back:
+
+Observed native maximum, configured maximum, displayed maximum, whether any purchase was attempted, and whether the
+disable path restored the native ceiling.
+
+## Result
+
+- Build/deploy command: AXF `stfc-mod-private.cycle`, Windows release mode.
+- Runtime command: the cycle stopped the existing client, deployed the hash-matched release DLL, launched
+  `prime.exe`, and verified fresh boot activity.
+- Human action performed: opened an eligible custom-quantity chest popup and moved its slider to the maximum without
+  confirming a purchase.
+- Observed log/event evidence: the pre-promotion `ChestPurchaseSliderExperiment` resolved
+  `InventoryUseRowWidget.SetWidgetData` and reported `installed=1 failed=0 skipped=0 total=1`. When the tagged row
+  rendered, the runtime logged `[ChestPurchaseSlider] extended quantity ceiling from 50 to 123`; the human confirmed
+  the displayed slider reached 123.
+- Crash/hang/recovery notes: no crash or hang during install/boot. The cycle reported the pre-existing
+  `MissionHudTweaks.UpdateButtons` missing-method audit failure, unrelated to this experiment.
+- Disable-path evidence: a release cycle with `extend_chest_purchase_max = 0` reported
+  `ChestPurchaseSliderHooks` as `installed=0 failed=0 skipped=1 total=1` with detail
+  `configured maximum is non-positive`. The setting was then raised to 999 for boundary discovery and a fresh cycle
+  installed the hook.
+- Exploratory high-config evidence: rendering the same tagged chest row during discovery logged
+  `[ChestPurchaseSlider] extended quantity ceiling from 50 to 999`.
+- End-to-end boundary: confirming a Standard Recruit Chest purchase at the extended 999 quantity produced the
+  game's generic `The purchase failed to go through` error. The client offered its normal latinum top-up path for
+  missing claim tokens, but available claim resources were not the limiting factor. Follow-up boundary tests
+  established that 159 and 160 completed successfully while 161 failed, making 160 the observed inclusive
+  transaction ceiling for Standard Recruit Chests. Current-client disassembly of
+  `ShopShowcaseViewController.TryPurchaseMultipleChests(ResourceCostData, uint)` shows the selected quantity being
+  forwarded unchanged into the purchase service, with no second client-side 50-item clamp.
+- Discovery payload: temporary log-only hooks later captured quantities 161 and 520 entering the Standard Recruit
+  loot-chest path and failing with `GSError` platform code 24, `InvalidBundleQuantity`, and message
+  `Can not purchase chosen quantity`. The payload contains no accepted maximum, so 160 remains empirical rather than
+  dynamically discoverable.
+- Independent boundary confirmation: a different recruit chest also accepted 160 and rejected 161, reproducing the
+  same inclusive transaction boundary.
+- Release-config evidence: the repo default and live config were finalized at 160; a clean Windows release cycle
+  installed `ChestPurchaseSliderHooks` with `installed=1 failed=0 skipped=0 total=1`.
+- Answer to the question: yes. The game's chest-purchase discriminator isolated the row, the configured ceiling
+  replaced the native 50, the original renderer returned successfully, and the slider displayed 123 in the initial
+  smoke. Two recruit chests then succeeded at the bounded ceiling of 160 and rejected 161.
+
+## Exit Decision
+
+Promote with a configurable and enforced UI ceiling of 160. Larger configured values clamp to 160, 0 disables the
+hook, and a future native game ceiling above the configured value remains authoritative rather than being lowered.
+
+Next action: revalidate the empirical transaction boundary after relevant game updates or when testing a materially
+different non-recruit chest category.

--- a/docs/probes/20260730-runtime-unity-ui-injection.md
+++ b/docs/probes/20260730-runtime-unity-ui-injection.md
@@ -1,0 +1,111 @@
+# Probe: Runtime Unity UI injection
+
+- Status: observed; prototype removed after proof
+- Owner: Guffawaffle / stfc-mod
+- Date: 2026-07-30
+- Related patch label: chest-purchase-slider UI proof
+- Related timeline refresh ID: 2026-07-30 current-client corpus
+- Related diff report: N/A
+- Native seam ledger entry: runtime Unity UI composition from
+  `Digit.Prime.Inventories.InventoryUseRowWidget.SetWidgetData()`
+
+## Question
+
+Can the injected mod create visible, arbitrarily positioned text on an active game canvas by composing the game's
+existing Unity UI objects at runtime?
+
+## Static Evidence
+
+- Symbols:
+  - `UnityEngine.Component.get_transform()` and `get_gameObject()`
+  - `UnityEngine.Transform.get_parent()`, `SetParent()`, and `SetAsLastSibling()`
+  - `UnityEngine.Object.Instantiate(Object, Transform, bool)`
+  - `UnityEngine.GameObject.GetComponent(Type)`
+  - `UnityEngine.RectTransform` layout setters
+  - `Digit.Client.UI.TextLocalizer.OverrideLocalizedText(string)`
+  - `TMPro.TMP_Text.set_fontSize(float)`
+- Composition strategy: clone a text object already owned by the chest popup, parent it to the popup's root canvas,
+  reposition its `RectTransform`, and replace its localized text. Reusing an existing object carries forward a
+  compatible font, material, and renderer without loading a new UI asset.
+- Why this is a capability proof rather than a feature: it establishes that the mod can add a visible object to an
+  active game canvas. It does not establish safe lifecycle management, reusable layout behavior, or compatibility
+  across game screens and client updates.
+
+## Risk
+
+- Risk class: R5
+- Confidence rung: runtime observed
+- Payload confidence: the source `TextLocalizer`, popup widget, and root canvas were identified successfully for the
+  tested Standard Recruit popup only.
+- Original/trampoline confidence: the existing chest-row hook returned successfully before the UI object was
+  composed; no additional native detour was introduced for this proof.
+- Behavior change expected: yes
+
+Open safety questions:
+
+- Whether the clone is destroyed reliably with every owning canvas and scene transition.
+- Whether cached managed pointers or handles remain safe after Unity destroys the cloned object.
+- Whether repeated popup opens, resolution changes, canvas scaling, and unusual aspect ratios produce duplicates or
+  off-screen/clipped content.
+- Whether cloned localization, sibling, animation, accessibility, raycast, or reactive components retain unwanted
+  behavior from the source object.
+- Whether layering remains correct across modal stacks and whether a notice could obscure or intercept interaction.
+- Whether the Unity calls are always reached on the game UI thread.
+- Whether this composition path survives class, method, field, font, and prefab changes in future clients.
+
+## Implementation Plan
+
+- Module/file: temporary proof formerly in `mods/src/patches/parts/misc.cc`; removed after capture
+- Historical prototype guard: reached only when `[ui].extend_chest_purchase_max` was above the verified 160 boundary
+  during discovery. The prototype and that above-boundary release behavior were removed.
+- Existing hook descriptor: `InventoryUseRowWidget.SetWidgetData`
+- Install path: `InstallMiscPatches`
+- Log tag: `ChestPurchaseSlider`
+
+This proof deliberately reuses an already registered hook. It does not justify adding an unregistered UI lifecycle
+hook or promoting a general overlay service.
+
+## Disable Path
+
+- The prototype composition call and helpers were removed after the visual proof.
+- The proof creates no persistent files or game assets.
+
+## Human Smoke Test
+
+Goal:
+
+Demonstrate visible mod-authored text on the Standard Recruit chest popup.
+
+Steps:
+
+1. Set `extend_chest_purchase_max = 999`.
+2. Cycle the Windows release DLL and open the Standard Recruit custom-quantity popup.
+3. Confirm that the centered purple-backed message is visible.
+
+Expected log marker:
+
+`[ChestPurchaseSlider] displayed experimental-limit in-game notice`
+
+Stop immediately if:
+
+The client crashes or hangs, the popup becomes non-interactive, the cloned object obscures purchase controls, or the
+notice persists incorrectly after leaving the owning UI.
+
+## Result
+
+- Build/deploy command: Windows release build followed by AXF `stfc-mod-private.cycle`.
+- Human action performed: opened the Standard Recruit custom-quantity popup at a configured maximum of 999.
+- Observed result: a cloned game-native text object appeared in the center of the active popup canvas with the
+  mod-authored text `STFC MOD UI TEST` and `Chest purchases above 160 are experimental.` The human supplied a
+  screenshot confirming the text, purple mark background, inherited game font, and placement within the modal.
+- Log evidence: `[ChestPurchaseSlider] displayed experimental-limit in-game notice`.
+- Crash/hang/recovery notes: no seam-related crash or hang was observed during this single proof.
+- Answer to the question: yes. Runtime Unity UI composition from the injected mod is possible in the current client.
+
+## Exit Decision
+
+Retain the documentation as an observed capability proof, not as evidence of a production-safe overlay system. The
+prototype runtime code was removed so the release-supported chest slider retains no experimental UI lifecycle.
+
+Next action: if a product UI surface is desired, build and test a bounded lifecycle contract covering creation,
+deduplication, destruction, canvas changes, scaling, input/raycast behavior, and rollback before promotion.

--- a/docs/probes/20260730-standard-recruit-transaction-limit-discovery.md
+++ b/docs/probes/20260730-standard-recruit-transaction-limit-discovery.md
@@ -1,0 +1,116 @@
+# Probe: Standard Recruit transaction-limit discovery
+
+- Status: completed; temporary instrumentation removed
+- Owner: Guffawaffle / stfc-mod
+- Date: 2026-07-30 through 2026-07-31
+- Related patch label: chest-purchase-slider discovery logging
+- Related timeline refresh ID: 2026-07-30 current-client corpus
+- Related diff report: N/A
+- Native seam ledger entry: Standard Recruit custom-quantity purchase submission and failure callbacks
+
+## Question
+
+Can the Standard Recruit Chest's observed inclusive transaction ceiling of 160 be discovered from client-visible
+bundle, feature-config, request, or failure data before relying on human boundary testing?
+
+## Static Evidence
+
+- `InventoryManager.GetChestsMaxPurchaseCustomQuantity()` reads
+  `FeaturesConfig.ChestsMaxPurchaseCustomQuantity` or
+  `FeaturesConfig.FactionStoreChestsMaxPurchaseCustomQuantity` and otherwise returns 50.
+- The Standard Recruit popup received the native client value 50 before the mod changed it.
+- Current-client disassembly of `ShopShowcaseViewController.TryPurchaseMultipleChests(ResourceCostData, uint)`,
+  `ShopSceneManager.TryPurchaseChest(...)`, and `ShopSceneManager.RequestAction(...)` shows the selected quantity
+  forwarded into the request path without a comparison against 160.
+- The generated `Bundle` model exposes purchase state, protobuf metadata, and `AllowCustomQuantity`, but its named
+  fields do not expose a maximum custom claim quantity.
+- Human boundary evidence already establishes success at 159 and 160 and rejection at 161 for Standard Recruit,
+  despite sufficient claim resources.
+
+## Risk
+
+- Risk class: R2 managed log-only
+- Confidence rung: payload understood
+- Payload confidence: typed `ShopShowcaseViewController`, `Bundle`, quantity, `GSError`, and
+  `BundleRewardClaimContext` parameters from current-client signatures. The captured error maps exactly to
+  `PlatformError.ReponseCodes.InvalidBundleQuantity`.
+- Original/trampoline confidence: submission and common loot-chest failure detours both executed and called their
+  originals once with unchanged arguments.
+- Behavior change expected: no
+
+## Implementation Plan
+
+- Temporary module/file: `ChestPurchaseDiscoveryHooks`, formerly in `mods/src/patches/parts/misc.cc` and removed
+  after capture
+- Guard: Windows only, compile-time discovery switch, and `extend_chest_purchase_max > 160`
+- Hook descriptors:
+  - `ShopShowcaseViewController.TryPurchaseMultipleChests`
+  - `ShopSceneManager.OnOpenLootChestFailure(GSError, BundleRewardClaimContext)`
+- Log tag: `ChestPurchaseDiscovery`
+- Logged data:
+  - submitted quantity and target bundle pointer
+  - bundle ID and named quantity/purchase-related fields
+  - bounded generated `Bundle.ToString()` diagnostic output
+  - failure reason and `GSError` type, code, HTTP code, category, message, transaction ID, and request URL
+
+The first runtime action proved that the popup-local
+`ShopShowcaseViewController.OnPurchaseFailedEventHandler` is not used for this rejection. The second action likewise
+proved that the scene-level premium-store failure event is not used. Static tracing then identified Standard Recruit
+as the loot-chest action path: the generated `TryRequestActionBundleType` failure callback forwards its `GSError` to
+the two-parameter `ShopSceneManager.OnOpenLootChestFailure` common implementation before the generic platform-error
+dialog is shown.
+
+## Disable Path
+
+- The temporary descriptors, detours, and install blocks were removed after capture.
+- No request values, game assets, or persistent data are modified.
+
+## Human Smoke Test
+
+Goal:
+
+Capture one rejected Standard Recruit purchase at quantity 161 and determine whether the client-visible preflight or
+failure payload contains the authoritative boundary.
+
+Steps:
+
+1. Cycle the instrumented Windows release build.
+2. Open Standard Recruit Chest custom quantity.
+3. Enter or select 161.
+4. Confirm the purchase once.
+5. Stop after the expected failure dialog.
+
+Expected log markers:
+
+- `[ChestPurchaseDiscovery] submit ... quantity=161`
+- `[ChestPurchaseDiscovery] failure ...`
+
+Stop immediately if:
+
+The client crashes or hangs, a different bundle is targeted, the requested quantity changes, or resources are spent
+despite the expected rejection.
+
+## Result
+
+The Windows release probes installed without missing methods, duplicate owners, or detour failures. Submission
+captures identified Standard Recruit bundle `145512548` and confirmed that quantities 161 and 520 were forwarded
+unchanged. The common loot-chest failure handler then captured both rejections:
+
+- `GSError.Type = PLATFORM`
+- `GSError.Code = 24`, which the current corpus names `InvalidBundleQuantity`
+- `GSError.Message = "Can not purchase chosen quantity"`
+- HTTP response code `0`, with empty category, transaction ID, and request URL
+- null `BundleRewardClaimContext`
+
+The quantity-161 rejection arrived about 134 ms after submission. Neither the bundle metadata nor the failure
+payload contained the accepted maximum. Existing human boundary evidence remains the only source for the inclusive
+Standard Recruit ceiling: 159 and 160 succeed; 161 fails despite sufficient resources. A subsequent human test of a
+different recruit chest independently reproduced the boundary: 160 succeeded and 161 failed.
+
+## Exit Decision
+
+The 160 ceiling is enforced by the loot-chest platform/action service but is not dynamically discoverable from the
+current client-visible bundle, request path, or failure payload. The repeated recruit-chest evidence supports locking
+the release UI extension to 160 without claiming that every chest service shares the same server limit. Clamp larger
+configured values to 160 and retain any higher future native ceiling. The temporary discovery hooks were removed;
+this probe and the seam ledger preserve the evidence.

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -715,6 +715,15 @@ disabled_banner_types = ""
 # Legacy [ui].notify_on_banner_types / notify_banner_types keys are still
 # accepted for migration from older configs, but they are not documented here.
 
+# Subgroup: Chest Purchases
+# -------------------------
+
+# Maximum quantity exposed by custom chest-purchase sliders on Windows (0-160).
+# Set to 0 to use the game's native ceiling. Two recruit chests accepted 160
+# and rejected 161. Larger configured values are clamped; a larger native
+# ceiling is never lowered.
+extend_chest_purchase_max = 160
+
 # Subgroup: Chat
 # --------------
 

--- a/manifests/hook_support_tiers.json
+++ b/manifests/hook_support_tiers.json
@@ -34,6 +34,12 @@
       "rationale": "Release-supported fleet-state, arrival, mining, and incoming-attack notification hooks."
     },
     {
+      "id": "ChestPurchaseSliderHooks",
+      "tier": "production",
+      "source": "mods/src/patches/parts/misc.cc",
+      "rationale": "Release-supported Windows quantity extension scoped to InventoryForPopup rows explicitly tagged as chest purchases; two recruit chests accepted the enforced UI ceiling of 160 and rejected 161."
+    },
+    {
       "id": "HotkeyHooks",
       "tier": "production",
       "source": "mods/src/patches/parts/hotkeys.cc",
@@ -143,6 +149,14 @@
       "release_example_allowed": false,
       "science_example_required": true,
       "rationale": "Legacy direct-handler experiment remains isolated from normal release configuration."
+    },
+    {
+      "path": "ui.extend_chest_purchase_max",
+      "tier": "production",
+      "owner": "ChestPurchaseSliderHooks",
+      "release_example_allowed": true,
+      "science_example_required": false,
+      "rationale": "Release-supported Windows-only 0-160 ceiling for tagged chest-purchase quantity sliders; larger configured values clamp to 160, non-positive values disable the hook, and higher native ceilings are retained."
     },
     {
       "path": "ui.restore_below_decks_assignment_sort",

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -68,8 +68,7 @@ using config_metadata::notificationToggleSpecs;
 
 static_assert(!DCS::allow_unsafe_tls_without_certificate_validation, "Unsafe TLS override default must remain false.");
 
-// Standalone flag — NOT in Config struct to avoid struct layout sensitivity.
-// See: fix/lto-and-sync-crashes for context on why Config struct changes crash.
+// Legacy settings exposed through read-only accessors.
 static bool                      g_allow_key_fallthrough    = false;
 static ScopelyShortcutPolicy     g_scopely_shortcuts_policy = ScopelyShortcutPolicy::Off;
 static OriginalFramePolicy       g_original_frame_policy    = OriginalFramePolicy::Mod;
@@ -1371,6 +1370,8 @@ void Config::Load()
                             DCU::restore_below_decks_assignment_sort, write_config);
 
 #if _WIN32
+  this->extend_chest_purchase_max = get_config_or_default(config, parsed, "ui", "extend_chest_purchase_max",
+                                                          DCU::extend_chest_purchase_max, write_config);
   this->extend_donation_slider =
       get_config_or_default(config, parsed, "ui", "extend_donation_slider", DCU::extend_donation_slider, write_config);
   this->extend_donation_max =

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -427,6 +427,7 @@ public:
   bool             borderless_fullscreen;
   std::vector<int> disabled_banner_types;
 
+  int  extend_chest_purchase_max;
   int  extend_donation_max;
   bool extend_donation_slider;
   bool disable_move_keys;
@@ -492,9 +493,7 @@ public:
 /**
  * @brief Whether unhandled key events pass through to the game's default input.
  *
- * Stored as a file-scope static in config.cc rather than a Config member to
- * avoid changing the struct layout, which can trigger LTO-related crashes.
- * @see fix/lto-and-sync-crashes
+ * This legacy setting is stored at file scope and exposed through a read-only accessor.
  */
 bool AllowKeyFallthrough();
 

--- a/mods/src/config_release_validation.cc
+++ b/mods/src/config_release_validation.cc
@@ -116,6 +116,7 @@ namespace
       "ui.disable_veil_chat",
       "ui.disabled_banner_types",
       "ui.escape_exit_timer",
+      "ui.extend_chest_purchase_max",
       "ui.extend_donation_max",
       "ui.extend_donation_slider",
       "ui.mission_hud.daily_goals",

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -495,6 +495,8 @@ namespace UI
   constexpr bool disable_veil_chat = false;
   /// Comma-separated list of toast banner type names to suppress (empty = none).
   constexpr const char* disabled_banner_types = "";
+  /// Maximum quantity exposed by tagged chest-purchase sliders. Range: 0-160. Default: 160. (Windows only.)
+  constexpr auto extend_chest_purchase_max = 160;
   /// Maximum alliance-donation slider value (percentage). Default: 80.
   constexpr auto extend_donation_max = 80;
   /// Enable the extended donation slider range. Default: true. (Windows only.)

--- a/mods/src/patches/parts/misc.cc
+++ b/mods/src/patches/parts/misc.cc
@@ -4,6 +4,7 @@
  *
  * A collection of independent patches that don't warrant their own file:
  *   - Donation slider extension (raise the 50-item cap)
+ *   - Tagged chest-purchase slider extension
  *   - Bundle cooldown bypass (click through to info view while on cooldown)
  *   - Resolution list cleanup (deduplicate and normalize refresh rates)
  *   - Buff extraction null-guard (prevent crash on null list entries)
@@ -13,14 +14,24 @@
 #include "config.h"
 #include "errormsg.h"
 
+#if _WIN32
+#include "patches/hook_registry.h"
+#endif
+
 #include <prime/BundleDataWidget.h>
 #include <prime/ClientModifierType.h>
 #include <prime/IList.h>
 #include <prime/InterstitialViewController.h>
 #include <prime/InventoryForPopup.h>
+#if _WIN32
+#include <prime/InventoryUseRowWidget.h>
+#endif
 
 #include <il2cpp/il2cpp_helper.h>
 
+#if _WIN32
+#include <spdlog/spdlog.h>
+#endif
 #include <spud/detour.h>
 
 #if _WIN32
@@ -31,7 +42,21 @@
 #include <cstdint>
 #include <vector>
 
-// ─── Donation Slider Extension ───────────────────────────────────────────────
+// ─── Inventory Slider Extensions ─────────────────────────────────────────────
+
+#if _WIN32
+namespace
+{
+constexpr int64_t kMaximumChestPurchaseMax = 160;
+
+constexpr HookDescriptor kChestPurchaseSliderHook{
+    "InventoryUseRowWidget.SetWidgetData",
+    "Raise the quantity ceiling only for inventory rows tagged by the game as chest purchases.",
+    {"Assembly-CSharp", "Digit.Prime.Inventories", "InventoryUseRowWidget", "SetWidgetData"},
+    "Tagged chest-purchase sliders will retain the native quantity ceiling.",
+    HookSupportTier::Production};
+} // namespace
+#endif
 
 /**
  * @brief Hook: InventoryForPopup::set_MaxItemsToUse
@@ -61,6 +86,37 @@ void InventoryForPopup_set_MaxItemsToUse(auto original, InventoryForPopup* a1, i
   original(a1, a2);
 }
 
+/**
+ * @brief Hook: InventoryUseRowWidget::SetWidgetData
+ *
+ * The chest-purchase context is tagged only after its native MaxItemsToUse value is assigned, so the earlier setter
+ * hook cannot reliably distinguish it. This later row-render seam sees both values and raises only tagged chest
+ * purchase rows with a positive native ceiling. It never replaces an unknown/non-positive sentinel or lowers a
+ * native maximum. A non-positive configured value disables the hook at install.
+ */
+#if _WIN32
+void InventoryUseRowWidget_SetWidgetData(auto original, InventoryUseRowWidget* widget)
+{
+  if (widget) {
+    if (auto* context = widget->Context; context && context->IsChestPurchase) {
+      const auto native_max    = context->MaxItemsToUse;
+      const auto requested_max = static_cast<int64_t>(Config::Get().extend_chest_purchase_max);
+      const auto bounded_max   = std::min(requested_max, kMaximumChestPurchaseMax);
+      if (native_max > 0 && bounded_max > native_max) {
+        context->MaxItemsToUse = bounded_max;
+        spdlog::info("[ChestPurchaseSlider] extended quantity ceiling from {} to {}", native_max, bounded_max);
+      } else if (native_max > bounded_max) {
+        spdlog::info("[ChestPurchaseSlider] retained native quantity ceiling {} above bounded configured ceiling {} "
+                     "(requested {})",
+                     native_max, bounded_max, requested_max);
+      }
+    }
+  }
+
+  original(widget);
+}
+#endif
+
 // ─── Bundle Cooldown Bypass ──────────────────────────────────────────────────
 
 /**
@@ -81,14 +137,15 @@ void BundleDataWidget_OnActionButtonPressedCallback(auto original, BundleDataWid
 }
 
 /**
- * @brief Installs donation slider and bundle cooldown patches.
+ * @brief Installs inventory-slider and bundle-cooldown patches.
  *
- * Hooks InventoryForPopup::set_MaxItemsToUse (Windows only) and
- * BundleDataWidget::OnActionButtonPressedCallback.
+ * Hooks the donation setter and tagged chest-purchase row renderer on Windows, plus the bundle action callback.
  */
 void InstallMiscPatches()
 {
 #if _WIN32
+  HookModuleHealth chest_slider_hooks("ChestPurchaseSliderHooks");
+
   auto h = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Inventories", "InventoryForPopup");
   if (!h.isValidHelper()) {
     ErrorMsg::MissingHelper("Digit.Prime.Inventories", "InventoryForPopup");
@@ -100,6 +157,29 @@ void InstallMiscPatches()
       SPUD_STATIC_DETOUR(ptr, InventoryForPopup_set_MaxItemsToUse);
     }
   }
+
+  const auto configured_chest_max = Config::Get().extend_chest_purchase_max;
+  if (configured_chest_max <= 0) {
+    chest_slider_hooks.record_skipped(kChestPurchaseSliderHook, "configured maximum is non-positive");
+  } else {
+    if (configured_chest_max > kMaximumChestPurchaseMax) {
+      spdlog::warn("[ChestPurchaseSlider] configured extension ceiling {} exceeds verified transaction ceiling {}; "
+                   "clamping the extension (higher native ceilings remain unchanged)",
+                   configured_chest_max, kMaximumChestPurchaseMax);
+    }
+
+    auto& row_widget = InventoryUseRowWidget::get_class_helper();
+    if (!row_widget.isValidHelper()) {
+      chest_slider_hooks.record_missing_helper(kChestPurchaseSliderHook);
+    } else if (auto set_widget_data = row_widget.GetMethod("SetWidgetData", 0); set_widget_data == nullptr) {
+      chest_slider_hooks.record_missing_method(kChestPurchaseSliderHook);
+    } else {
+      HOOK_REGISTRY_SPUD_STATIC_DETOUR(chest_slider_hooks, kChestPurchaseSliderHook, set_widget_data,
+                                       InventoryUseRowWidget_SetWidgetData);
+    }
+  }
+
+  chest_slider_hooks.log_summary();
 #endif
 
   auto bundle_data_widget = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "BundleDataWidget");

--- a/mods/src/prime/InventoryForPopup.h
+++ b/mods/src/prime/InventoryForPopup.h
@@ -2,9 +2,13 @@
 
 #include <il2cpp/il2cpp_helper.h>
 
+#include <cstdint>
+
 struct InventoryForPopup {
 public:
-  __declspec(property(get = __get_IsDonationUse, put = __set_IsDonationUse)) bool IsDonationUse;
+  __declspec(property(get = __get_MaxItemsToUse, put = __set_MaxItemsToUse)) int64_t MaxItemsToUse;
+  __declspec(property(get = __get_IsDonationUse, put = __set_IsDonationUse)) bool    IsDonationUse;
+  __declspec(property(get = __get_IsChestPurchase)) bool                             IsChestPurchase;
 
 private:
   static IL2CppClassHelper& get_class_helper()
@@ -15,15 +19,36 @@ private:
   }
 
 public:
-  bool __get_IsDonationUse()
+  int64_t __get_MaxItemsToUse()
   {
-    static auto field = get_class_helper().GetProperty("IsDonationUse");
-    return field.GetRaw(this);
+    static auto property = get_class_helper().GetProperty("MaxItemsToUse");
+    const auto* value    = property.Get<int64_t>(this);
+    return value ? *value : 0;
   }
 
-  void __set_IsDonationUse(float v)
+  void __set_MaxItemsToUse(int64_t value)
   {
-    static auto field = get_class_helper().GetProperty("IsDonationUse");
-    return field.SetRaw(this, v);
+    static auto property = get_class_helper().GetProperty("MaxItemsToUse");
+    property.SetRaw(this, value);
+  }
+
+  bool __get_IsDonationUse()
+  {
+    static auto property = get_class_helper().GetProperty("IsDonationUse");
+    const auto* value    = property.Get<bool>(this);
+    return value ? *value : false;
+  }
+
+  void __set_IsDonationUse(bool value)
+  {
+    static auto property = get_class_helper().GetProperty("IsDonationUse");
+    property.SetRaw(this, value);
+  }
+
+  bool __get_IsChestPurchase()
+  {
+    static auto property = get_class_helper().GetProperty("IsChestPurchase");
+    const auto* value    = property.Get<bool>(this);
+    return value ? *value : false;
   }
 };

--- a/mods/src/prime/InventoryUseRowWidget.h
+++ b/mods/src/prime/InventoryUseRowWidget.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "InventoryForPopup.h"
+#include "Widget.h"
+
+struct InventoryUseRowWidget : public Widget<InventoryForPopup, InventoryUseRowWidget> {
+  static IL2CppClassHelper& get_class_helper()
+  {
+    static auto class_helper =
+        il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Inventories", "InventoryUseRowWidget");
+    return class_helper;
+  }
+
+private:
+  friend struct Widget<InventoryForPopup, InventoryUseRowWidget>;
+};


### PR DESCRIPTION
## What changed

- add `[ui].extend_chest_purchase_max` for Windows, defaulting to the verified ceiling of 160
- hook `InventoryUseRowWidget.SetWidgetData()` and mutate only contexts tagged by the game as chest purchases
- clamp oversized configured extensions to 160, let `0` retain native behavior, preserve higher native ceilings, and leave unknown/non-positive native sentinels unchanged
- add production hook ownership/health metadata and managed bindings for the widget context
- correct `IsDonationUse` boolean unboxing so the existing donation hook remains scoped to donation contexts
- document the runtime UI capability proof and the completed transaction-limit discovery, while removing all temporary discovery/UI code

## Why

The game still supports custom chest quantities internally, but its native recruit chest UI is capped at 50. Runtime testing showed two recruit chests accept 160 and reject 161. Discovery hooks confirmed the selected quantity reaches the platform unchanged and that rejected requests return platform code 24 (`InvalidBundleQuantity`) without exposing an authoritative maximum.

## Impact

Eligible tagged chest-purchase sliders can expose quantities through 160. Untagged inventory, artifact, and donation paths remain unchanged. The hook is Windows-only and can be disabled with `extend_chest_purchase_max = 0`.

## Validation

- blocking hook review contract passed
- hook support manifest: 14/14 modules accounted for, no errors or warnings
- gameplay seam scan: no new unmanaged findings and no stale baseline entries
- `git diff --check`
- 326/326 pure tests passed with 4,472 assertions
- Windows release build passed
- clean game cycle installed `ChestPurchaseSliderHooks`: 1 installed, 0 failed, 0 skipped
- human runtime tests: two recruit chests accepted 160 and rejected 161
