### PR TITLE
Repair mission HUD visibility controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
 
 ### Fixes
 
+- Repaired mission HUD visibility controls against the current game UI: Q Trials,
+  Field Training, Outposts, and Missions again honor `always`/`auto`/`never`;
+  the removed Daily Goals HUD button setting is now ignored with a warning
 - Added a Windows modifier-state fallback for Shift/Ctrl/Alt so `ALT-*` chords
   do not fall through as plain keys when Unity drops the modifier state
 - Fixed `Key::HasAlt()` checking RightShift instead of RightAlt

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -33,6 +33,33 @@ Risk classes are also defined there: R0 static, R1 passive runtime, R2 managed l
 
 ## Entries
 
+### `Digit.Prime.HUD.MissionsHudViewController` current-button visibility lifecycle
+
+- Owner / file: release-supported patch in `mods/src/patches/parts/mission_hud_tweaks.cc`; probe record in
+  `docs/probes/20260731-mission-hud-current-buttons.md`.
+- Intended question: can the four buttons retained by the current mission HUD continue to honor the configured
+  `always`/`auto`/`never` policy after the former common refresh method and Daily Goals button were removed?
+- Static evidence: the 2026-07-30 current-client corpus no longer contains `_dailyGoalsButton` or `UpdateButtons()`.
+  It retains `_missionsButton`, `_achievementsButton`, `_outpostsButton`, and `_challengesButton`, plus
+  `OnEnable()` and the narrower `HandleOutpostsAndChallengesHUD()` refresh method.
+- Risk class: R5 behavioral.
+- Confidence rung: state-correlated for `OnEnable()`; runtime observed for the dedicated refresh seam.
+- Runtime evidence: a Windows release experiment installed the replacement `OnEnable()` detour without failure.
+  With `q_trials = "never"`, the human confirmed Q Trials was hidden; with `q_trials = "auto"` and
+  `outposts = "always"`, the human confirmed all three buttons in that HUD state were visible. The final two-hook
+  release cycle resolved and installed both current methods (`installed=2 failed=0 skipped=0 total=2`), and
+  `PatchAudit` reported the module consistent.
+- Payload confidence: typed managed controller only; both hooks have no extra arguments.
+- Original/trampoline confidence: `OnEnable()` returned successfully and the UI remained interactive. The original
+  is called exactly once before the mod reapplies configured visibility.
+- Config / rollback path: `[ui.mission_hud]` retains `q_trials`, `field_training`, `outposts`, and `missions`.
+  Set all four to `auto` to skip the module and install no hooks. The obsolete `daily_goals` key is ignored with a
+  warning and omitted from rewritten/example configuration.
+- Status: release-promoted for the current four-button surface. Daily Goals remains navigable elsewhere but no
+  longer has a HUD component that this visibility feature can control.
+- Next action: recheck visibility after an outpost or challenge state refresh when practical, and revalidate the
+  explicit field/method dependency set after relevant client updates.
+
 ### Standard Recruit custom-quantity submission and failure callbacks
 
 - Owner / file: completed temporary discovery record in

--- a/docs/probes/20260731-mission-hud-current-buttons.md
+++ b/docs/probes/20260731-mission-hud-current-buttons.md
@@ -1,0 +1,74 @@
+# Probe: Current mission HUD button visibility
+
+- Status: release-promoted
+- Owner: Guffawaffle / stfc-mod
+- Date: 2026-07-31
+- Related patch label: mission-hud-current-buttons
+- Related timeline refresh ID: 2026-07-30 current-client corpus
+- Related diff report: N/A
+- Native seam ledger entry: `Digit.Prime.HUD.MissionsHudViewController` current-button visibility lifecycle
+
+## Question
+
+Can the mission HUD visibility feature be repaired for the current client without retaining a dead Daily Goals
+target or depending on the removed common `UpdateButtons()` method?
+
+## Static Evidence
+
+- Symbol: `Digit.Prime.HUD.MissionsHudViewController`
+- Current fields:
+  - `_missionsButton` at offset `0x38`
+  - `_achievementsButton` at offset `0x40`
+  - `_outpostsButton` at offset `0x58`
+  - `_challengesButton` at offset `0x60`
+- Current lifecycle/refresh methods:
+  - `void OnEnable()` at RVA `0x13EB680`
+  - `void HandleOutpostsAndChallengesHUD()` at RVA `0x13ED8F0`
+- Removed surface: the current corpus contains neither `_dailyGoalsButton` nor `UpdateButtons()` on this controller.
+  Daily Goals navigation still exists elsewhere, but it is not a current mission HUD button.
+- Why these targets are bounded: `OnEnable()` establishes visibility after the controller becomes active. The
+  dedicated outpost/challenge refresh is the only current controller method named for recalculating those two
+  buttons, so reapplying after it prevents that native refresh from undoing configured Q Trials or Outposts policy.
+
+## Risk
+
+- Risk class: R5
+- Confidence rung: state-correlated for `OnEnable()`; runtime observed for the dedicated refresh hook
+- Payload confidence: typed managed controller with no additional hook parameters
+- Original/trampoline confidence: observed returning successfully for `OnEnable()`; each hook calls its original
+  exactly once before applying the configured state
+- Behavior change expected: yes, only for buttons configured away from `auto`
+
+## Implementation
+
+- Module/file: `mods/src/patches/parts/mission_hud_tweaks.cc`
+- Config: `[ui.mission_hud]` with `q_trials`, `field_training`, `outposts`, and `missions`
+- Defaults: all four are `auto`; when all remain `auto`, the patch module is skipped and no detour is installed
+- Hook descriptors:
+  - `MissionsHudViewController.OnEnable`
+  - `MissionsHudViewController.HandleOutpostsAndChallengesHUD`
+- Refresh scope: the second hook installs only when Q Trials or Outposts has a non-`auto` override
+- Removed config: `daily_goals` is ignored with a warning because no current HUD component exists to control
+- Registry path: both hooks use `HookDescriptor`, `HookModuleHealth`, and `HOOK_REGISTRY_SPUD_STATIC_DETOUR`
+
+## Runtime Evidence
+
+- Build/deploy mode: Windows release
+- Initial experiment: replacing the missing `UpdateButtons()` detour with `OnEnable()` installed cleanly.
+- Human smoke evidence:
+  - `q_trials = "never"` hid Q Trials.
+  - `q_trials = "auto"` with `outposts = "always"` left all three buttons visible in the observed HUD state.
+- Disable path: all current keys at `auto` leaves native visibility behavior unchanged and skips both hooks.
+- Final enabled-path evidence: the exact dirty-source Windows release cycle resolved and installed both current
+  methods (`installed=2 failed=0 skipped=0 total=2`), and `PatchAudit` reported `MissionHudTweaks` consistent.
+- Retired-key evidence: the same cycle logged that `ui.mission_hud.daily_goals` is unsupported and ignored. After
+  removing that key and returning all four current keys to `auto`, a second clean cycle skipped the module, installed
+  no mission HUD hooks, emitted no Daily Goals warning, and again reported the module consistent.
+- Artifact evidence: the built and deployed release DLLs had matching SHA-256
+  `3336A94265097AC63E588A693ADE0FD9FCFE669D1081287D193E5BF52FA7316E`.
+
+## Exit Decision
+
+Promote the current four-button repair. Retire Daily Goals from the supported schema rather than pretending its
+removed HUD object can still be controlled. The dedicated refresh seam is runtime-observed and has a bounded install
+condition; a later human state-change smoke can raise its behavioral confidence without blocking this repair.

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -775,12 +775,11 @@ auto_confirm_discovery = true
 # Subgroup: Mission HUD
 # ---------------------
 
-# EXPERIMENTAL: Controls mission HUD button visibility. Valid values: "always", "auto", "never"
+# Controls the current mission HUD buttons. Valid values: "always", "auto", "never"
 [ui.mission_hud]
 q_trials = "auto"
 field_training = "auto"
 outposts = "auto"
-daily_goals = "auto"
 missions = "auto"
 
 #  <[===================================================================]>

--- a/manifests/hook_support_tiers.json
+++ b/manifests/hook_support_tiers.json
@@ -56,7 +56,7 @@
       "id": "MissionHudTweaks",
       "tier": "production",
       "source": "mods/src/patches/parts/mission_hud_tweaks.cc",
-      "rationale": "Release-supported UI visibility controls."
+      "rationale": "Release-supported visibility controls for the four current mission HUD buttons, reapplied after controller enablement and outpost/challenge refreshes."
     },
     {
       "id": "OfficerAssignmentSort",

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -739,11 +739,10 @@ struct MissionHudVisibilityConfigSpec {
   std::string_view default_value;
 };
 
-constexpr std::array<MissionHudVisibilityConfigSpec, 5> kMissionHudVisibilityConfigSpecs{{
+constexpr std::array<MissionHudVisibilityConfigSpec, 4> kMissionHudVisibilityConfigSpecs{{
     {"q_trials", DCMH::q_trials},
     {"field_training", DCMH::field_training},
     {"outposts", DCMH::outposts},
-    {"daily_goals", DCMH::daily_goals},
     {"missions", DCMH::missions},
 }};
 
@@ -805,6 +804,20 @@ std::string MissionHudVisibilityValue(toml::table& config, std::string_view item
   spdlog::warn("invalid config value ui.mission_hud.{}; found {}; using auto", item,
                get_config_type_as_string(node->type()));
   return std::string(default_value);
+}
+
+void WarnRemovedMissionHudSettings(toml::table& config)
+{
+  auto* ui_table = config["ui"].as_table();
+  if (!ui_table) {
+    return;
+  }
+
+  auto* mission_hud_table = (*ui_table)["mission_hud"].as_table();
+  if (mission_hud_table && mission_hud_table->contains("daily_goals")) {
+    spdlog::warn("config value ui.mission_hud.daily_goals is no longer supported by the current game and will be "
+                 "ignored");
+  }
 }
 
 toml::table& EnsureUiMissionHudTable(toml::table& config)
@@ -1395,6 +1408,7 @@ void Config::Load()
 
   this->always_skip_reveal_sequence = get_config_or_default(config, parsed, "ui", "always_skip_reveal_sequence",
                                                             DCU::always_skip_reveal_sequence, write_config);
+  WarnRemovedMissionHudSettings(config);
   g_mission_hud_buttons.clear();
   for (const auto& spec : kMissionHudVisibilityConfigSpecs) {
     g_mission_hud_buttons.emplace(std::string(spec.key), GetMissionHudVisibility(config, parsed, spec, write_config));

--- a/mods/src/config_release_validation.cc
+++ b/mods/src/config_release_validation.cc
@@ -119,7 +119,6 @@ namespace
       "ui.extend_chest_purchase_max",
       "ui.extend_donation_max",
       "ui.extend_donation_slider",
-      "ui.mission_hud.daily_goals",
       "ui.mission_hud.field_training",
       "ui.mission_hud.missions",
       "ui.mission_hud.outposts",

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -519,7 +519,6 @@ namespace UI
     constexpr const char* q_trials       = "auto";
     constexpr const char* field_training = "auto";
     constexpr const char* outposts       = "auto";
-    constexpr const char* daily_goals    = "auto";
     constexpr const char* missions       = "auto";
   } // namespace MissionHud
 } // namespace UI

--- a/mods/src/patches/parts/mission_hud_tweaks.cc
+++ b/mods/src/patches/parts/mission_hud_tweaks.cc
@@ -5,9 +5,9 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
-#include <cstdint>
 #include <exception>
 #include <string>
 #include <string_view>
@@ -22,7 +22,6 @@ enum class MissionHudButtonId : std::size_t {
   QTrials,
   FieldTraining,
   Outposts,
-  DailyGoals,
   Missions,
   Count,
 };
@@ -49,15 +48,20 @@ constexpr std::array<MissionHudButtonSpec, kButtonCount> kButtonSpecs{{
     {MissionHudButtonId::QTrials, "q_trials", "_challengesButton"},
     {MissionHudButtonId::FieldTraining, "field_training", "_achievementsButton"},
     {MissionHudButtonId::Outposts, "outposts", "_outpostsButton"},
-    {MissionHudButtonId::DailyGoals, "daily_goals", "_dailyGoalsButton"},
     {MissionHudButtonId::Missions, "missions", "_missionsButton"},
 }};
 
-constexpr HookDescriptor kUpdateButtonsHook{
-    "MissionsHudViewController.UpdateButtons",
-    "Apply configured mission HUD button visibility after the game recalculates buttons.",
-    {"Assembly-CSharp", "Digit.Prime.HUD", "MissionsHudViewController", "UpdateButtons"},
+constexpr HookDescriptor kOnEnableHook{
+    "MissionsHudViewController.OnEnable",
+    "Apply configured mission HUD button visibility after the controller is enabled.",
+    {"Assembly-CSharp", "Digit.Prime.HUD", "MissionsHudViewController", "OnEnable"},
     "Configured mission HUD buttons may remain hidden or visible."};
+
+constexpr HookDescriptor kOutpostsAndChallengesRefreshHook{
+    "MissionsHudViewController.HandleOutpostsAndChallengesHUD",
+    "Reapply configured mission HUD visibility after outpost and challenge state changes.",
+    {"Assembly-CSharp", "Digit.Prime.HUD", "MissionsHudViewController", "HandleOutpostsAndChallengesHUD"},
+    "Configured Q Trials or Outposts visibility may revert after state changes."};
 
 using ComponentGetGameObjectFn = void* (*)(void*);
 using GameObjectSetActiveFn    = void (*)(void*, bool);
@@ -119,6 +123,13 @@ const MissionHudRuntimeConfig& RuntimeConfig()
 {
   static const auto config = ParseRuntimeConfig();
   return config;
+}
+
+bool NeedsOutpostsAndChallengesRefresh()
+{
+  return std::ranges::any_of(RuntimeConfig().buttons, [](const auto& button) {
+    return button.id == MissionHudButtonId::QTrials || button.id == MissionHudButtonId::Outposts;
+  });
 }
 
 const std::array<ptrdiff_t, kButtonCount>& ControllerFieldOffsets()
@@ -229,9 +240,8 @@ void ApplyConfiguredVisibility(MissionsHudViewController* controller)
   }
 }
 
-int32_t MissionsHudViewController_UpdateButtons_Hook(auto original, MissionsHudViewController* controller)
+void ApplyConfiguredVisibilitySafely(MissionsHudViewController* controller)
 {
-  const auto result = original(controller);
   try {
     ApplyConfiguredVisibility(controller);
   } catch (const std::exception& exception) {
@@ -239,7 +249,18 @@ int32_t MissionsHudViewController_UpdateButtons_Hook(auto original, MissionsHudV
   } catch (...) {
     spdlog::warn("[MissionHudTweaks] failed applying visibility");
   }
-  return result;
+}
+
+void MissionsHudViewController_OnEnable_Hook(auto original, MissionsHudViewController* controller)
+{
+  original(controller);
+  ApplyConfiguredVisibilitySafely(controller);
+}
+
+void MissionsHudViewController_HandleOutpostsAndChallengesHUD_Hook(auto original, MissionsHudViewController* controller)
+{
+  original(controller);
+  ApplyConfiguredVisibilitySafely(controller);
 }
 } // namespace
 
@@ -248,20 +269,31 @@ void InstallMissionHudTweaksHooks()
   HookModuleHealth hooks("MissionHudTweaks");
 
   if (RuntimeConfig().buttons.empty()) {
-    hooks.record_skipped(kUpdateButtonsHook, "no mission HUD button visibility overrides configured");
+    hooks.record_skipped(kOnEnableHook, "no mission HUD button visibility overrides configured");
+    hooks.record_skipped(kOutpostsAndChallengesRefreshHook, "no mission HUD button visibility overrides configured");
     hooks.log_summary();
     return;
   }
 
   auto& helper = MissionsHudClassHelper();
   if (!helper.isValidHelper()) {
-    hooks.record_missing_helper(kUpdateButtonsHook);
-  } else if (auto update_buttons = helper.GetMethod("UpdateButtons", 0); update_buttons == nullptr) {
-    hooks.record_missing_method(kUpdateButtonsHook);
+    hooks.record_missing_helper(kOnEnableHook);
+  } else if (auto on_enable = helper.GetMethod("OnEnable", 0); on_enable == nullptr) {
+    hooks.record_missing_method(kOnEnableHook);
   } else {
     (void)ControllerFieldOffsets();
-    HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kUpdateButtonsHook, update_buttons,
-                                     MissionsHudViewController_UpdateButtons_Hook);
+    HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kOnEnableHook, on_enable, MissionsHudViewController_OnEnable_Hook);
+  }
+
+  if (!NeedsOutpostsAndChallengesRefresh()) {
+    hooks.record_skipped(kOutpostsAndChallengesRefreshHook, "Q Trials and Outposts use native visibility");
+  } else if (!helper.isValidHelper()) {
+    hooks.record_missing_helper(kOutpostsAndChallengesRefreshHook);
+  } else if (auto refresh = helper.GetMethod("HandleOutpostsAndChallengesHUD", 0); refresh == nullptr) {
+    hooks.record_missing_method(kOutpostsAndChallengesRefreshHook);
+  } else {
+    HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kOutpostsAndChallengesRefreshHook, refresh,
+                                     MissionsHudViewController_HandleOutpostsAndChallengesHUD_Hook);
   }
 
   hooks.log_summary();


### PR DESCRIPTION
## What changed

- replace the removed `MissionsHudViewController.UpdateButtons()` hook with the current `OnEnable()` lifecycle seam
- reapply Q Trials and Outposts overrides after `HandleOutpostsAndChallengesHUD()` refreshes
- retain `always` / `auto` / `never` support for Q Trials, Field Training, Outposts, and Missions
- retire the removed Daily Goals HUD target from defaults, release validation, and the example config; legacy values are ignored with an explicit warning
- document the current IL2CPP field/method dependency set and runtime evidence

## Why

The current game removed both `_dailyGoalsButton` and `UpdateButtons()`, so the old hook no longer installed and none of the mission HUD visibility settings took effect. The replacement uses the current controller lifecycle and its narrower outpost/challenge refresh method while leaving native behavior untouched when all four supported settings are `auto`.

## Validation

- AXF blocking review contract: hook-tier validation, gameplay-seam scanner, diff checks, and pure tests
- 326 test cases / 4,472 assertions passed
- Windows release build passed
- enabled-path release cycle: both hooks installed, `installed=2 failed=0`, PatchAudit consistent
- human smoke: `q_trials = "never"` hid Q Trials; `outposts = "always"` restored the visible button state
- retired-key cycle: `daily_goals` emitted the expected ignored-key warning
- final all-`auto` cycle: MissionHudTweaks skipped cleanly and PatchAudit remained consistent
