### PR TITLE
Finish Windows launcher delivery and typed multi-target Sync setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,10 +146,19 @@ jobs:
           ./windows-launcher/scripts/publish.ps1 `
             -OutputDirectory "${{ runner.temp }}/stfc-community-mod-launcher"
 
-      - name: Upload launcher spike artifact
+      - name: Upload launcher installer artifact
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ startsWith(github.ref, 'refs/tags/v') && 'stfc-community-mod-launcher-win-x64-unsigned' || 'stfc-community-mod-launcher-win-x64' }}
+          name: stfc-community-mod-launcher-setup-win-x64
+          path: ${{ runner.temp }}/stfc-community-mod-launcher/setup/STFCCommunityMod.Launcher.Setup.exe
+          if-no-files-found: error
+
+      - name: Upload unsigned launcher release bundle
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v7
+        with:
+          name: stfc-community-mod-launcher-win-x64-unsigned
           path: ${{ runner.temp }}/stfc-community-mod-launcher
           if-no-files-found: error
 
@@ -355,6 +364,13 @@ jobs:
         with:
           name: stfc-community-mod-launcher-win-x64
           path: ${{ runner.temp }}/stfc-community-mod-launcher
+          if-no-files-found: error
+
+      - name: Upload signed Windows launcher installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: stfc-community-mod-launcher-setup-win-x64
+          path: ${{ runner.temp }}/stfc-community-mod-launcher/setup/STFCCommunityMod.Launcher.Setup.exe
           if-no-files-found: error
 
   build-mac:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,13 +87,13 @@ jobs:
           cp stfc-community-mod/version.dll version.dll
           cp stfc-community-mod.zip stfc-community-mod-${{ github.ref_name }}.zip
           test -f stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip
-          test -f stfc-community-mod-launcher-win-x64/setup/STFCCommunityMod.Launcher.Setup.exe
+          test -f stfc-community-mod-launcher-setup-win-x64/STFCCommunityMod.Launcher.Setup.exe
           sha256sum version.dll \
             stfc-community-mod.zip \
             stfc-community-mod-${{ github.ref_name }}.zip \
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \
             stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip \
-            stfc-community-mod-launcher-win-x64/setup/STFCCommunityMod.Launcher.Setup.exe \
+            stfc-community-mod-launcher-setup-win-x64/STFCCommunityMod.Launcher.Setup.exe \
             stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst \
             stfc-community-mod-installer/stfc-community-mod-installer.dmg > SHA256SUMS.txt
 
@@ -175,7 +175,7 @@ jobs:
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst.sha256 \
             stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip \
-            stfc-community-mod-launcher-win-x64/setup/STFCCommunityMod.Launcher.Setup.exe \
+            stfc-community-mod-launcher-setup-win-x64/STFCCommunityMod.Launcher.Setup.exe \
             stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst \
             stfc-community-mod-macos-universal/stfc-community-mod-macos-universal.tar.zst.sha256 \
             stfc-community-mod-installer/stfc-community-mod-installer.dmg \

--- a/docs/windows-launcher/LAUNCH_HANDOFF.md
+++ b/docs/windows-launcher/LAUNCH_HANDOFF.md
@@ -10,8 +10,10 @@ base-game update, repair, and first-time sign-in remain owned by that launcher.
 The community launcher does not reproduce the Xsolla protocol and does not
 start `prime.exe` directly.
 
-The action is explicitly a modded launch. A launcher-managed `version.dll`
-must exist and still match its persisted SHA-256 identity. An unmodded mode is
+The action is explicitly a modded launch. An existing manual `version.dll` is
+eligible without first being adopted into launcher ownership. Adoption remains
+an explicit mod-management action. A missing mod or a launcher-managed install
+whose recorded bytes no longer match still blocks launch. An unmodded mode is
 represented as a distinct blocked state; v1 does not claim it because safely
 disabling and restoring the proxy across an official-launcher handoff has not
 been accepted.

--- a/docs/windows-launcher/LEXRUNNER_SYNC_SETUP_PLAN.json
+++ b/docs/windows-launcher/LEXRUNNER_SYNC_SETUP_PLAN.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": "1.0.0",
+  "campaign": {
+    "id": "launcher-sync-setup",
+    "repository": "Guffawaffle/stfc-mod",
+    "epicIssue": 221,
+    "milestone": "Windows Launcher: Sync Setup",
+    "label": "campaign:launcher-sync",
+    "portableDistribution": "deferred"
+  },
+  "target": "agent/launcher-artifact-surface",
+  "policy": {
+    "requiredGates": [
+      "diff-check",
+      "dotnet-test"
+    ],
+    "optionalGates": [
+      "schema-tests",
+      "schema-current",
+      "release-manifest-tests",
+      "wpf-build",
+      "windows-proxy-build",
+      "package",
+      "packaged-ui-smoke"
+    ],
+    "maxWorkers": 2,
+    "blockOn": [
+      "fail",
+      "blocked"
+    ],
+    "mergeRule": {
+      "type": "strict-required",
+      "strategy": "merge-weave"
+    }
+  },
+  "items": [
+    {
+      "name": "LS-001-delivery-polish",
+      "issue": 222,
+      "deps": [],
+      "gates": [
+        {
+          "name": "release-manifest-tests",
+          "run": "py -m unittest tests.test_generate_release_manifest -v"
+        },
+        {
+          "name": "dotnet-test",
+          "run": "dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release"
+        },
+        {
+          "name": "package",
+          "run": "powershell -NoProfile -ExecutionPolicy Bypass -File windows-launcher/scripts/publish.ps1"
+        },
+        {
+          "name": "diff-check",
+          "run": "git diff --check"
+        }
+      ]
+    },
+    {
+      "name": "LS-002-sync-contract-corpus",
+      "issue": 223,
+      "deps": [
+        "LS-001-delivery-polish"
+      ],
+      "gates": [
+        {
+          "name": "schema-tests",
+          "run": "node --test scripts/test_config_schema.mjs"
+        },
+        {
+          "name": "schema-current",
+          "run": "node scripts/generate_config_schema.mjs --check"
+        },
+        {
+          "name": "dotnet-test",
+          "run": "dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release"
+        },
+        {
+          "name": "windows-proxy-build",
+          "run": "xmake f -p windows -m release -y && xmake -y stfc-community-mod"
+        },
+        {
+          "name": "diff-check",
+          "run": "git diff --check"
+        }
+      ]
+    },
+    {
+      "name": "LS-003-topology-domain",
+      "issue": 224,
+      "deps": [
+        "LS-002-sync-contract-corpus"
+      ],
+      "gates": [
+        {
+          "name": "dotnet-test",
+          "run": "dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release"
+        },
+        {
+          "name": "wpf-build",
+          "run": "dotnet build windows-launcher/src/STFCCommunityMod.Launcher/STFCCommunityMod.Launcher.csproj -c Release"
+        },
+        {
+          "name": "diff-check",
+          "run": "git diff --check"
+        }
+      ]
+    },
+    {
+      "name": "LS-004-topology-persistence",
+      "issue": 225,
+      "deps": [
+        "LS-002-sync-contract-corpus",
+        "LS-003-topology-domain"
+      ],
+      "gates": [
+        {
+          "name": "dotnet-test",
+          "run": "dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release"
+        },
+        {
+          "name": "schema-tests",
+          "run": "node --test scripts/test_config_schema.mjs"
+        },
+        {
+          "name": "diff-check",
+          "run": "git diff --check"
+        }
+      ]
+    },
+    {
+      "name": "LS-005-sync-workspace-acceptance",
+      "issue": 226,
+      "deps": [
+        "LS-001-delivery-polish",
+        "LS-003-topology-domain",
+        "LS-004-topology-persistence"
+      ],
+      "gates": [
+        {
+          "name": "schema-tests",
+          "run": "node --test scripts/test_config_schema.mjs"
+        },
+        {
+          "name": "schema-current",
+          "run": "node scripts/generate_config_schema.mjs --check"
+        },
+        {
+          "name": "release-manifest-tests",
+          "run": "py -m unittest tests.test_generate_release_manifest -v"
+        },
+        {
+          "name": "dotnet-test",
+          "run": "dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release"
+        },
+        {
+          "name": "wpf-build",
+          "run": "dotnet build windows-launcher/src/STFCCommunityMod.Launcher/STFCCommunityMod.Launcher.csproj -c Release"
+        },
+        {
+          "name": "windows-proxy-build",
+          "run": "xmake f -p windows -m release -y && xmake -y stfc-community-mod"
+        },
+        {
+          "name": "package",
+          "run": "powershell -NoProfile -ExecutionPolicy Bypass -File windows-launcher/scripts/publish.ps1"
+        },
+        {
+          "name": "packaged-ui-smoke",
+          "run": "powershell -NoProfile -ExecutionPolicy Bypass -File windows-launcher/scripts/smoke-settings.ps1 -LauncherPath windows-launcher/artifacts/win-x64/app/STFCCommunityMod.Launcher.exe"
+        },
+        {
+          "name": "diff-check",
+          "run": "git diff --check"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/windows-launcher/RELEASE_MANIFEST.md
+++ b/docs/windows-launcher/RELEASE_MANIFEST.md
@@ -92,7 +92,7 @@ Each artifact has a stable `id` and a semantic `kind`. Schema v1 publishes:
 |---|---|---|
 | `windows-mod-dll-x64` | `windows-mod` | Direct signed `version.dll` used by the transactional installer and retained for manual installation. |
 | `windows-mod-archive-x64` | `windows-mod-archive` | Existing Windows archive containing the signed mod DLL. |
-| `windows-launcher-archive-x64` | `windows-launcher` | Self-contained launcher archive containing the signed launcher and replace-on-exit helper executables. |
+| `windows-launcher-archive-x64` | `windows-launcher` | Machine-consumed self-update archive containing the signed launcher and replace-on-exit helper executables; this is not an install artifact. |
 | `windows-launcher-setup-x64` | `windows-launcher-setup` | User-facing signed single executable that embeds, installs, and starts the signed launcher archive. |
 
 Future independently installed components receive distinct IDs and kinds.

--- a/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
+++ b/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
@@ -77,7 +77,8 @@ Majel-only capability and fleet-assignment snapshots are transport behavior and 
 
 Inheritance is field-scoped, not table-scoped. For each resolved field the launcher records one of:
 
-- `inherited`: the target omitted an inheritable field and uses `[sync]`.
+- `inherited`: the target omitted the field. External targets resolve it from `[sync]`; non-inheriting target kinds
+  resolve it from their own safe type default. Resolved values retain that source distinction.
 - `explicit_value`: the target supplied a value, including `true` and non-empty strings.
 - `explicit_false`: the target explicitly supplied boolean `false`; it overrides global `true`.
 - `explicit_empty`: the target explicitly supplied an empty string where empty is meaningful; it overrides a non-empty

--- a/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
+++ b/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
@@ -1,0 +1,155 @@
+# Windows Launcher Sync Target Contract
+
+Status: locked for the `Windows Launcher: Sync Setup` campaign
+
+Contract artifact: `sync-target-contract.guffawaffle.v1.json`
+
+Compatibility corpus: `sync-target-corpus/cases.json`
+
+## Purpose
+
+This contract fixes the vocabulary and resolution rules shared by the native mod and Windows launcher before the
+launcher grows a multi-target editor. It separates what the user wrote from what the runtime can use, and prevents the
+UI, persistence layer, and native parser from independently inventing sync semantics.
+
+This slice is descriptive and executable evidence. It does not add target editing, migration writes, or new native
+transport behavior.
+
+## Topology
+
+The launcher owns two related views:
+
+- **Desired topology** is a source-faithful projection of the TOML. It includes global defaults, the fixed local
+  sidecar slot, named external targets, explicit values, and invalid or unsupported entries with diagnostics.
+- **Resolved topology** contains only runnable targets after validation, inheritance, safety policy, and legacy
+  compatibility have been applied. It records the source provenance of every effective value.
+
+Loading configuration never changes the desired topology or the TOML. A resolved target synthesized from legacy
+`[sync].url` and `[sync].token` is compatibility state, not permission to rewrite the source.
+
+## Target kinds and presets
+
+| Kind | Persistence | Cardinality | Wire contract | Notes |
+|---|---|---:|---|---|
+| Local Sidecar | `[sidecar.sync]` | Zero or one | Local sidecar ingest | Fixed launcher identity; not an external target and never receives external network policy by inheritance. |
+| Legacy/community | `[sync.targets.<name>]` | Zero or more | Legacy STFC sync JSON | `mode` absent, empty, or `legacy`. Spocks Club presets use this kind. |
+| Majel ingest | `[sync.targets.<name>]` | Zero or more | `majel.ingest.v1` envelopes | `mode = "majel"`; one-way event ingest only. |
+
+Provider names are presets, not protocol types:
+
+- **Spocks Club** creates a legacy/community target with the suggested identity `spocksclub`.
+- **Next Spocks Club** creates a legacy/community target with the suggested identity `nextspocksclub`.
+- **Custom legacy/community** and **Custom Majel** use the same concrete kinds without provider branding.
+
+The local sidecar appears as a target card in the launcher, but persists to the singleton `[sidecar.sync]` table. It is
+not represented as `[sync.targets.sidecar]`.
+
+## Field and capability matrix
+
+`I` means the external target may inherit the global value when absent. `E` means the setting is explicit on that
+target kind. `F` means forbidden. A dash means the field is not part of that target kind.
+
+| Field/capability | Global `[sync]` | Local Sidecar | Legacy/community | Majel ingest |
+|---|---:|---:|---:|---:|
+| Target identity | - | Fixed | E | E |
+| Enabled state | - | E | Launcher desired state | Launcher desired state |
+| URL | Compatibility only | E | E | E |
+| Token | Compatibility only | E | E | E |
+| Mode | - | - | E (`legacy`) | E (`majel`) |
+| Proxy | Default | E, never inherited | I | I |
+| Verify TLS | Default | E, never inherited | I | I |
+| Unsafe TLS opt-in | Default | E, never inherited | I | I |
+| Standard sync categories | Defaults | - | I | I, transport-filtered |
+| Realtime battle logs | Default | E, never inherited | I | I |
+| Fleet runtime | Not routable externally | E, never inherited | F | F |
+| Battle-log enrichment | - | E, never inherited | - | - |
+| Fleet runtime mode | - | E, never inherited | - | - |
+
+External `enabled` is launcher desired-state metadata until the native config grows a canonical persisted field. The
+launcher must not invent an unrecognized TOML key. In the initial editor, disabling an existing external target is a
+pending edit that requires an explicitly selected supported persistence strategy; merely viewing or loading it does
+nothing.
+
+Majel targets use the same category inputs as legacy targets, followed by the native transport capability filter.
+Majel-only capability and fleet-assignment snapshots are transport behavior and are not new inherited user fields.
+
+## Inheritance and provenance
+
+Inheritance is field-scoped, not table-scoped. For each resolved field the launcher records one of:
+
+- `inherited`: the target omitted an inheritable field and uses `[sync]`.
+- `explicit_value`: the target supplied a value, including `true` and non-empty strings.
+- `explicit_false`: the target explicitly supplied boolean `false`; it overrides global `true`.
+- `explicit_empty`: the target explicitly supplied an empty string where empty is meaningful; it overrides a non-empty
+  global value. This is permitted for `proxy` and means no proxy.
+
+URL, token, target identity, enabled state, mode, and type-only settings never inherit. An absent required URL or token
+is not equivalent to an inherited credential. Secrets must not flow between targets.
+
+The local sidecar never inherits external proxy, TLS, unsafe-TLS, or category defaults. Its values come only from
+`[sidecar.sync]` and native sidecar defaults. This prevents an internet proxy or relaxed external TLS policy from being
+silently applied to loopback ingest.
+
+## Validation and compatibility rules
+
+Resolution uses these stable outcomes:
+
+- `error`: target is retained in desired topology but excluded from resolved topology.
+- `warning`: target may resolve, but a field is ignored, normalized, or deprecated.
+- `info`: compatibility behavior was applied without changing the source.
+
+Rules:
+
+1. An external target requires string `url` and string `token` assignments. Missing or invalid credentials produce an
+   error and the target is not runnable. Empty credentials are displayed as incomplete and are never inherited.
+2. External loopback sidecar ingest URLs, `[sync.targets.sidecar]`, and `mode = "sidecar_broker"` are errors. The
+   corrective destination is `[sidecar.sync]`.
+3. External `fleet_runtime = true` produces a warning and resolves to false. Fleet runtime is sidecar-only.
+4. Unknown target modes warn and resolve as legacy for native compatibility. The launcher must not silently rewrite the
+   unknown source value; an explicit user correction is required.
+5. When both non-empty legacy `[sync].url` and `[sync].token` are present and the URL is not a rejected loopback sidecar
+   endpoint, resolved topology synthesizes a legacy/community target named `default`. The source remains untouched.
+6. One missing legacy root credential produces a warning and no synthesized target.
+7. If both a named `sync.targets.default` and legacy root credentials exist, the named target wins and the failed
+   conversion is diagnosed.
+8. Unknown keys, comments, ordering, line endings, and supported formatting survive all unrelated edits.
+
+## Migration and mutation policy
+
+- Reads, validation, preview, target selection, and resolved-value display are non-mutating.
+- Existing valid TOML is never normalized merely because the launcher opened it.
+- Legacy root conversion is virtual until the user requests migration, reviews a source diff, and confirms one atomic
+  write.
+- Invalid and unsupported entries remain in the source unless the user explicitly edits or removes them.
+- Sparse writes touch only the selected assignment or target block and preserve unknown content.
+- A stale revision, duplicate table, unsupported TOML construct, failed backup, or failed verification aborts the
+  entire write.
+- Presets create a desired draft. They do not send traffic or persist credentials before confirmation.
+
+## Security and secret display
+
+- Tokens are secrets. List and summary views show only configured/missing state, never token contents.
+- A detail editor may reveal a token only through a deliberate transient action; it must not place the value in logs,
+  diagnostics, telemetry, error text, screenshots generated by automation, or campaign fixtures.
+- Proxy user information is masked in summaries and logs.
+- Copying or exporting diagnostics always redacts tokens and proxy credentials.
+- `verify_ssl = false` is effective only with the explicit unsafe-TLS opt-in accepted by native policy. The launcher
+  presents this as a high-risk pair, not as an ordinary convenience toggle.
+- Sidecar loopback credentials remain secret even though the endpoint is local.
+- Presets contain no real URLs or credentials unless the provider contract publishes a stable public endpoint.
+
+## Corpus authority
+
+`sync-target-corpus/cases.json` enumerates the compatibility cases required by issue #223. Each TOML fixture is valid,
+source-preserving input. Its expected target kinds, provenance states, and diagnostic codes are declarative inputs for
+the LS-003 domain resolver and LS-004 persistence tests.
+
+The LS-002 test suite currently enforces:
+
+- every required case and fixture exists;
+- every fixture is readable by the launcher's conservative TOML surface without byte mutation;
+- declared paths exist exactly as written;
+- diagnostic identifiers and provenance states come from the locked machine contract;
+- security, non-inheritance, and sidecar-only invariants cannot drift unnoticed.
+
+Later slices must consume this corpus rather than copying the examples into new private test data.

--- a/docs/windows-launcher/SYNC_TARGET_PERSISTENCE.md
+++ b/docs/windows-launcher/SYNC_TARGET_PERSISTENCE.md
@@ -1,0 +1,74 @@
+# Windows Launcher Sync Target Persistence
+
+This document records the LS-004 persistence boundary for the launcher sync campaign. The implementation maps the
+dependency-free desired topology to sparse TOML operations and delegates the only filesystem replacement to the
+existing `AtomicTomlStore`.
+
+## Pipeline
+
+1. `SyncTopologyTomlAdapter` reads conservative TOML assignments into the desired domain without modifying bytes.
+2. `SyncTopologyPersistencePlanner` compares the baseline and desired topology and produces bounded semantic
+   mutations. Mutation display text contains paths and secret-state markers, never rendered token values.
+3. `SyncTopologyPersistencePlan.Apply` re-loads the sparse document before every mutation and fails closed on the first
+   unsupported or conflicting construct.
+4. `SyncTopologyPersistenceWorkspace` submits the transformed bytes and exact baseline bytes to `AtomicTomlStore`.
+5. The atomic store rechecks the destination, writes durably to a sibling temporary file, creates a backup, and replaces
+   the destination. A stale or disappearing destination is a conflict and preserves the external file.
+
+No sync change bypasses this boundary or writes one field at a time to the live file.
+
+## Mapping
+
+- Global values persist under `[sync]`.
+- External targets persist under `[sync.targets.<name>]` and newly added or kind-changed targets receive explicit
+  `mode = "legacy"` or `mode = "majel"`.
+- Local Sidecar persists only under `[sidecar.sync]`.
+- An inherited target override removes the target-local assignment.
+- Explicit false and explicit empty proxy remain assignments.
+- Unchanged tokens produce no mutation. Replacement and clearing are secret-bearing internal mutations whose display
+  form is redacted.
+- External targets cannot be persisted as disabled because the native schema has no canonical enabled field. The user
+  must keep the target enabled or remove it.
+
+## Structural operations
+
+The sparse editor supports whole-table removal and rename for bare-key tables. Rename includes descendant tables and
+preserves body bytes, comments, whitespace, line endings, BOM, ordering, and unknown fields. Removal deletes the owned
+table and its descendants while retaining unrelated tables.
+
+Both operations reject:
+
+- a destination table or dotted-assignment collision;
+- a source represented only through dotted assignments;
+- duplicate tables or malformed source documents;
+- unsupported quoted table paths and array-of-table syntax.
+
+Declared target tables are inventoried independently of their assignments. An empty target table is therefore surfaced
+as an invalid, incomplete target instead of disappearing from the launcher model.
+
+## Kind changes and migration
+
+Changing an external target kind requires one explicit policy:
+
+- `PreserveCompatibleOverrides` keeps compatible target-local overrides.
+- `ResetOverrides` requires the desired target to have no explicit overrides and persists their removal.
+
+Legacy root `[sync].url` and `[sync].token` load as a virtual `default` target. An unchanged virtual target never rewrites
+the source. Editing or renaming it is blocked until migration is explicitly confirmed; confirmed migration clears the
+legacy root credentials and creates `[sync.targets.default]` atomically.
+
+## Security and display
+
+- `SyncSecret`, `SyncOverride<T>`, `SyncResolvedValue<T>`, and `SyncResolvedTarget` have redacted display forms.
+- Resolved summaries expose only whether credentials are configured.
+- Proxy values remain available to the editor but are absent from domain and plan `ToString()` output.
+- Endpoint URLs containing embedded user information are rejected; credentials belong in the opaque token field.
+- Invalid-value diagnostics name the canonical path and line, never the rendered value.
+- Mutation factories accepting rendered values are assembly-internal.
+
+## Workspace behavior
+
+Staging changes does not touch disk or the startup runtime snapshot, and a semantic no-op does not create pending work.
+Discard restores the baseline topology. Successful commit advances the baseline only after atomic replacement. Conflict
+leaves the desired draft pending, marks the workspace stale, and preserves the external file without creating a backup;
+staging or discarding cannot falsely clear that stale state.

--- a/docs/windows-launcher/SYNC_WORKSPACE.md
+++ b/docs/windows-launcher/SYNC_WORKSPACE.md
@@ -1,0 +1,57 @@
+# Windows Launcher Sync Workspace
+
+This document records the LS-005 player surface and dogfood boundary for typed multi-target sync setup.
+
+## Player model
+
+The existing **Data Sync** settings destination now opens a dedicated workspace. It deliberately separates:
+
+- global proxy, TLS, and feed defaults;
+- concrete target instances and their wire contracts;
+- target-local inherited, explicit-on/value, explicit-off, and explicit-clear states;
+- Sidecar-only controls from external provider controls.
+
+The add surface supports the singleton local Sidecar, Majel, the Spocks Club preset, and custom community/legacy
+instances. External targets are enabled while present because the native contract has no canonical disabled field;
+removal is the explicit disable operation. Sidecar retains its native enabled switch.
+
+Each target card shows its stable identity, player-facing type, wire contract, validation state, effective enabled feeds,
+endpoint, opaque token state, proxy provenance, TLS overrides, and supported feed overrides. Sidecar cards additionally
+show battle-log enrichment and fleet-runtime mode. Unsupported controls are not rendered.
+
+## Secret intent
+
+Saved tokens are never placed in a text property or displayed. The password control begins empty and reports only
+whether a saved token exists. Typing alone does not alter the desired topology; **Replace** explicitly adopts the new
+secret, while **Clear** explicitly removes it. Persistence plan display remains redacted.
+
+## Document coordination
+
+Typed sync and ordinary settings use the same selected TOML and atomic store but keep separate typed edit sessions.
+Only one session may save while the other owns a pending draft. A successful save refreshes the sibling baseline,
+preventing two optimistic revisions from racing. Open and navigation never write the document, and successful sync save
+does not mutate the startup runtime snapshot; restart is required.
+
+Legacy root `sync.url` / `sync.token` loads as a virtual default target. Editing it remains blocked until the player
+checks the explicit migration confirmation, after which the move into `sync.targets.default` occurs in the same atomic
+save.
+
+## Accessibility and scale
+
+- Navigation, add actions, global controls, target actions, secret intent, override selectors, Save, and Discard have
+  keyboard-focusable native controls and automation names/help.
+- The target collection uses a recycling `VirtualizingStackPanel`.
+- Long identities use trimming while their containing target card retains the complete automation name.
+- Validation and operation status use polite live regions.
+- Layout uses the launcher's dynamic theme brushes and scales with WPF DPI behavior.
+
+## Automated evidence
+
+- View-model tests cover byte-preserving open, mixed typed targets, Sidecar cardinality, inherited/effective feed state,
+  secret replacement intent, proxy/TLS tri-state overrides, Sidecar-only controls, legacy migration confirmation,
+  cross-workspace save exclusion, and atomic save/reload.
+- Packaged UI Automation enters Data Sync, finds the typed workspace, global defaults, and virtualized target collection,
+  then verifies both the active manual TOML and an isolated mixed-target fixture remain unchanged. The fixture run restores
+  the real launcher selection byte-for-byte in `finally`.
+- Packaging asserts the public setup directory contains exactly one `STFCCommunityMod.Launcher.Setup.exe`; the internal
+  ZIP remains only the embedded installer/self-update payload, not a second public install artifact.

--- a/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
+++ b/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": "1.0.0",
+  "provenanceStates": [
+    "inherited",
+    "explicit_value",
+    "explicit_false",
+    "explicit_empty"
+  ],
+  "diagnosticSeverities": [
+    "info",
+    "warning",
+    "error"
+  ],
+  "targetKinds": {
+    "local_sidecar": {
+      "persistencePattern": "sidecar.sync",
+      "cardinality": "zero_or_one",
+      "wireContract": "sidecar_local_ingest",
+      "inheritsGlobalSync": false
+    },
+    "legacy_community": {
+      "persistencePattern": "sync.targets.*",
+      "cardinality": "zero_or_more",
+      "wireContract": "legacy_sync_json",
+      "inheritsGlobalSync": true
+    },
+    "majel_ingest": {
+      "persistencePattern": "sync.targets.*",
+      "cardinality": "zero_or_more",
+      "wireContract": "majel.ingest.v1",
+      "inheritsGlobalSync": true
+    }
+  },
+  "presets": {
+    "spocks_club": {
+      "targetKind": "legacy_community",
+      "suggestedIdentity": "spocksclub"
+    },
+    "next_spocks_club": {
+      "targetKind": "legacy_community",
+      "suggestedIdentity": "nextspocksclub"
+    }
+  },
+  "fields": {
+    "identity": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "enabled": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "url": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "token": {
+      "inheritance": "never",
+      "secret": true,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "mode": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["legacy_community", "majel_ingest"]
+    },
+    "proxy": {
+      "inheritance": "external_only",
+      "allowsExplicitEmpty": true,
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "verify_ssl": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "allow_unsafe_tls_without_certificate_validation": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "sync_categories": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["legacy_community", "majel_ingest"]
+    },
+    "battlelogs_realtime": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "fleet_runtime": {
+      "inheritance": "never",
+      "secret": false,
+      "sidecarOnly": true,
+      "kinds": ["local_sidecar"]
+    },
+    "battlelog_enrichment": {
+      "inheritance": "never",
+      "secret": false,
+      "sidecarOnly": true,
+      "kinds": ["local_sidecar"]
+    },
+    "fleet_runtime_mode": {
+      "inheritance": "never",
+      "secret": false,
+      "sidecarOnly": true,
+      "kinds": ["local_sidecar"]
+    }
+  },
+  "diagnostics": {
+    "SYNC_CREDENTIALS_INCOMPLETE": "error",
+    "SYNC_EXTERNAL_FLEET_RUNTIME_UNSUPPORTED": "warning",
+    "SYNC_LEGACY_ROOT_CONVERTED": "info",
+    "SYNC_LEGACY_ROOT_INCOMPLETE": "warning",
+    "SYNC_LOOPBACK_TARGET_INVALID": "error",
+    "SYNC_TARGET_MODE_INVALID": "warning",
+    "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID": "error",
+    "SYNC_UNKNOWN_KEY_PRESERVED": "warning"
+  },
+  "mutationPolicy": {
+    "load": "never",
+    "resolve": "never",
+    "legacyConversion": "preview_then_explicit_atomic_write",
+    "preserveUnknownKeys": true,
+    "preserveComments": true,
+    "preserveOrdering": true
+  },
+  "security": {
+    "redactFields": ["token"],
+    "maskProxyUserInfo": true,
+    "unsafeTlsRequiresExplicitPair": true,
+    "sidecarInheritsExternalNetworkPolicy": false
+  }
+}

--- a/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
+++ b/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
@@ -6,6 +6,11 @@
     "explicit_false",
     "explicit_empty"
   ],
+  "resolutionSources": [
+    "global_default",
+    "target_type_default",
+    "target"
+  ],
   "diagnosticSeverities": [
     "info",
     "warning",

--- a/docs/windows-launcher/sync-target-corpus/canonical-local-sidecar.toml
+++ b/docs/windows-launcher/sync-target-corpus/canonical-local-sidecar.toml
@@ -1,0 +1,15 @@
+[sync]
+proxy = "http://external-proxy.example.invalid:8080"
+verify_ssl = false
+
+[sidecar.sync]
+enabled = true
+url = "http://127.0.0.1:43127/api/sidecar/ingest"
+token = "fixture-redacted-sidecar"
+proxy = ""
+verify_ssl = true
+allow_unsafe_tls_without_certificate_validation = false
+battlelogs_realtime = true
+battlelog_enrichment = true
+fleet_runtime = true
+fleet_runtime_mode = "normal"

--- a/docs/windows-launcher/sync-target-corpus/cases.json
+++ b/docs/windows-launcher/sync-target-corpus/cases.json
@@ -1,0 +1,205 @@
+{
+  "schemaVersion": "1.0.0",
+  "contract": "../sync-target-contract.guffawaffle.v1.json",
+  "cases": [
+    {
+      "id": "global-only-defaults",
+      "file": "global-only-defaults.toml",
+      "expectedTargetKinds": [],
+      "expectedPaths": [
+        "sync.allow_unsafe_tls_without_certificate_validation",
+        "sync.battlelogs",
+        "sync.jobs",
+        "sync.proxy",
+        "sync.verify_ssl"
+      ],
+      "provenance": {},
+      "diagnostics": []
+    },
+    {
+      "id": "legacy-spocks-presets",
+      "file": "legacy-spocks-presets.toml",
+      "expectedTargetKinds": ["legacy_community", "legacy_community"],
+      "expectedPaths": [
+        "sync.battlelogs",
+        "sync.targets.nextspocksclub.mode",
+        "sync.targets.nextspocksclub.token",
+        "sync.targets.nextspocksclub.url",
+        "sync.targets.spocksclub.mode",
+        "sync.targets.spocksclub.token",
+        "sync.targets.spocksclub.url"
+      ],
+      "provenance": {
+        "nextspocksclub.battlelogs": "inherited",
+        "nextspocksclub.mode": "explicit_value",
+        "spocksclub.battlelogs": "inherited",
+        "spocksclub.mode": "explicit_value"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "majel-realtime",
+      "file": "majel-realtime.toml",
+      "expectedTargetKinds": ["majel_ingest"],
+      "expectedPaths": [
+        "sync.battlelogs_realtime",
+        "sync.targets.majel.battlelogs",
+        "sync.targets.majel.mode",
+        "sync.targets.majel.token",
+        "sync.targets.majel.url"
+      ],
+      "provenance": {
+        "majel.battlelogs": "explicit_false",
+        "majel.battlelogs_realtime": "inherited",
+        "majel.mode": "explicit_value"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "canonical-local-sidecar",
+      "file": "canonical-local-sidecar.toml",
+      "expectedTargetKinds": ["local_sidecar"],
+      "expectedPaths": [
+        "sidecar.sync.allow_unsafe_tls_without_certificate_validation",
+        "sidecar.sync.battlelog_enrichment",
+        "sidecar.sync.battlelogs_realtime",
+        "sidecar.sync.enabled",
+        "sidecar.sync.fleet_runtime",
+        "sidecar.sync.fleet_runtime_mode",
+        "sidecar.sync.proxy",
+        "sidecar.sync.token",
+        "sidecar.sync.url",
+        "sidecar.sync.verify_ssl",
+        "sync.proxy",
+        "sync.verify_ssl"
+      ],
+      "provenance": {
+        "local_sidecar.proxy": "explicit_empty",
+        "local_sidecar.verify_ssl": "explicit_value"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "mixed-multiple-targets",
+      "file": "mixed-multiple-targets.toml",
+      "expectedTargetKinds": ["local_sidecar", "legacy_community", "majel_ingest"],
+      "expectedPaths": [
+        "sidecar.sync.battlelogs_realtime",
+        "sidecar.sync.enabled",
+        "sidecar.sync.token",
+        "sidecar.sync.url",
+        "sync.jobs",
+        "sync.targets.community.jobs",
+        "sync.targets.community.mode",
+        "sync.targets.community.token",
+        "sync.targets.community.url",
+        "sync.targets.majel.battlelogs_realtime",
+        "sync.targets.majel.mode",
+        "sync.targets.majel.token",
+        "sync.targets.majel.url"
+      ],
+      "provenance": {
+        "community.jobs": "explicit_false",
+        "majel.jobs": "inherited"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "explicit-false-overrides-global",
+      "file": "explicit-false-overrides-global.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.battlelogs",
+        "sync.targets.optout.battlelogs",
+        "sync.targets.optout.token",
+        "sync.targets.optout.url"
+      ],
+      "provenance": {
+        "optout.battlelogs": "explicit_false"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "explicit-empty-proxy",
+      "file": "explicit-empty-proxy.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.proxy",
+        "sync.targets.direct.proxy",
+        "sync.targets.direct.token",
+        "sync.targets.direct.url"
+      ],
+      "provenance": {
+        "direct.proxy": "explicit_empty"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "missing-partial-credentials",
+      "file": "missing-partial-credentials.toml",
+      "expectedTargetKinds": [],
+      "expectedPaths": [
+        "sync.targets.missing_token.url",
+        "sync.targets.missing_url.token"
+      ],
+      "provenance": {},
+      "diagnostics": ["SYNC_CREDENTIALS_INCOMPLETE"]
+    },
+    {
+      "id": "unsupported-external-fleet-runtime",
+      "file": "unsupported-external-fleet-runtime.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.targets.external.fleet_runtime",
+        "sync.targets.external.token",
+        "sync.targets.external.url"
+      ],
+      "provenance": {
+        "external.fleet_runtime": "explicit_value"
+      },
+      "diagnostics": ["SYNC_EXTERNAL_FLEET_RUNTIME_UNSUPPORTED"]
+    },
+    {
+      "id": "legacy-root-conversion",
+      "file": "legacy-root-conversion.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.battlelogs",
+        "sync.token",
+        "sync.url"
+      ],
+      "provenance": {
+        "default.identity": "explicit_value"
+      },
+      "diagnostics": ["SYNC_LEGACY_ROOT_CONVERTED"]
+    },
+    {
+      "id": "invalid-loopback-external-target",
+      "file": "invalid-loopback-external-target.toml",
+      "expectedTargetKinds": [],
+      "expectedPaths": [
+        "sync.targets.sidecar.mode",
+        "sync.targets.sidecar.token",
+        "sync.targets.sidecar.url"
+      ],
+      "provenance": {},
+      "diagnostics": [
+        "SYNC_LOOPBACK_TARGET_INVALID",
+        "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID"
+      ]
+    },
+    {
+      "id": "unknown-source-content-preserved",
+      "file": "unknown-source-content-preserved.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "future_sync_setting",
+        "sync.targets.future.future_transport_option",
+        "sync.targets.future.token",
+        "sync.targets.future.url"
+      ],
+      "provenance": {},
+      "diagnostics": ["SYNC_UNKNOWN_KEY_PRESERVED"]
+    }
+  ]
+}

--- a/docs/windows-launcher/sync-target-corpus/explicit-empty-proxy.toml
+++ b/docs/windows-launcher/sync-target-corpus/explicit-empty-proxy.toml
@@ -1,0 +1,7 @@
+[sync]
+proxy = "http://proxy.example.invalid:8080"
+
+[sync.targets.direct]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-direct"
+proxy = ""

--- a/docs/windows-launcher/sync-target-corpus/explicit-false-overrides-global.toml
+++ b/docs/windows-launcher/sync-target-corpus/explicit-false-overrides-global.toml
@@ -1,0 +1,7 @@
+[sync]
+battlelogs = true
+
+[sync.targets.optout]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-optout"
+battlelogs = false

--- a/docs/windows-launcher/sync-target-corpus/global-only-defaults.toml
+++ b/docs/windows-launcher/sync-target-corpus/global-only-defaults.toml
@@ -1,0 +1,7 @@
+# Defaults without a target are valid desired state and create no runnable target.
+[sync]
+proxy = "http://proxy.example.invalid:8080"
+verify_ssl = true
+allow_unsafe_tls_without_certificate_validation = false
+battlelogs = true
+jobs = false

--- a/docs/windows-launcher/sync-target-corpus/invalid-loopback-external-target.toml
+++ b/docs/windows-launcher/sync-target-corpus/invalid-loopback-external-target.toml
@@ -1,0 +1,4 @@
+[sync.targets.sidecar]
+url = "http://127.0.0.1:43127/api/sidecar/ingest"
+token = "fixture-redacted-invalid"
+mode = "sidecar_broker"

--- a/docs/windows-launcher/sync-target-corpus/legacy-root-conversion.toml
+++ b/docs/windows-launcher/sync-target-corpus/legacy-root-conversion.toml
@@ -1,0 +1,4 @@
+[sync]
+url = "https://legacy.example.invalid/sync"
+token = "fixture-redacted-legacy"
+battlelogs = true

--- a/docs/windows-launcher/sync-target-corpus/legacy-spocks-presets.toml
+++ b/docs/windows-launcher/sync-target-corpus/legacy-spocks-presets.toml
@@ -1,0 +1,12 @@
+[sync]
+battlelogs = true
+
+[sync.targets.spocksclub]
+url = "https://legacy.example.invalid/sync"
+token = "fixture-redacted-spocks"
+mode = "legacy"
+
+[sync.targets.nextspocksclub]
+url = "https://next.example.invalid/sync"
+token = "fixture-redacted-next"
+mode = "legacy"

--- a/docs/windows-launcher/sync-target-corpus/majel-realtime.toml
+++ b/docs/windows-launcher/sync-target-corpus/majel-realtime.toml
@@ -1,0 +1,8 @@
+[sync]
+battlelogs_realtime = true
+
+[sync.targets.majel]
+url = "https://majel.example.invalid/api/ingest/events"
+token = "fixture-redacted-majel"
+mode = "majel"
+battlelogs = false

--- a/docs/windows-launcher/sync-target-corpus/missing-partial-credentials.toml
+++ b/docs/windows-launcher/sync-target-corpus/missing-partial-credentials.toml
@@ -1,0 +1,5 @@
+[sync.targets.missing_token]
+url = "https://community.example.invalid/sync"
+
+[sync.targets.missing_url]
+token = "fixture-redacted-partial"

--- a/docs/windows-launcher/sync-target-corpus/mixed-multiple-targets.toml
+++ b/docs/windows-launcher/sync-target-corpus/mixed-multiple-targets.toml
@@ -1,0 +1,20 @@
+[sync]
+jobs = true
+
+[sidecar.sync]
+enabled = true
+url = "http://localhost:43127/api/sidecar/ingest"
+token = "fixture-redacted-sidecar"
+battlelogs_realtime = true
+
+[sync.targets.community]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-community"
+mode = "legacy"
+jobs = false
+
+[sync.targets.majel]
+url = "https://majel.example.invalid/api/ingest/events"
+token = "fixture-redacted-majel"
+mode = "majel"
+battlelogs_realtime = true

--- a/docs/windows-launcher/sync-target-corpus/unknown-source-content-preserved.toml
+++ b/docs/windows-launcher/sync-target-corpus/unknown-source-content-preserved.toml
@@ -1,0 +1,7 @@
+# The launcher does not own this root key.
+future_sync_setting = "keep exactly"
+
+[sync.targets.future]
+url = "https://future.example.invalid/sync"
+token = "fixture-redacted-future"
+future_transport_option = "preserve me" # including this comment

--- a/docs/windows-launcher/sync-target-corpus/unsupported-external-fleet-runtime.toml
+++ b/docs/windows-launcher/sync-target-corpus/unsupported-external-fleet-runtime.toml
@@ -1,0 +1,4 @@
+[sync.targets.external]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-external"
+fleet_runtime = true

--- a/run-launcher.cmd
+++ b/run-launcher.cmd
@@ -1,0 +1,37 @@
+@echo off
+setlocal
+
+set "REPO_ROOT=%~dp0"
+set "LAUNCHER_PROJECT=%REPO_ROOT%windows-launcher\src\STFCCommunityMod.Launcher\STFCCommunityMod.Launcher.csproj"
+set "LAUNCHER_DIRECTORY=%REPO_ROOT%windows-launcher\src\STFCCommunityMod.Launcher\bin\Release\net8.0-windows\win-x64"
+set "LAUNCHER_EXE=%LAUNCHER_DIRECTORY%\STFCCommunityMod.Launcher.exe"
+
+if not defined WINDIR (
+  if not defined SystemRoot (
+    echo Neither WINDIR nor SystemRoot is available in this shell.
+    goto :failure
+  )
+  set "WINDIR=%SystemRoot%"
+)
+
+echo Building the latest launcher from this checkout...
+dotnet build "%LAUNCHER_PROJECT%" -c Release -r win-x64 --self-contained true --nologo
+if errorlevel 1 goto :failure
+
+if not exist "%LAUNCHER_EXE%" (
+  echo.
+  echo Build completed, but the launcher executable was not found:
+  echo   %LAUNCHER_EXE%
+  goto :failure
+)
+
+echo Starting:
+echo   %LAUNCHER_EXE%
+start "" /D "%LAUNCHER_DIRECTORY%" "%LAUNCHER_EXE%"
+exit /b 0
+
+:failure
+echo.
+echo The launcher was not started. Review the build output above.
+pause
+exit /b 1

--- a/scripts/windows_release_manifest_spec.json
+++ b/scripts/windows_release_manifest_spec.json
@@ -53,7 +53,7 @@
       "kind": "windows-launcher-setup",
       "platform": "windows",
       "architecture": "x64",
-      "sourcePath": "stfc-community-mod-launcher-win-x64/setup/STFCCommunityMod.Launcher.Setup.exe",
+      "sourcePath": "stfc-community-mod-launcher-setup-win-x64/STFCCommunityMod.Launcher.Setup.exe",
       "fileName": "STFCCommunityMod.Launcher.Setup.exe",
       "mediaType": "application/vnd.microsoft.portable-executable",
       "authenticity": {

--- a/windows-launcher/README.md
+++ b/windows-launcher/README.md
@@ -35,6 +35,11 @@ dotnet publish windows-launcher/src/STFCCommunityMod.Launcher/STFCCommunityMod.L
 The repository `global.json` selects .NET 8. The launcher publish is
 self-contained and does not require a machine-wide .NET runtime.
 
+For routine local dogfooding, double-click `run-launcher.cmd` at the repository
+root. It incrementally builds the current checkout in Release mode and starts
+the exact launcher executable produced by that build. A failed build remains
+visible in the command window instead of launching an older output.
+
 ## Package the launcher
 
 ```powershell

--- a/windows-launcher/README.md
+++ b/windows-launcher/README.md
@@ -41,13 +41,19 @@ self-contained and does not require a machine-wide .NET runtime.
 ./windows-launcher/scripts/publish.ps1
 ```
 
-The script writes an unpackaged per-user payload, an internal self-update ZIP,
-a SHA-256 sidecar, a small launcher manifest, and the user-facing single-file
-`setup/STFCCommunityMod.Launcher.Setup.exe` under `windows-launcher/artifacts/`.
-Release users download only the setup executable; it installs without
-elevation, creates a Start-menu shortcut, and starts the launcher. Ordinary PR
-artifacts are unsigned build evidence and are intentionally rejected by the
-production install trust checks.
+The script writes an unpackaged payload and machine-consumed self-update ZIP as
+release-pipeline inputs, plus the single-file
+`setup/STFCCommunityMod.Launcher.Setup.exe`. Setup is the only Windows launcher
+install artifact: it installs per-user without elevation, creates a Start-menu
+shortcut, and starts the launcher. A portable distribution is intentionally
+deferred.
+
+Branch and pull-request workflow artifacts expose only the setup executable;
+the unavoidable GitHub Actions transport ZIP contains no nested build
+workspace. Tagged workflows retain the signed self-update archive because the
+launcher consumes it automatically, but release users install through Setup.
+Ordinary PR builds remain unsigned build evidence and are correctly rejected
+by the production install trust checks.
 
 ## Current safety boundary
 

--- a/windows-launcher/scripts/smoke-settings.ps1
+++ b/windows-launcher/scripts/smoke-settings.ps1
@@ -4,7 +4,9 @@ param(
   [string]$LauncherPath,
 
   [ValidateRange(5, 120)]
-  [int]$TimeoutSeconds = 30
+  [int]$TimeoutSeconds = 30,
+
+  [switch]$UseDisposableSyncFixture
 )
 
 $ErrorActionPreference = "Stop"
@@ -222,6 +224,33 @@ function Stop-OwnedProcess {
   }
 }
 
+function Restore-DisposableFixture {
+  param(
+    [bool]$SelectionExisted,
+    [AllowNull()][byte[]]$SelectionBytes,
+    [string]$SelectionPath,
+    [AllowNull()][string]$DisposableGameDirectory
+  )
+
+  if ($SelectionExisted) {
+    [System.IO.File]::WriteAllBytes($SelectionPath, $SelectionBytes)
+  }
+  elseif (Test-Path -LiteralPath $SelectionPath -PathType Leaf) {
+    [System.IO.File]::Delete($SelectionPath)
+  }
+
+  if ($null -ne $DisposableGameDirectory -and
+      $DisposableGameDirectory.StartsWith(
+        [System.IO.Path]::GetTempPath(),
+        [StringComparison]::OrdinalIgnoreCase) -and
+      (Split-Path -Leaf $DisposableGameDirectory).StartsWith(
+        "stfc-launcher-sync-smoke-",
+        [StringComparison]::Ordinal) -and
+      (Test-Path -LiteralPath $DisposableGameDirectory -PathType Container)) {
+    [System.IO.Directory]::Delete($DisposableGameDirectory, $true)
+  }
+}
+
 $resolvedLauncherPath = (Resolve-Path -LiteralPath $LauncherPath).Path
 if (-not (Test-Path -LiteralPath $resolvedLauncherPath -PathType Leaf) -or
     [System.IO.Path]::GetExtension($resolvedLauncherPath) -ne ".exe") {
@@ -253,16 +282,73 @@ if ([string]::IsNullOrWhiteSpace($originalWindir)) {
   Write-Verbose "Restored process WINDIR from SystemRoot for the launcher smoke."
 }
 
-$configurationPath = Get-ActiveConfigurationPath
-$configurationHashBefore = $null
-if ($null -ne $configurationPath) {
-  $configurationHashBefore = (
-    Get-FileHash -LiteralPath $configurationPath -Algorithm SHA256
-  ).Hash
-  Write-Host "Guarding active TOML: $configurationPath"
+$selectionPath = Join-Path `
+  ([Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)) `
+  "STFC Community Mod Launcher\install-selection.json"
+$selectionExisted = Test-Path -LiteralPath $selectionPath -PathType Leaf
+$selectionBytes = if ($selectionExisted) {
+  [System.IO.File]::ReadAllBytes($selectionPath)
+} else {
+  $null
 }
-else {
-  Write-Host "No active game TOML was discoverable; continuing with read-only UI checks."
+$disposableGameDirectory = $null
+try {
+  if ($UseDisposableSyncFixture) {
+    $disposableGameDirectory = Join-Path `
+      ([System.IO.Path]::GetTempPath()) `
+      "stfc-launcher-sync-smoke-$([Guid]::NewGuid().ToString('N'))"
+    [void](New-Item -ItemType Directory -Path $disposableGameDirectory)
+    [System.IO.File]::WriteAllBytes(
+      (Join-Path $disposableGameDirectory "prime.exe"),
+      [byte[]]::new(0))
+    [System.IO.File]::WriteAllText(
+      (Join-Path $disposableGameDirectory "community_patch_settings.toml"),
+      @"
+[sync]
+jobs = true
+
+[sidecar.sync]
+enabled = false
+
+[sync.targets.community]
+url = "https://community.example.invalid/sync"
+token = "disposable-smoke-secret"
+"@,
+      [System.Text.UTF8Encoding]::new($false))
+    [void](New-Item -ItemType Directory -Path (Split-Path -Parent $selectionPath) -Force)
+    $selectionDocument = [ordered]@{
+      schemaVersion = 1
+      gameDirectory = $disposableGameDirectory
+      confirmedAtUtc = [DateTimeOffset]::UtcNow
+    }
+    [System.IO.File]::WriteAllText(
+      $selectionPath,
+      ($selectionDocument | ConvertTo-Json),
+      [System.Text.UTF8Encoding]::new($false))
+    Write-Host "Using disposable Sync fixture: $disposableGameDirectory"
+  }
+
+  $configurationPath = Get-ActiveConfigurationPath
+  $configurationHashBefore = $null
+  if ($null -ne $configurationPath) {
+    $configurationHashBefore = (
+      Get-FileHash -LiteralPath $configurationPath -Algorithm SHA256
+    ).Hash
+    Write-Host "Guarding active TOML: $configurationPath"
+  }
+  else {
+    Write-Host "No active game TOML was discoverable; continuing with read-only UI checks."
+  }
+}
+catch {
+  if ($UseDisposableSyncFixture) {
+    Restore-DisposableFixture `
+      -SelectionExisted $selectionExisted `
+      -SelectionBytes $selectionBytes `
+      -SelectionPath $selectionPath `
+      -DisposableGameDirectory $disposableGameDirectory
+  }
+  throw
 }
 
 $launcherProcess = $null
@@ -412,6 +498,11 @@ try {
     -Name "Hotkey settings" `
     -ControlType ([System.Windows.Automation.ControlType]::Button) `
     -Deadline $settingsDeadline
+  $syncNavigation = Find-AutomationElement `
+    -Root $root `
+    -Name "Data Sync settings" `
+    -ControlType ([System.Windows.Automation.ControlType]::Button) `
+    -Deadline $settingsDeadline
 
   Invoke-AutomationElement -Element $notificationsNavigation
   [void](Find-AutomationElement `
@@ -436,6 +527,22 @@ try {
     -ControlType ([System.Windows.Automation.ControlType]::Button) `
     -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
 
+  Invoke-AutomationElement -Element $syncNavigation
+  [void](Find-AutomationElement `
+    -Root $root `
+    -Name "Sync setup workspace" `
+    -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
+  [void](Find-AutomationElement `
+    -Root $root `
+    -Name "Global defaults" `
+    -ControlType ([System.Windows.Automation.ControlType]::Text) `
+    -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
+  [void](Find-AutomationElement `
+    -Root $root `
+    -Name "Configured sync targets" `
+    -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
+  Write-Host "PASS: typed Sync setup, global defaults, and virtualized target collection are UI Automation accessible."
+
   $aboutNavigation = Find-AutomationElement `
     -Root $root `
     -Name "About launcher settings" `
@@ -455,7 +562,7 @@ try {
       -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
   }
 
-  Write-Host "PASS: launcher chrome, grouped Hotkeys actions, overflow binding actions, appearance selection, and startup activation diagnostics are UI Automation accessible."
+  Write-Host "PASS: launcher chrome, typed Sync setup, grouped Hotkeys actions, overflow binding actions, appearance selection, and startup activation diagnostics are UI Automation accessible."
 }
 catch {
   $smokeFailure = $_
@@ -482,6 +589,14 @@ finally {
 
   if ($windirWasRestored) {
     [Environment]::SetEnvironmentVariable("WINDIR", $null, "Process")
+  }
+
+  if ($UseDisposableSyncFixture) {
+    Restore-DisposableFixture `
+      -SelectionExisted $selectionExisted `
+      -SelectionBytes $selectionBytes `
+      -SelectionPath $selectionPath `
+      -DisposableGameDirectory $disposableGameDirectory
   }
 }
 

--- a/windows-launcher/scripts/smoke-settings.ps1
+++ b/windows-launcher/scripts/smoke-settings.ps1
@@ -488,6 +488,15 @@ try {
     -Name "General settings" `
     -ControlType ([System.Windows.Automation.ControlType]::Button) `
     -Deadline $settingsDeadline)
+  $unexpectedSyncWorkspace = $root.FindFirst(
+    [System.Windows.Automation.TreeScope]::Descendants,
+    [System.Windows.Automation.PropertyCondition]::new(
+      [System.Windows.Automation.AutomationElement]::NameProperty,
+      "Sync setup workspace"))
+  if ($null -ne $unexpectedSyncWorkspace) {
+    throw "The typed Sync workspace is visible while General settings is selected."
+  }
+  Write-Host "PASS: typed Sync setup stays hidden outside the Data Sync section."
   $notificationsNavigation = Find-AutomationElement `
     -Root $root `
     -Name "Notification settings" `

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/GameLaunchHandoff.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/GameLaunchHandoff.cs
@@ -207,9 +207,12 @@ public sealed class GameLaunchHandoffCoordinator(
             var targetPath = Path.Combine(validation.GameDirectory, "version.dll");
             if (state is null)
             {
-                return Blocked("Mod required", "Install or adopt the community mod before a modded launch.", mode);
+                if (!File.Exists(targetPath))
+                {
+                    return Blocked("Mod required", "Install the community mod before a modded launch.", mode);
+                }
             }
-            if (!PathEquals(state.GameDirectory, validation.GameDirectory)
+            else if (!PathEquals(state.GameDirectory, validation.GameDirectory)
                 || !File.Exists(targetPath)
                 || !string.Equals(ComputeSha256(targetPath), state.Sha256, StringComparison.OrdinalIgnoreCase))
             {

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlDocument.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlDocument.cs
@@ -79,8 +79,14 @@ public sealed partial class SparseTomlDocument
                 text[assignment.ValueStart..assignment.ValueEnd],
                 assignment.Line.Number),
             StringComparer.Ordinal);
+        var tables = analysis.Sections
+            .Select(section => new SparseTomlTable(
+                string.Join('.', section.Path),
+                section.HeaderLine.Number))
+            .ToArray();
         return SparseTomlReadResult.Success(
-            new ReadOnlyDictionary<string, SparseTomlOverride>(overrides));
+            new ReadOnlyDictionary<string, SparseTomlOverride>(overrides),
+            Array.AsReadOnly(tables));
     }
 
     public SparseTomlEditResult SetOverride(string canonicalPath, string renderedTomlValue)
@@ -215,6 +221,140 @@ public sealed partial class SparseTomlDocument
         var line = analysis.TargetAssignments[0].Line;
         var updatedText = text.Remove(line.Start, line.End - line.Start);
         return BuildResult(updatedText);
+    }
+
+    public SparseTomlEditResult RemoveTable(string canonicalTablePath)
+    {
+        var pathResult = ParseCanonicalPath(canonicalTablePath);
+        if (pathResult.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(pathResult.Error);
+        }
+
+        var path = pathResult.Segments!;
+        var analysis = Analyze(targetPath: null);
+        if (analysis.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(analysis.Error);
+        }
+
+        var matchingSections = analysis.Sections
+            .Where(section => HasPathPrefix(section.Path, path))
+            .OrderByDescending(section => section.HeaderLine.Start)
+            .ToArray();
+        if (matchingSections.Length == 0)
+        {
+            return analysis.AllAssignments.Any(assignment => HasPathPrefix(assignment.Path, path))
+                ? SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{canonicalTablePath}]' is represented by dotted assignments and cannot be removed safely."))
+                : SparseTomlEditResult.Unchanged([.. originalContents]);
+        }
+
+        var updatedText = text;
+        foreach (var section in matchingSections)
+        {
+            updatedText = updatedText.Remove(
+                section.HeaderLine.Start,
+                section.End - section.HeaderLine.Start);
+        }
+
+        return BuildValidatedResult(updatedText);
+    }
+
+    public SparseTomlEditResult RenameTable(string canonicalTablePath, string newCanonicalTablePath)
+    {
+        var sourceResult = ParseCanonicalPath(canonicalTablePath);
+        if (sourceResult.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(sourceResult.Error);
+        }
+
+        var destinationResult = ParseCanonicalPath(newCanonicalTablePath);
+        if (destinationResult.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(destinationResult.Error);
+        }
+
+        var source = sourceResult.Segments!;
+        var destination = destinationResult.Segments!;
+        if (source.SequenceEqual(destination, StringComparer.Ordinal))
+        {
+            return SparseTomlEditResult.Unchanged([.. originalContents]);
+        }
+
+        var analysis = Analyze(targetPath: null);
+        if (analysis.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(analysis.Error);
+        }
+
+        var matchingSections = analysis.Sections
+            .Where(section => HasPathPrefix(section.Path, source))
+            .ToArray();
+        if (matchingSections.Length == 0)
+        {
+            return analysis.AllAssignments.Any(assignment => HasPathPrefix(assignment.Path, source))
+                ? SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{canonicalTablePath}]' is represented by dotted assignments and cannot be renamed safely."))
+                : SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{canonicalTablePath}]' does not exist."));
+        }
+
+        var selected = matchingSections.ToHashSet();
+        foreach (var section in matchingSections)
+        {
+            var mappedPath = destination.Concat(section.Path[source.Length..]).ToArray();
+            if (analysis.Sections.Any(other =>
+                    !selected.Contains(other)
+                    && other.Path.SequenceEqual(mappedPath, StringComparer.Ordinal)))
+            {
+                return SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.DuplicateTarget,
+                        $"Table '[{string.Join('.', mappedPath)}]' already exists.",
+                        section.HeaderLine.Number));
+            }
+
+            if (analysis.AllAssignments.Any(assignment =>
+                    !HasPathPrefix(assignment.Path, source)
+                    && HasPathPrefix(assignment.Path, mappedPath)))
+            {
+                return SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{string.Join('.', mappedPath)}]' collides with an existing dotted assignment.",
+                        section.HeaderLine.Number));
+            }
+        }
+
+        var replacements = matchingSections
+            .Select(section =>
+            {
+                var match = SimpleTableHeaderRegex().Match(section.HeaderLine.Content);
+                var pathGroup = match.Groups["path"];
+                var suffix = section.Path[source.Length..];
+                return new TableHeaderReplacement(
+                    section.HeaderLine.Start + pathGroup.Index,
+                    pathGroup.Length,
+                    string.Join('.', destination.Concat(suffix)));
+            })
+            .OrderByDescending(replacement => replacement.Start)
+            .ToArray();
+
+        var updatedText = text;
+        foreach (var replacement in replacements)
+        {
+            updatedText = updatedText.Remove(replacement.Start, replacement.Length)
+                .Insert(replacement.Start, replacement.Value);
+        }
+
+        return BuildValidatedResult(updatedText);
     }
 
     private Analysis Analyze(string[]? targetPath)
@@ -566,6 +706,28 @@ public sealed partial class SparseTomlDocument
             ? SparseTomlEditResult.Unchanged(updatedContents)
             : SparseTomlEditResult.Updated(updatedContents);
     }
+
+    private SparseTomlEditResult BuildValidatedResult(string updatedText)
+    {
+        var result = BuildResult(updatedText);
+        if (!result.IsValid || !result.Changed || result.Contents is null)
+        {
+            return result;
+        }
+
+        var load = Load(result.Contents, out var updatedDocument);
+        if (!load.IsValid || updatedDocument is null)
+        {
+            return load;
+        }
+
+        var validation = updatedDocument.ValidateForMutation();
+        return validation.IsValid ? result : validation;
+    }
+
+    private static bool HasPathPrefix(string[] path, string[] prefix) =>
+        path.Length >= prefix.Length
+        && path.AsSpan(0, prefix.Length).SequenceEqual(prefix);
 
     private static PathParseResult ParseCanonicalPath(string canonicalPath)
     {
@@ -919,6 +1081,11 @@ public sealed partial class SparseTomlDocument
         PhysicalLine Line,
         int ValueStart,
         int ValueEnd);
+
+    private sealed record TableHeaderReplacement(
+        int Start,
+        int Length,
+        string Value);
 
     private sealed class Section(string[] path, PhysicalLine headerLine, int end)
     {

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlResult.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlResult.cs
@@ -36,15 +36,21 @@ public sealed record SparseTomlOverride(
     string RenderedValue,
     int LineNumber);
 
+public sealed record SparseTomlTable(
+    string CanonicalPath,
+    int LineNumber);
+
 public sealed record SparseTomlReadResult(
     bool IsValid,
     IReadOnlyDictionary<string, SparseTomlOverride>? Overrides,
+    IReadOnlyList<SparseTomlTable>? Tables,
     SparseTomlError? Error)
 {
     public static SparseTomlReadResult Success(
-        IReadOnlyDictionary<string, SparseTomlOverride> overrides) =>
-        new(true, overrides, null);
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        IReadOnlyList<SparseTomlTable> tables) =>
+        new(true, overrides, tables, null);
 
     public static SparseTomlReadResult Invalid(SparseTomlError error) =>
-        new(false, null, error);
+        new(false, null, null, error);
 }

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
@@ -1,0 +1,483 @@
+using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public sealed class SyncDesiredTopology
+{
+    public const string LocalSidecarIdentity = "local-sidecar";
+
+    private static readonly Regex TargetNamePattern = new(
+        "^[A-Za-z0-9_-]+$",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+
+    private readonly ReadOnlyDictionary<string, SyncTargetDraft> targets;
+
+    public SyncDesiredTopology(
+        SyncGlobalDefaults globalDefaults,
+        IReadOnlyDictionary<string, SyncTargetDraft>? targets = null)
+    {
+        GlobalDefaults = globalDefaults ?? throw new ArgumentNullException(nameof(globalDefaults));
+        this.targets = new(
+            targets?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal) ??
+            new Dictionary<string, SyncTargetDraft>(StringComparer.Ordinal));
+    }
+
+    public SyncGlobalDefaults GlobalDefaults { get; }
+
+    public IReadOnlyDictionary<string, SyncTargetDraft> Targets => targets;
+
+    public static SyncDesiredTopology Empty { get; } =
+        new(new SyncGlobalDefaults(string.Empty, true, false));
+
+    public SyncDesiredTopology WithGlobalDefaults(SyncGlobalDefaults value) => new(value, targets);
+
+    public SyncTopologyTransitionResult AddTarget(string name, SyncTargetKind kind)
+    {
+        var identity = kind == SyncTargetKind.LocalSidecar ? LocalSidecarIdentity : name;
+        var nameDiagnostic = ValidateIdentity(identity, kind);
+        if (nameDiagnostic is not null)
+        {
+            return Failed(nameDiagnostic);
+        }
+
+        if (targets.ContainsKey(identity))
+        {
+            return Failed(Error("SYNC_TARGET_NAME_DUPLICATE", identity, "identity", "A sync target already uses this name."));
+        }
+
+        var definition = SyncTargetTypeCatalog.Get(kind);
+        if (targets.Values.Count(target => target.Kind == kind) >= definition.MaximumInstances)
+        {
+            return Failed(Error("SYNC_TARGET_CARDINALITY", identity, "kind", "This target kind has reached its instance limit."));
+        }
+
+        var changed = CopyTargets();
+        changed.Add(identity, SyncTargetDraft.Create(identity, kind));
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult AddPreset(string presetId)
+    {
+        var preset = SyncTargetTypeCatalog.GetPreset(presetId);
+        return AddTarget(preset.SuggestedIdentity, preset.TargetKind);
+    }
+
+    public SyncTopologyTransitionResult UpdateTarget(
+        string name,
+        Func<SyncTargetDraft, SyncTargetDraft> update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        if (!targets.TryGetValue(name, out var current))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", name, null, "The sync target no longer exists."));
+        }
+
+        var updated = update(current);
+        if (!string.Equals(updated.Name, current.Name, StringComparison.Ordinal))
+        {
+            return Failed(Error(
+                "SYNC_TARGET_IDENTITY_TRANSITION_REQUIRED",
+                name,
+                "identity",
+                "Use the rename transition to change a target identity."));
+        }
+
+        var changed = CopyTargets();
+        changed[name] = updated;
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult RenameTarget(string currentName, string newName)
+    {
+        if (!targets.TryGetValue(currentName, out var target))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", currentName, null, "The sync target no longer exists."));
+        }
+
+        if (target.Kind == SyncTargetKind.LocalSidecar)
+        {
+            return Failed(Error(
+                "SYNC_SIDECAR_IDENTITY_FIXED",
+                currentName,
+                "identity",
+                "The local Sidecar identity is fixed."));
+        }
+
+        var nameDiagnostic = ValidateIdentity(newName, target.Kind);
+        if (nameDiagnostic is not null)
+        {
+            return Failed(nameDiagnostic);
+        }
+
+        if (targets.ContainsKey(newName))
+        {
+            return Failed(Error("SYNC_TARGET_NAME_DUPLICATE", newName, "identity", "A sync target already uses this name."));
+        }
+
+        var changed = CopyTargets();
+        changed.Remove(currentName);
+        changed.Add(newName, target.WithIdentity(newName));
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult DuplicateTarget(string sourceName, string newName)
+    {
+        if (!targets.TryGetValue(sourceName, out var source))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", sourceName, null, "The sync target no longer exists."));
+        }
+
+        if (source.Kind == SyncTargetKind.LocalSidecar)
+        {
+            return Failed(Error(
+                "SYNC_TARGET_CARDINALITY",
+                sourceName,
+                "kind",
+                "The singleton local Sidecar target cannot be duplicated."));
+        }
+
+        var nameDiagnostic = ValidateIdentity(newName, source.Kind);
+        if (nameDiagnostic is not null)
+        {
+            return Failed(nameDiagnostic);
+        }
+
+        if (targets.ContainsKey(newName))
+        {
+            return Failed(Error("SYNC_TARGET_NAME_DUPLICATE", newName, "identity", "A sync target already uses this name."));
+        }
+
+        var duplicate = source
+            .WithIdentity(newName)
+            .WithEnabled(false)
+            .WithoutSecret();
+        var changed = CopyTargets();
+        changed.Add(newName, duplicate);
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult ChangeTargetKind(string name, SyncTargetKind newKind)
+    {
+        if (!targets.TryGetValue(name, out var target))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", name, null, "The sync target no longer exists."));
+        }
+
+        if (target.Kind == newKind)
+        {
+            return Succeeded(this);
+        }
+
+        if (target.Kind == SyncTargetKind.LocalSidecar || newKind == SyncTargetKind.LocalSidecar)
+        {
+            return Failed(Error(
+                "SYNC_KIND_CHANGE_UNSUPPORTED",
+                name,
+                "kind",
+                "Local Sidecar cannot be converted to or from an external target."));
+        }
+
+        var supported = SyncTargetTypeCatalog.Get(newKind).SupportedDataKinds;
+        var changedTarget = target.WithKind(newKind);
+        foreach (var unsupported in changedTarget.DataOverrides.Keys.Where(kind => !supported.Contains(kind)).ToArray())
+        {
+            changedTarget = changedTarget.WithDataOverride(unsupported, SyncOverride.Inherited<bool>());
+        }
+
+        var changed = CopyTargets();
+        changed[name] = changedTarget;
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult SetTargetEnabled(string name, bool enabled) =>
+        UpdateTarget(name, target => target.WithEnabled(enabled));
+
+    public SyncTopologyTransitionResult RemoveTarget(string name)
+    {
+        if (!targets.ContainsKey(name))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", name, null, "The sync target no longer exists."));
+        }
+
+        var changed = CopyTargets();
+        changed.Remove(name);
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncResolvedTopology Resolve() => SyncTopologyResolver.Resolve(this);
+
+    internal static SyncTopologyDiagnostic? ValidateIdentity(string name, SyncTargetKind kind)
+    {
+        if (kind == SyncTargetKind.LocalSidecar)
+        {
+            return string.Equals(name, LocalSidecarIdentity, StringComparison.Ordinal)
+                ? null
+                : Error("SYNC_SIDECAR_IDENTITY_FIXED", name, "identity", "The local Sidecar identity is fixed.");
+        }
+
+        if (name.Length is < 1 or > 64 || !TargetNamePattern.IsMatch(name))
+        {
+            return Error(
+                "SYNC_TARGET_NAME_INVALID",
+                name,
+                "identity",
+                "Target names must contain 1-64 ASCII letters, numbers, underscores, or hyphens.");
+        }
+
+        return string.Equals(name, "sidecar", StringComparison.OrdinalIgnoreCase)
+            ? Error(
+                "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID",
+                name,
+                "identity",
+                "External targets cannot use the reserved Sidecar identity.")
+            : null;
+    }
+
+    private Dictionary<string, SyncTargetDraft> CopyTargets() =>
+        targets.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal);
+
+    private SyncTopologyTransitionResult Failed(SyncTopologyDiagnostic diagnostic) => new(false, this, diagnostic);
+
+    private static SyncTopologyTransitionResult Succeeded(SyncDesiredTopology topology) => new(true, topology);
+
+    internal static SyncTopologyDiagnostic Error(string code, string? targetName, string? field, string message) =>
+        new(code, SyncTopologyDiagnosticSeverity.Error, message, targetName, field);
+}
+
+public static class SyncTopologyResolver
+{
+    public static SyncResolvedTopology Resolve(SyncDesiredTopology desired)
+    {
+        ArgumentNullException.ThrowIfNull(desired);
+        var diagnostics = new List<SyncTopologyDiagnostic>();
+        var targets = new List<SyncResolvedTarget>();
+        var invalidCardinality = desired.Targets.Values
+            .GroupBy(target => target.Kind)
+            .Where(group => group.Count() > SyncTargetTypeCatalog.Get(group.Key).MaximumInstances)
+            .Select(group => group.Key)
+            .ToHashSet();
+        foreach (var kind in invalidCardinality)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_TARGET_CARDINALITY",
+                null,
+                "kind",
+                $"Target kind '{kind}' exceeds its instance limit."));
+        }
+
+        foreach (var target in desired.Targets.Values.OrderBy(item => item.Name, StringComparer.Ordinal))
+        {
+            if (invalidCardinality.Contains(target.Kind))
+            {
+                continue;
+            }
+
+            var targetDiagnostics = ValidateTarget(desired.GlobalDefaults, target);
+            diagnostics.AddRange(targetDiagnostics);
+            if (targetDiagnostics.Any(item => item.Severity == SyncTopologyDiagnosticSeverity.Error))
+            {
+                continue;
+            }
+
+            targets.Add(ResolveTarget(desired.GlobalDefaults, target));
+        }
+
+        return new(targets.AsReadOnly(), diagnostics.AsReadOnly());
+    }
+
+    private static List<SyncTopologyDiagnostic> ValidateTarget(
+        SyncGlobalDefaults globals,
+        SyncTargetDraft target)
+    {
+        var diagnostics = new List<SyncTopologyDiagnostic>();
+        var identity = SyncDesiredTopology.ValidateIdentity(target.Name, target.Kind);
+        if (identity is not null)
+        {
+            diagnostics.Add(identity);
+        }
+
+        var definition = SyncTargetTypeCatalog.Get(target.Kind);
+        if (definition.RequiresUrl && !TryValidateEndpoint(target.Url, target.Kind, out var endpointCode, out var endpointMessage))
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(endpointCode, target.Name, "url", endpointMessage));
+        }
+
+        if (definition.RequiresToken && !target.Token.IsConfigured)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_CREDENTIALS_INCOMPLETE",
+                target.Name,
+                "token",
+                "This target requires a configured token."));
+        }
+
+        foreach (var (kind, value) in target.DataOverrides)
+        {
+            if (value.IsExplicit && !definition.SupportedDataKinds.Contains(kind))
+            {
+                diagnostics.Add(SyncDesiredTopology.Error(
+                    "SYNC_CAPABILITY_UNSUPPORTED",
+                    target.Name,
+                    kind.ToString(),
+                    "This data capability is not supported by the selected target kind."));
+            }
+        }
+
+        if (target.BattlelogEnrichment.IsExplicit && !definition.SupportsBattlelogEnrichment)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_CAPABILITY_UNSUPPORTED",
+                target.Name,
+                "battlelog_enrichment",
+                "Battle-log enrichment is supported only by the local Sidecar target."));
+        }
+
+        if (target.FleetRuntimeMode.IsExplicit && !definition.SupportsFleetRuntimeMode)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_CAPABILITY_UNSUPPORTED",
+                target.Name,
+                "fleet_runtime_mode",
+                "Fleet runtime mode is supported only by the local Sidecar target."));
+        }
+        else if (target.FleetRuntimeMode.IsExplicit && !IsFleetRuntimeModeSupported(target.FleetRuntimeMode.Value))
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_FLEET_RUNTIME_MODE_INVALID",
+                target.Name,
+                "fleet_runtime_mode",
+                "Fleet runtime mode must be normal, request_only, snapshot_only, or enqueue_no_transport."));
+        }
+
+        var verifySsl = ResolveVerifySsl(target, definition, globals).Value;
+        var unsafeTls = ResolveUnsafeTls(target, definition, globals).Value;
+        if (!verifySsl && !unsafeTls)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_UNSAFE_TLS_PAIR_REQUIRED",
+                target.Name,
+                "verify_ssl",
+                "Disabling TLS verification requires the explicit unsafe-TLS acknowledgement."));
+        }
+
+        return diagnostics;
+    }
+
+    private static SyncResolvedTarget ResolveTarget(SyncGlobalDefaults globals, SyncTargetDraft target)
+    {
+        var definition = SyncTargetTypeCatalog.Get(target.Kind);
+        var dataKinds = new ReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>>(
+            definition.SupportedDataKinds.ToDictionary(
+                kind => kind,
+                kind => ResolveDataKind(globals, target, definition, kind)));
+        return new(
+            target.Name,
+            target.Kind,
+            target.Enabled,
+            target.Url,
+            target.Token.IsConfigured,
+            ResolveProxy(globals, target, definition),
+            ResolveVerifySsl(target, definition, globals),
+            ResolveUnsafeTls(target, definition, globals),
+            dataKinds,
+            definition.SupportsBattlelogEnrichment
+                ? target.BattlelogEnrichment.Resolve(false, SyncValueSource.TargetTypeDefault)
+                : null,
+            definition.SupportsFleetRuntimeMode
+                ? target.FleetRuntimeMode.Resolve("normal", SyncValueSource.TargetTypeDefault)
+                : null);
+    }
+
+    private static SyncResolvedValue<string> ResolveProxy(
+        SyncGlobalDefaults globals,
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition) =>
+        definition.InheritsGlobalSync
+            ? target.Proxy.Resolve(globals.Proxy, SyncValueSource.GlobalDefault)
+            : target.Proxy.Resolve(string.Empty, SyncValueSource.TargetTypeDefault);
+
+    private static SyncResolvedValue<bool> ResolveVerifySsl(
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition,
+        SyncGlobalDefaults? globals = null) =>
+        definition.InheritsGlobalSync
+            ? target.VerifySsl.Resolve(globals?.VerifySsl ?? true, SyncValueSource.GlobalDefault)
+            : target.VerifySsl.Resolve(true, SyncValueSource.TargetTypeDefault);
+
+    private static SyncResolvedValue<bool> ResolveUnsafeTls(
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition,
+        SyncGlobalDefaults? globals = null) =>
+        definition.InheritsGlobalSync
+            ? target.AllowUnsafeTlsWithoutCertificateValidation.Resolve(
+                globals?.AllowUnsafeTlsWithoutCertificateValidation ?? false,
+                SyncValueSource.GlobalDefault)
+            : target.AllowUnsafeTlsWithoutCertificateValidation.Resolve(false, SyncValueSource.TargetTypeDefault);
+
+    private static SyncResolvedValue<bool> ResolveDataKind(
+        SyncGlobalDefaults globals,
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition,
+        SyncDataKind kind)
+    {
+        var value = target.DataOverrides.TryGetValue(kind, out var configured)
+            ? configured
+            : SyncOverride.Inherited<bool>();
+        return definition.InheritsGlobalSync
+            ? value.Resolve(globals.DataKinds[kind], SyncValueSource.GlobalDefault)
+            : value.Resolve(false, SyncValueSource.TargetTypeDefault);
+    }
+
+    private static bool TryValidateEndpoint(
+        string value,
+        SyncTargetKind kind,
+        out string code,
+        out string message)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || uri.Scheme is not ("http" or "https")
+            || string.IsNullOrEmpty(uri.Host))
+        {
+            code = "SYNC_ENDPOINT_INVALID";
+            message = "The target endpoint must be an absolute HTTP or HTTPS URL.";
+            return false;
+        }
+
+        if (kind == SyncTargetKind.LocalSidecar && !uri.IsLoopback)
+        {
+            code = "SYNC_SIDECAR_ENDPOINT_NOT_LOOPBACK";
+            message = "The local Sidecar endpoint must use a loopback host.";
+            return false;
+        }
+
+        if (kind != SyncTargetKind.LocalSidecar && uri.IsLoopback)
+        {
+            code = "SYNC_LOOPBACK_TARGET_INVALID";
+            message = "Loopback Sidecar endpoints belong to the local Sidecar target.";
+            return false;
+        }
+
+        code = string.Empty;
+        message = string.Empty;
+        return true;
+    }
+
+    private static bool IsFleetRuntimeModeSupported(string value) =>
+        value is "normal" or "request_only" or "snapshot_only" or "enqueue_no_transport";
+}
+
+public sealed record SyncTopologyWorkspace(
+    SyncDesiredTopology Desired,
+    SyncResolvedTopology StartupRuntime)
+{
+    public static SyncTopologyWorkspace Begin(SyncDesiredTopology desired) => new(desired, desired.Resolve());
+
+    public SyncTopologyWorkspace Apply(SyncTopologyTransitionResult transition)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+        return transition.Succeeded ? new(transition.Topology, StartupRuntime) : this;
+    }
+
+    public SyncResolvedTopology Preview => Desired.Resolve();
+}

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
@@ -157,7 +157,10 @@ public sealed class SyncDesiredTopology
         return Succeeded(new(GlobalDefaults, changed));
     }
 
-    public SyncTopologyTransitionResult ChangeTargetKind(string name, SyncTargetKind newKind)
+    public SyncTopologyTransitionResult ChangeTargetKind(
+        string name,
+        SyncTargetKind newKind,
+        SyncTargetKindChangePolicy policy = SyncTargetKindChangePolicy.PreserveCompatibleOverrides)
     {
         if (!targets.TryGetValue(name, out var target))
         {
@@ -180,6 +183,11 @@ public sealed class SyncDesiredTopology
 
         var supported = SyncTargetTypeCatalog.Get(newKind).SupportedDataKinds;
         var changedTarget = target.WithKind(newKind);
+        if (policy == SyncTargetKindChangePolicy.ResetOverrides)
+        {
+            changedTarget = changedTarget.WithoutOverrides();
+        }
+
         foreach (var unsupported in changedTarget.DataOverrides.Keys.Where(kind => !supported.Contains(kind)).ToArray())
         {
             changedTarget = changedTarget.WithDataOverride(unsupported, SyncOverride.Inherited<bool>());
@@ -298,12 +306,14 @@ public static class SyncTopologyResolver
         }
 
         var definition = SyncTargetTypeCatalog.Get(target.Kind);
-        if (definition.RequiresUrl && !TryValidateEndpoint(target.Url, target.Kind, out var endpointCode, out var endpointMessage))
+        if (target.Enabled
+            && definition.RequiresUrl
+            && !TryValidateEndpoint(target.Url, target.Kind, out var endpointCode, out var endpointMessage))
         {
             diagnostics.Add(SyncDesiredTopology.Error(endpointCode, target.Name, "url", endpointMessage));
         }
 
-        if (definition.RequiresToken && !target.Token.IsConfigured)
+        if (target.Enabled && definition.RequiresToken && !target.Token.IsConfigured)
         {
             diagnostics.Add(SyncDesiredTopology.Error(
                 "SYNC_CREDENTIALS_INCOMPLETE",
@@ -441,6 +451,13 @@ public static class SyncTopologyResolver
         {
             code = "SYNC_ENDPOINT_INVALID";
             message = "The target endpoint must be an absolute HTTP or HTTPS URL.";
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            code = "SYNC_ENDPOINT_EMBEDDED_CREDENTIALS";
+            message = "The target endpoint cannot contain embedded credentials; use the token field.";
             return false;
         }
 

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
@@ -1,0 +1,406 @@
+using System.Collections.Frozen;
+using System.Collections.ObjectModel;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public enum SyncTargetKind
+{
+    LocalSidecar,
+    LegacyCommunity,
+    MajelIngest,
+}
+
+public enum SyncDataKind
+{
+    Battlelogs,
+    BattlelogsRealtime,
+    Buffs,
+    Buildings,
+    Inventory,
+    Jobs,
+    Missions,
+    Officer,
+    Research,
+    Resources,
+    Ships,
+    Slots,
+    Tech,
+    Traits,
+    FleetRuntime,
+}
+
+public enum SyncValueProvenance
+{
+    Inherited,
+    ExplicitValue,
+    ExplicitFalse,
+    ExplicitEmpty,
+}
+
+public enum SyncValueSource
+{
+    GlobalDefault,
+    TargetTypeDefault,
+    Target,
+}
+
+public enum SyncTopologyDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error,
+}
+
+public readonly record struct SyncOverride<T>(bool IsExplicit, T Value)
+{
+    public SyncResolvedValue<T> Resolve(T inheritedValue, SyncValueSource inheritedSource)
+    {
+        if (!IsExplicit)
+        {
+            return new(inheritedValue, SyncValueProvenance.Inherited, inheritedSource);
+        }
+
+        var provenance = Value switch
+        {
+            false => SyncValueProvenance.ExplicitFalse,
+            string { Length: 0 } => SyncValueProvenance.ExplicitEmpty,
+            _ => SyncValueProvenance.ExplicitValue,
+        };
+        return new(Value, provenance, SyncValueSource.Target);
+    }
+}
+
+public static class SyncOverride
+{
+    public static SyncOverride<T> Inherited<T>() => new(false, default!);
+
+    public static SyncOverride<T> Explicit<T>(T value) => new(true, value);
+}
+
+public sealed record SyncResolvedValue<T>(
+    T Value,
+    SyncValueProvenance Provenance,
+    SyncValueSource Source);
+
+public sealed class SyncSecret : IEquatable<SyncSecret>
+{
+    private readonly string value;
+
+    private SyncSecret(string value)
+    {
+        this.value = value;
+    }
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(value);
+
+    public static SyncSecret Missing { get; } = new(string.Empty);
+
+    public static SyncSecret FromPlainText(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new(value);
+    }
+
+    public bool Equals(SyncSecret? other) =>
+        other is not null && string.Equals(value, other.value, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is SyncSecret other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(value);
+
+    public override string ToString() => IsConfigured ? "[configured]" : "[missing]";
+
+    internal string RevealForPersistence() => value;
+}
+
+public sealed record SyncTargetTypeDefinition(
+    SyncTargetKind Kind,
+    string PersistencePattern,
+    string WireContract,
+    int MaximumInstances,
+    bool InheritsGlobalSync,
+    bool RequiresUrl,
+    bool RequiresToken,
+    bool SupportsBattlelogEnrichment,
+    bool SupportsFleetRuntimeMode,
+    IReadOnlySet<SyncDataKind> SupportedDataKinds,
+    string DefaultUrl);
+
+public sealed record SyncTargetPreset(
+    string Id,
+    string DisplayName,
+    SyncTargetKind TargetKind,
+    string SuggestedIdentity);
+
+public static class SyncTargetTypeCatalog
+{
+    private static readonly ReadOnlyDictionary<SyncTargetKind, SyncTargetTypeDefinition> Definitions =
+        new(
+            new Dictionary<SyncTargetKind, SyncTargetTypeDefinition>
+            {
+                [SyncTargetKind.LocalSidecar] = new(
+                    SyncTargetKind.LocalSidecar,
+                    "sidecar.sync",
+                    "sidecar_local_ingest",
+                    1,
+                    false,
+                    true,
+                    true,
+                    true,
+                    true,
+                    new[]
+                    {
+                        SyncDataKind.BattlelogsRealtime,
+                        SyncDataKind.FleetRuntime,
+                    }.ToFrozenSet(),
+                    "http://127.0.0.1:43127/api/sidecar/ingest"),
+                [SyncTargetKind.LegacyCommunity] = External(
+                    SyncTargetKind.LegacyCommunity,
+                    "legacy_sync_json"),
+                [SyncTargetKind.MajelIngest] = External(
+                    SyncTargetKind.MajelIngest,
+                    "majel.ingest.v1"),
+            });
+
+    private static readonly ReadOnlyCollection<SyncTargetPreset> PresetDefinitions =
+        Array.AsReadOnly(
+        new SyncTargetPreset[]
+        {
+            new("spocks_club", "Spocks Club", SyncTargetKind.LegacyCommunity, "spocksclub"),
+            new("next_spocks_club", "Next Spocks Club", SyncTargetKind.LegacyCommunity, "nextspocksclub"),
+        });
+
+    public static IReadOnlyDictionary<SyncTargetKind, SyncTargetTypeDefinition> All => Definitions;
+
+    public static IReadOnlyList<SyncTargetPreset> Presets => PresetDefinitions;
+
+    public static SyncTargetTypeDefinition Get(SyncTargetKind kind) => Definitions[kind];
+
+    public static SyncTargetPreset GetPreset(string id) =>
+        PresetDefinitions.Single(preset => string.Equals(preset.Id, id, StringComparison.Ordinal));
+
+    private static SyncTargetTypeDefinition External(SyncTargetKind kind, string wireContract)
+    {
+        return new(
+            kind,
+            "sync.targets.*",
+            wireContract,
+            int.MaxValue,
+            true,
+            true,
+            true,
+            false,
+            false,
+            Enum.GetValues<SyncDataKind>()
+                .Where(value => value != SyncDataKind.FleetRuntime)
+                .ToFrozenSet(),
+            string.Empty);
+    }
+}
+
+public sealed class SyncGlobalDefaults
+{
+    private readonly ReadOnlyDictionary<SyncDataKind, bool> dataKinds;
+
+    public SyncGlobalDefaults(
+        string proxy,
+        bool verifySsl,
+        bool allowUnsafeTlsWithoutCertificateValidation,
+        IReadOnlyDictionary<SyncDataKind, bool>? dataKinds = null)
+    {
+        Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+        VerifySsl = verifySsl;
+        AllowUnsafeTlsWithoutCertificateValidation = allowUnsafeTlsWithoutCertificateValidation;
+        this.dataKinds = new(
+            Enum.GetValues<SyncDataKind>()
+                .ToDictionary(
+                    kind => kind,
+                    kind => dataKinds is not null && dataKinds.TryGetValue(kind, out var enabled) && enabled));
+    }
+
+    public string Proxy { get; }
+
+    public bool VerifySsl { get; }
+
+    public bool AllowUnsafeTlsWithoutCertificateValidation { get; }
+
+    public IReadOnlyDictionary<SyncDataKind, bool> DataKinds => dataKinds;
+
+    public SyncGlobalDefaults WithProxy(string proxy) =>
+        new(proxy, VerifySsl, AllowUnsafeTlsWithoutCertificateValidation, dataKinds);
+
+    public SyncGlobalDefaults WithVerifySsl(bool value) =>
+        new(Proxy, value, AllowUnsafeTlsWithoutCertificateValidation, dataKinds);
+
+    public SyncGlobalDefaults WithUnsafeTls(bool value) =>
+        new(Proxy, VerifySsl, value, dataKinds);
+
+    public SyncGlobalDefaults WithDataKind(SyncDataKind kind, bool enabled)
+    {
+        var changed = dataKinds.ToDictionary(item => item.Key, item => item.Value);
+        changed[kind] = enabled;
+        return new(Proxy, VerifySsl, AllowUnsafeTlsWithoutCertificateValidation, changed);
+    }
+}
+
+public sealed class SyncTargetDraft
+{
+    private readonly ReadOnlyDictionary<SyncDataKind, SyncOverride<bool>> dataOverrides;
+
+    public SyncTargetDraft(
+        string name,
+        SyncTargetKind kind,
+        bool enabled,
+        string url,
+        SyncSecret token,
+        SyncOverride<string> proxy,
+        SyncOverride<bool> verifySsl,
+        SyncOverride<bool> allowUnsafeTlsWithoutCertificateValidation,
+        IReadOnlyDictionary<SyncDataKind, SyncOverride<bool>>? dataOverrides = null,
+        SyncOverride<bool>? battlelogEnrichment = null,
+        SyncOverride<string>? fleetRuntimeMode = null)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Kind = kind;
+        Enabled = enabled;
+        Url = url ?? throw new ArgumentNullException(nameof(url));
+        Token = token ?? throw new ArgumentNullException(nameof(token));
+        Proxy = proxy;
+        VerifySsl = verifySsl;
+        AllowUnsafeTlsWithoutCertificateValidation = allowUnsafeTlsWithoutCertificateValidation;
+        this.dataOverrides = new(dataOverrides?.ToDictionary(item => item.Key, item => item.Value) ?? []);
+        BattlelogEnrichment = battlelogEnrichment ?? SyncOverride.Inherited<bool>();
+        FleetRuntimeMode = fleetRuntimeMode ?? SyncOverride.Inherited<string>();
+    }
+
+    public string Name { get; }
+
+    public SyncTargetKind Kind { get; }
+
+    public bool Enabled { get; }
+
+    public string Url { get; }
+
+    public SyncSecret Token { get; }
+
+    public SyncOverride<string> Proxy { get; }
+
+    public SyncOverride<bool> VerifySsl { get; }
+
+    public SyncOverride<bool> AllowUnsafeTlsWithoutCertificateValidation { get; }
+
+    public IReadOnlyDictionary<SyncDataKind, SyncOverride<bool>> DataOverrides => dataOverrides;
+
+    public SyncOverride<bool> BattlelogEnrichment { get; }
+
+    public SyncOverride<string> FleetRuntimeMode { get; }
+
+    public static SyncTargetDraft Create(string name, SyncTargetKind kind)
+    {
+        var definition = SyncTargetTypeCatalog.Get(kind);
+        return new(
+            kind == SyncTargetKind.LocalSidecar ? SyncDesiredTopology.LocalSidecarIdentity : name,
+            kind,
+            false,
+            definition.DefaultUrl,
+            SyncSecret.Missing,
+            SyncOverride.Inherited<string>(),
+            SyncOverride.Inherited<bool>(),
+            SyncOverride.Inherited<bool>());
+    }
+
+    public SyncTargetDraft WithIdentity(string name) => Copy(name: name);
+
+    public SyncTargetDraft WithKind(SyncTargetKind kind) => Copy(kind: kind);
+
+    public SyncTargetDraft WithEnabled(bool enabled) => Copy(enabled: enabled);
+
+    public SyncTargetDraft WithConnection(string url, SyncSecret token) => Copy(url: url, token: token);
+
+    public SyncTargetDraft WithProxy(SyncOverride<string> value) => Copy(proxy: value);
+
+    public SyncTargetDraft WithVerifySsl(SyncOverride<bool> value) => Copy(verifySsl: value);
+
+    public SyncTargetDraft WithUnsafeTls(SyncOverride<bool> value) =>
+        Copy(allowUnsafeTlsWithoutCertificateValidation: value);
+
+    public SyncTargetDraft WithBattlelogEnrichment(SyncOverride<bool> value) =>
+        Copy(battlelogEnrichment: value);
+
+    public SyncTargetDraft WithFleetRuntimeMode(SyncOverride<string> value) =>
+        Copy(fleetRuntimeMode: value);
+
+    public SyncTargetDraft WithDataOverride(SyncDataKind kind, SyncOverride<bool> value)
+    {
+        var changed = dataOverrides.ToDictionary(item => item.Key, item => item.Value);
+        if (value.IsExplicit)
+        {
+            changed[kind] = value;
+        }
+        else
+        {
+            changed.Remove(kind);
+        }
+
+        return Copy(dataOverrides: changed);
+    }
+
+    public SyncTargetDraft WithoutSecret() => Copy(token: SyncSecret.Missing);
+
+    private SyncTargetDraft Copy(
+        string? name = null,
+        SyncTargetKind? kind = null,
+        bool? enabled = null,
+        string? url = null,
+        SyncSecret? token = null,
+        SyncOverride<string>? proxy = null,
+        SyncOverride<bool>? verifySsl = null,
+        SyncOverride<bool>? allowUnsafeTlsWithoutCertificateValidation = null,
+        IReadOnlyDictionary<SyncDataKind, SyncOverride<bool>>? dataOverrides = null,
+        SyncOverride<bool>? battlelogEnrichment = null,
+        SyncOverride<string>? fleetRuntimeMode = null) =>
+        new(
+            name ?? Name,
+            kind ?? Kind,
+            enabled ?? Enabled,
+            url ?? Url,
+            token ?? Token,
+            proxy ?? Proxy,
+            verifySsl ?? VerifySsl,
+            allowUnsafeTlsWithoutCertificateValidation ?? AllowUnsafeTlsWithoutCertificateValidation,
+            dataOverrides ?? this.dataOverrides,
+            battlelogEnrichment ?? BattlelogEnrichment,
+            fleetRuntimeMode ?? FleetRuntimeMode);
+}
+
+public sealed record SyncTopologyDiagnostic(
+    string Code,
+    SyncTopologyDiagnosticSeverity Severity,
+    string Message,
+    string? TargetName = null,
+    string? Field = null);
+
+public sealed record SyncResolvedTarget(
+    string Name,
+    SyncTargetKind Kind,
+    bool Enabled,
+    string Url,
+    bool CredentialsConfigured,
+    SyncResolvedValue<string> Proxy,
+    SyncResolvedValue<bool> VerifySsl,
+    SyncResolvedValue<bool> AllowUnsafeTlsWithoutCertificateValidation,
+    IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> DataKinds,
+    SyncResolvedValue<bool>? BattlelogEnrichment,
+    SyncResolvedValue<string>? FleetRuntimeMode);
+
+public sealed record SyncResolvedTopology(
+    IReadOnlyList<SyncResolvedTarget> Targets,
+    IReadOnlyList<SyncTopologyDiagnostic> Diagnostics)
+{
+    public bool IsCommittable => Diagnostics.All(item => item.Severity != SyncTopologyDiagnosticSeverity.Error);
+}
+
+public sealed record SyncTopologyTransitionResult(
+    bool Succeeded,
+    SyncDesiredTopology Topology,
+    SyncTopologyDiagnostic? Diagnostic = null);

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
@@ -51,6 +51,12 @@ public enum SyncTopologyDiagnosticSeverity
     Error,
 }
 
+public enum SyncTargetKindChangePolicy
+{
+    PreserveCompatibleOverrides,
+    ResetOverrides,
+}
+
 public readonly record struct SyncOverride<T>(bool IsExplicit, T Value)
 {
     public SyncResolvedValue<T> Resolve(T inheritedValue, SyncValueSource inheritedSource)
@@ -68,6 +74,8 @@ public readonly record struct SyncOverride<T>(bool IsExplicit, T Value)
         };
         return new(Value, provenance, SyncValueSource.Target);
     }
+
+    public override string ToString() => IsExplicit ? "[explicit]" : "[inherited]";
 }
 
 public static class SyncOverride
@@ -80,7 +88,10 @@ public static class SyncOverride
 public sealed record SyncResolvedValue<T>(
     T Value,
     SyncValueProvenance Provenance,
-    SyncValueSource Source);
+    SyncValueSource Source)
+{
+    public override string ToString() => $"[{Provenance} from {Source}]";
+}
 
 public sealed class SyncSecret : IEquatable<SyncSecret>
 {
@@ -347,6 +358,15 @@ public sealed class SyncTargetDraft
 
     public SyncTargetDraft WithoutSecret() => Copy(token: SyncSecret.Missing);
 
+    public SyncTargetDraft WithoutOverrides() =>
+        Copy(
+            proxy: SyncOverride.Inherited<string>(),
+            verifySsl: SyncOverride.Inherited<bool>(),
+            allowUnsafeTlsWithoutCertificateValidation: SyncOverride.Inherited<bool>(),
+            dataOverrides: new Dictionary<SyncDataKind, SyncOverride<bool>>(),
+            battlelogEnrichment: SyncOverride.Inherited<bool>(),
+            fleetRuntimeMode: SyncOverride.Inherited<string>());
+
     private SyncTargetDraft Copy(
         string? name = null,
         SyncTargetKind? kind = null,
@@ -380,18 +400,45 @@ public sealed record SyncTopologyDiagnostic(
     string? TargetName = null,
     string? Field = null);
 
-public sealed record SyncResolvedTarget(
-    string Name,
-    SyncTargetKind Kind,
-    bool Enabled,
-    string Url,
-    bool CredentialsConfigured,
-    SyncResolvedValue<string> Proxy,
-    SyncResolvedValue<bool> VerifySsl,
-    SyncResolvedValue<bool> AllowUnsafeTlsWithoutCertificateValidation,
-    IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> DataKinds,
-    SyncResolvedValue<bool>? BattlelogEnrichment,
-    SyncResolvedValue<string>? FleetRuntimeMode);
+public sealed class SyncResolvedTarget(
+    string name,
+    SyncTargetKind kind,
+    bool enabled,
+    string url,
+    bool credentialsConfigured,
+    SyncResolvedValue<string> proxy,
+    SyncResolvedValue<bool> verifySsl,
+    SyncResolvedValue<bool> allowUnsafeTlsWithoutCertificateValidation,
+    IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> dataKinds,
+    SyncResolvedValue<bool>? battlelogEnrichment,
+    SyncResolvedValue<string>? fleetRuntimeMode)
+{
+    public string Name { get; } = name;
+
+    public SyncTargetKind Kind { get; } = kind;
+
+    public bool Enabled { get; } = enabled;
+
+    public string Url { get; } = url;
+
+    public bool CredentialsConfigured { get; } = credentialsConfigured;
+
+    public SyncResolvedValue<string> Proxy { get; } = proxy;
+
+    public SyncResolvedValue<bool> VerifySsl { get; } = verifySsl;
+
+    public SyncResolvedValue<bool> AllowUnsafeTlsWithoutCertificateValidation { get; } =
+        allowUnsafeTlsWithoutCertificateValidation;
+
+    public IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> DataKinds { get; } = dataKinds;
+
+    public SyncResolvedValue<bool>? BattlelogEnrichment { get; } = battlelogEnrichment;
+
+    public SyncResolvedValue<string>? FleetRuntimeMode { get; } = fleetRuntimeMode;
+
+    public override string ToString() =>
+        $"{Name} ({Kind}, {(Enabled ? "enabled" : "disabled")}, credentials {(CredentialsConfigured ? "configured" : "missing")})";
+}
 
 public sealed record SyncResolvedTopology(
     IReadOnlyList<SyncResolvedTarget> Targets,

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
@@ -510,6 +510,16 @@ public sealed class SyncTopologyPersistenceWorkspace
 
     public ConfigurationDocumentRevision BaselineRevision => snapshot.Revision;
 
+    public bool HasLegacyRootTarget => baseline.HasLegacyRootTarget;
+
+    public SyncTopologyPersistencePlan PreparePlan(bool migrateLegacyRoot = false) =>
+        SyncTopologyPersistencePlanner.Build(
+            baseline,
+            Desired,
+            renames,
+            kindChangeDecisions,
+            migrateLegacyRoot);
+
     public static SyncTopologyTomlLoadResult Load(
         ConfigurationDocumentSnapshot snapshot,
         out SyncTopologyPersistenceWorkspace? workspace,
@@ -556,12 +566,7 @@ public sealed class SyncTopologyPersistenceWorkspace
         bool migrateLegacyRoot = false,
         CancellationToken cancellationToken = default)
     {
-        var plan = SyncTopologyPersistencePlanner.Build(
-            baseline,
-            Desired,
-            renames,
-            kindChangeDecisions,
-            migrateLegacyRoot);
+        var plan = PreparePlan(migrateLegacyRoot);
         if (!plan.IsValid)
         {
             return new(AtomicTomlWriteState.Invalid, Plan: plan);

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
@@ -1,0 +1,606 @@
+using System.Collections.ObjectModel;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public enum SyncTomlMutationKind
+{
+    SetOverride,
+    ClearOverride,
+    RenameTable,
+    RemoveTable,
+}
+
+public sealed class SyncTomlMutation
+{
+    private SyncTomlMutation(
+        SyncTomlMutationKind kind,
+        string path,
+        string? renderedValue,
+        string? destinationPath,
+        bool containsSecret)
+    {
+        Kind = kind;
+        Path = path;
+        RenderedValue = renderedValue;
+        DestinationPath = destinationPath;
+        ContainsSecret = containsSecret;
+    }
+
+    public SyncTomlMutationKind Kind { get; }
+
+    public string Path { get; }
+
+    public string? DestinationPath { get; }
+
+    public bool ContainsSecret { get; }
+
+    internal string? RenderedValue { get; }
+
+    internal static SyncTomlMutation Set(string path, string renderedValue, bool containsSecret = false) =>
+        new(SyncTomlMutationKind.SetOverride, path, renderedValue, null, containsSecret);
+
+    internal static SyncTomlMutation Clear(string path) =>
+        new(SyncTomlMutationKind.ClearOverride, path, null, null, false);
+
+    internal static SyncTomlMutation Rename(string path, string destinationPath) =>
+        new(SyncTomlMutationKind.RenameTable, path, null, destinationPath, false);
+
+    internal static SyncTomlMutation Remove(string path) =>
+        new(SyncTomlMutationKind.RemoveTable, path, null, null, false);
+
+    public override string ToString() =>
+        Kind switch
+        {
+            SyncTomlMutationKind.RenameTable => $"{Kind}: {Path} -> {DestinationPath}",
+            SyncTomlMutationKind.SetOverride when ContainsSecret => $"{Kind}: {Path} [secret]",
+            _ => $"{Kind}: {Path}",
+        };
+}
+
+public sealed record SyncTopologyPersistencePlan(
+    bool IsValid,
+    IReadOnlyList<SyncTomlMutation> Mutations,
+    IReadOnlyList<SyncTopologyDiagnostic> Diagnostics)
+{
+    public SparseTomlEditResult Apply(byte[] baselineContents)
+    {
+        ArgumentNullException.ThrowIfNull(baselineContents);
+        if (!IsValid)
+        {
+            return SparseTomlEditResult.Invalid(
+                new(
+                    SparseTomlErrorCode.InvalidValue,
+                    "The sync topology contains persistence errors and was not applied."));
+        }
+
+        byte[] contents = [.. baselineContents];
+        var changed = false;
+        foreach (var mutation in Mutations)
+        {
+            var load = SparseTomlDocument.Load(contents, out var document);
+            if (!load.IsValid || document is null)
+            {
+                return load;
+            }
+
+            var edit = mutation.Kind switch
+            {
+                SyncTomlMutationKind.SetOverride when mutation.RenderedValue is not null =>
+                    document.SetOverride(mutation.Path, mutation.RenderedValue),
+                SyncTomlMutationKind.ClearOverride => document.RemoveOverride(mutation.Path),
+                SyncTomlMutationKind.RenameTable when mutation.DestinationPath is not null =>
+                    document.RenameTable(mutation.Path, mutation.DestinationPath),
+                SyncTomlMutationKind.RemoveTable => document.RemoveTable(mutation.Path),
+                _ => SparseTomlEditResult.Invalid(
+                    new(SparseTomlErrorCode.InvalidValue, $"Mutation '{mutation.Kind}' is incomplete.")),
+            };
+            if (!edit.IsValid || edit.Contents is null)
+            {
+                return edit;
+            }
+
+            contents = edit.Contents;
+            changed |= edit.Changed;
+        }
+
+        return changed
+            ? SparseTomlEditResult.Updated(contents)
+            : SparseTomlEditResult.Unchanged(contents);
+    }
+}
+
+public static class SyncTopologyPersistencePlanner
+{
+    public static SyncTopologyPersistencePlan Build(
+        SyncTopologyTomlLoadResult baseline,
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string>? renames = null,
+        IReadOnlyDictionary<string, SyncTargetKindChangePolicy>? kindChangeDecisions = null,
+        bool migrateLegacyRoot = false)
+    {
+        ArgumentNullException.ThrowIfNull(baseline);
+        ArgumentNullException.ThrowIfNull(desired);
+        if (!baseline.IsValid || baseline.Topology is null)
+        {
+            return Invalid("SYNC_BASELINE_INVALID", "The baseline sync topology is invalid.");
+        }
+
+        var diagnostics = baseline.Diagnostics.Concat(desired.Resolve().Diagnostics).ToList();
+        foreach (var target in desired.Targets.Values.Where(target =>
+                     target.Kind != SyncTargetKind.LocalSidecar && !target.Enabled))
+        {
+            diagnostics.Add(Error(
+                "SYNC_EXTERNAL_DISABLED_PERSISTENCE_REQUIRED",
+                target.Name,
+                "enabled",
+                "External targets cannot be persisted as disabled; remove the target or keep it enabled."));
+        }
+
+        var renameMap = renames?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        var kindDecisions = kindChangeDecisions?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal);
+        ValidateRenames(baseline.Topology, desired, renameMap, diagnostics);
+        ValidateKindChanges(baseline.Topology, desired, renameMap, kindDecisions, diagnostics);
+        if (diagnostics.Any(item => item.Severity == SyncTopologyDiagnosticSeverity.Error))
+        {
+            return new(false, [], diagnostics.AsReadOnly());
+        }
+
+        var mutations = new List<SyncTomlMutation>();
+        AddGlobalChanges(mutations, baseline.Topology.GlobalDefaults, desired.GlobalDefaults);
+
+        var baselineTargets = baseline.Topology.Targets;
+        var consumedDesired = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (baselineName, baselineTarget) in baselineTargets)
+        {
+            var desiredName = renameMap.GetValueOrDefault(baselineName, baselineName);
+            var hasDesired = desired.Targets.TryGetValue(desiredName, out var desiredTarget);
+            var isLegacyVirtual = baseline.HasLegacyRootTarget
+                && string.Equals(baselineName, "default", StringComparison.Ordinal);
+
+            if (!hasDesired)
+            {
+                if (isLegacyVirtual)
+                {
+                    mutations.Add(SyncTomlMutation.Clear("sync.url"));
+                    mutations.Add(SyncTomlMutation.Clear("sync.token"));
+                }
+                else
+                {
+                    mutations.Add(SyncTomlMutation.Remove(TargetRoot(baselineTarget)));
+                }
+
+                continue;
+            }
+
+            consumedDesired.Add(desiredName);
+            if (isLegacyVirtual)
+            {
+                var changed = !TargetsEquivalent(baselineTarget, desiredTarget!);
+                var renamed = !string.Equals(baselineName, desiredName, StringComparison.Ordinal);
+                if ((changed || renamed) && !migrateLegacyRoot)
+                {
+                    diagnostics.Add(Error(
+                        "SYNC_LEGACY_MIGRATION_REQUIRED",
+                        desiredName,
+                        null,
+                        "Editing or renaming the virtual legacy target requires explicit migration confirmation."));
+                    continue;
+                }
+
+                if (changed || renamed)
+                {
+                    mutations.Add(SyncTomlMutation.Clear("sync.url"));
+                    mutations.Add(SyncTomlMutation.Clear("sync.token"));
+                    AddTarget(mutations, desiredTarget!);
+                }
+
+                continue;
+            }
+
+            if (!string.Equals(baselineName, desiredName, StringComparison.Ordinal))
+            {
+                mutations.Add(SyncTomlMutation.Rename(TargetRoot(baselineTarget), TargetRoot(desiredTarget!)));
+            }
+
+            AddTargetChanges(mutations, baselineTarget, desiredTarget!);
+        }
+
+        foreach (var (name, target) in desired.Targets)
+        {
+            if (!consumedDesired.Contains(name))
+            {
+                AddTarget(mutations, target);
+            }
+        }
+
+        var valid = diagnostics.All(item => item.Severity != SyncTopologyDiagnosticSeverity.Error);
+        return new(valid, valid ? mutations.AsReadOnly() : [], diagnostics.AsReadOnly());
+    }
+
+    private static void AddGlobalChanges(
+        List<SyncTomlMutation> mutations,
+        SyncGlobalDefaults baseline,
+        SyncGlobalDefaults desired)
+    {
+        AddChanged(mutations, "sync.proxy", baseline.Proxy, desired.Proxy);
+        AddChanged(mutations, "sync.verify_ssl", baseline.VerifySsl, desired.VerifySsl);
+        AddChanged(
+            mutations,
+            "sync.allow_unsafe_tls_without_certificate_validation",
+            baseline.AllowUnsafeTlsWithoutCertificateValidation,
+            desired.AllowUnsafeTlsWithoutCertificateValidation);
+        foreach (var (kind, key) in SyncTopologyTomlAdapter.DataKeys)
+        {
+            AddChanged(mutations, $"sync.{key}", baseline.DataKinds[kind], desired.DataKinds[kind]);
+        }
+    }
+
+    private static void AddTarget(List<SyncTomlMutation> mutations, SyncTargetDraft target)
+    {
+        var root = TargetRoot(target);
+        if (target.Kind == SyncTargetKind.LocalSidecar)
+        {
+            mutations.Add(SyncTomlMutation.Set(root + ".enabled", Render(target.Enabled)));
+        }
+        else
+        {
+            mutations.Add(SyncTomlMutation.Set(root + ".mode", LauncherTomlValue.RenderString(Mode(target.Kind))));
+        }
+
+        mutations.Add(SyncTomlMutation.Set(root + ".url", LauncherTomlValue.RenderString(target.Url)));
+        mutations.Add(SyncTomlMutation.Set(
+            root + ".token",
+            LauncherTomlValue.RenderString(target.Token.RevealForPersistence()),
+            containsSecret: true));
+        AddOverride(mutations, root + ".proxy", target.Proxy, LauncherTomlValue.RenderString);
+        AddOverride(mutations, root + ".verify_ssl", target.VerifySsl, Render);
+        AddOverride(
+            mutations,
+            root + ".allow_unsafe_tls_without_certificate_validation",
+            target.AllowUnsafeTlsWithoutCertificateValidation,
+            Render);
+        foreach (var (kind, value) in target.DataOverrides)
+        {
+            AddOverride(mutations, $"{root}.{SyncTopologyTomlAdapter.DataKey(kind)}", value, Render);
+        }
+
+        if (target.Kind == SyncTargetKind.LocalSidecar)
+        {
+            AddOverride(mutations, root + ".battlelog_enrichment", target.BattlelogEnrichment, Render);
+            AddOverride(mutations, root + ".fleet_runtime_mode", target.FleetRuntimeMode, LauncherTomlValue.RenderString);
+        }
+    }
+
+    private static void AddTargetChanges(
+        List<SyncTomlMutation> mutations,
+        SyncTargetDraft baseline,
+        SyncTargetDraft desired)
+    {
+        var root = TargetRoot(desired);
+        if (baseline.Kind != desired.Kind)
+        {
+            mutations.Add(SyncTomlMutation.Set(root + ".mode", LauncherTomlValue.RenderString(Mode(desired.Kind))));
+        }
+
+        if (desired.Kind == SyncTargetKind.LocalSidecar)
+        {
+            AddChanged(mutations, root + ".enabled", baseline.Enabled, desired.Enabled);
+        }
+
+        AddChanged(mutations, root + ".url", baseline.Url, desired.Url);
+        if (!baseline.Token.Equals(desired.Token))
+        {
+            mutations.Add(SyncTomlMutation.Set(
+                root + ".token",
+                LauncherTomlValue.RenderString(desired.Token.RevealForPersistence()),
+                containsSecret: true));
+        }
+
+        AddOverrideChange(mutations, root + ".proxy", baseline.Proxy, desired.Proxy, LauncherTomlValue.RenderString);
+        AddOverrideChange(mutations, root + ".verify_ssl", baseline.VerifySsl, desired.VerifySsl, Render);
+        AddOverrideChange(
+            mutations,
+            root + ".allow_unsafe_tls_without_certificate_validation",
+            baseline.AllowUnsafeTlsWithoutCertificateValidation,
+            desired.AllowUnsafeTlsWithoutCertificateValidation,
+            Render);
+        foreach (var kind in baseline.DataOverrides.Keys.Union(desired.DataOverrides.Keys))
+        {
+            AddOverrideChange(
+                mutations,
+                $"{root}.{SyncTopologyTomlAdapter.DataKey(kind)}",
+                baseline.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>()),
+                desired.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>()),
+                Render);
+        }
+
+        AddOverrideChange(
+            mutations,
+            root + ".battlelog_enrichment",
+            baseline.BattlelogEnrichment,
+            desired.BattlelogEnrichment,
+            Render);
+        AddOverrideChange(
+            mutations,
+            root + ".fleet_runtime_mode",
+            baseline.FleetRuntimeMode,
+            desired.FleetRuntimeMode,
+            LauncherTomlValue.RenderString);
+    }
+
+    private static void AddChanged(List<SyncTomlMutation> mutations, string path, string baseline, string desired)
+    {
+        if (!string.Equals(baseline, desired, StringComparison.Ordinal))
+        {
+            mutations.Add(SyncTomlMutation.Set(path, LauncherTomlValue.RenderString(desired)));
+        }
+    }
+
+    private static void AddChanged(List<SyncTomlMutation> mutations, string path, bool baseline, bool desired)
+    {
+        if (baseline != desired)
+        {
+            mutations.Add(SyncTomlMutation.Set(path, Render(desired)));
+        }
+    }
+
+    private static void AddOverride<T>(
+        List<SyncTomlMutation> mutations,
+        string path,
+        SyncOverride<T> value,
+        Func<T, string> render)
+    {
+        if (value.IsExplicit)
+        {
+            mutations.Add(SyncTomlMutation.Set(path, render(value.Value)));
+        }
+    }
+
+    private static void AddOverrideChange<T>(
+        List<SyncTomlMutation> mutations,
+        string path,
+        SyncOverride<T> baseline,
+        SyncOverride<T> desired,
+        Func<T, string> render)
+    {
+        if (baseline.Equals(desired))
+        {
+            return;
+        }
+
+        mutations.Add(desired.IsExplicit
+            ? SyncTomlMutation.Set(path, render(desired.Value))
+            : SyncTomlMutation.Clear(path));
+    }
+
+    private static void ValidateRenames(
+        SyncDesiredTopology baseline,
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string> renames,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var destinations = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (source, destination) in renames)
+        {
+            if (!baseline.Targets.ContainsKey(source)
+                || !desired.Targets.ContainsKey(destination)
+                || !destinations.Add(destination))
+            {
+                diagnostics.Add(Error(
+                    "SYNC_RENAME_INVALID",
+                    source,
+                    "identity",
+                    "The target rename does not match the baseline and desired topology."));
+            }
+        }
+    }
+
+    private static void ValidateKindChanges(
+        SyncDesiredTopology baseline,
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string> renames,
+        Dictionary<string, SyncTargetKindChangePolicy> decisions,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        foreach (var (baselineName, baselineTarget) in baseline.Targets)
+        {
+            var desiredName = renames.GetValueOrDefault(baselineName, baselineName);
+            if (!desired.Targets.TryGetValue(desiredName, out var desiredTarget)
+                || baselineTarget.Kind == desiredTarget.Kind)
+            {
+                continue;
+            }
+
+            if (!decisions.TryGetValue(desiredName, out var decision))
+            {
+                diagnostics.Add(Error(
+                    "SYNC_KIND_CHANGE_DECISION_REQUIRED",
+                    desiredName,
+                    "kind",
+                    "Changing target kind requires an explicit preserve-or-reset decision."));
+                continue;
+            }
+
+            if (decision == SyncTargetKindChangePolicy.ResetOverrides && HasExplicitOverrides(desiredTarget))
+            {
+                diagnostics.Add(Error(
+                    "SYNC_KIND_CHANGE_RESET_MISMATCH",
+                    desiredName,
+                    "kind",
+                    "The reset decision requires all target overrides to use inherited values."));
+            }
+        }
+    }
+
+    private static bool HasExplicitOverrides(SyncTargetDraft target) =>
+        target.Proxy.IsExplicit
+        || target.VerifySsl.IsExplicit
+        || target.AllowUnsafeTlsWithoutCertificateValidation.IsExplicit
+        || target.BattlelogEnrichment.IsExplicit
+        || target.FleetRuntimeMode.IsExplicit
+        || target.DataOverrides.Values.Any(value => value.IsExplicit);
+
+    private static bool TargetsEquivalent(SyncTargetDraft left, SyncTargetDraft right) =>
+        left.Kind == right.Kind
+        && left.Enabled == right.Enabled
+        && string.Equals(left.Url, right.Url, StringComparison.Ordinal)
+        && left.Token.Equals(right.Token)
+        && left.Proxy.Equals(right.Proxy)
+        && left.VerifySsl.Equals(right.VerifySsl)
+        && left.AllowUnsafeTlsWithoutCertificateValidation.Equals(right.AllowUnsafeTlsWithoutCertificateValidation)
+        && left.BattlelogEnrichment.Equals(right.BattlelogEnrichment)
+        && left.FleetRuntimeMode.Equals(right.FleetRuntimeMode)
+        && left.DataOverrides.Count == right.DataOverrides.Count
+        && left.DataOverrides.All(item => right.DataOverrides.TryGetValue(item.Key, out var value) && value.Equals(item.Value));
+
+    private static string TargetRoot(SyncTargetDraft target) =>
+        target.Kind == SyncTargetKind.LocalSidecar
+            ? "sidecar.sync"
+            : $"sync.targets.{target.Name}";
+
+    private static string Mode(SyncTargetKind kind) =>
+        kind == SyncTargetKind.MajelIngest ? "majel" : "legacy";
+
+    private static string Render(bool value) => value ? "true" : "false";
+
+    private static SyncTopologyPersistencePlan Invalid(string code, string message) =>
+        new(false, [], [Error(code, null, null, message)]);
+
+    private static SyncTopologyDiagnostic Error(string code, string? targetName, string? field, string message) =>
+        new(code, SyncTopologyDiagnosticSeverity.Error, message, targetName, field);
+}
+
+public sealed record SyncTopologyPersistenceCommitResult(
+    AtomicTomlWriteState State,
+    ConfigurationDocumentSnapshot? Snapshot = null,
+    SyncTopologyPersistencePlan? Plan = null,
+    string? BackupPath = null,
+    SparseTomlError? ValidationError = null,
+    string? Error = null);
+
+public sealed class SyncTopologyPersistenceWorkspace
+{
+    private readonly AtomicTomlStore store;
+    private SyncTopologyTomlLoadResult baseline;
+    private ConfigurationDocumentSnapshot snapshot;
+    private IReadOnlyDictionary<string, string> renames = new ReadOnlyDictionary<string, string>(
+        new Dictionary<string, string>(StringComparer.Ordinal));
+    private IReadOnlyDictionary<string, SyncTargetKindChangePolicy> kindChangeDecisions =
+        new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+
+    private SyncTopologyPersistenceWorkspace(
+        ConfigurationDocumentSnapshot snapshot,
+        SyncTopologyTomlLoadResult baseline,
+        AtomicTomlStore store)
+    {
+        this.snapshot = snapshot;
+        this.baseline = baseline;
+        this.store = store;
+        Desired = baseline.Topology!;
+    }
+
+    public SyncDesiredTopology Desired { get; private set; }
+
+    public bool HasPendingChanges { get; private set; }
+
+    public bool IsStale { get; private set; }
+
+    public ConfigurationDocumentRevision BaselineRevision => snapshot.Revision;
+
+    public static SyncTopologyTomlLoadResult Load(
+        ConfigurationDocumentSnapshot snapshot,
+        out SyncTopologyPersistenceWorkspace? workspace,
+        AtomicTomlStore? store = null)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        var load = SyncTopologyTomlAdapter.Load(snapshot.Contents);
+        workspace = load.IsValid && load.Topology is not null
+            ? new(snapshot, load, store ?? new AtomicTomlStore())
+            : null;
+        return load;
+    }
+
+    public void Stage(
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string>? targetRenames = null,
+        IReadOnlyDictionary<string, SyncTargetKindChangePolicy>? targetKindChangeDecisions = null)
+    {
+        Desired = desired ?? throw new ArgumentNullException(nameof(desired));
+        renames = new ReadOnlyDictionary<string, string>(
+            targetRenames?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, string>(StringComparer.Ordinal));
+        kindChangeDecisions = new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            targetKindChangeDecisions?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+        var plan = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            Desired,
+            renames,
+            kindChangeDecisions);
+        HasPendingChanges = !plan.IsValid || plan.Mutations.Count > 0;
+    }
+
+    public void Discard()
+    {
+        Desired = baseline.Topology!;
+        renames = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.Ordinal));
+        kindChangeDecisions = new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+        HasPendingChanges = false;
+    }
+
+    public async Task<SyncTopologyPersistenceCommitResult> CommitAsync(
+        bool migrateLegacyRoot = false,
+        CancellationToken cancellationToken = default)
+    {
+        var plan = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            Desired,
+            renames,
+            kindChangeDecisions,
+            migrateLegacyRoot);
+        if (!plan.IsValid)
+        {
+            return new(AtomicTomlWriteState.Invalid, Plan: plan);
+        }
+
+        var edit = plan.Apply(snapshot.Contents);
+        if (!edit.IsValid || edit.Contents is null)
+        {
+            return new(AtomicTomlWriteState.Invalid, Plan: plan, ValidationError: edit.Error);
+        }
+
+        var write = await store.SaveDocumentAsync(
+            snapshot.Path,
+            snapshot.Contents,
+            edit.Contents,
+            cancellationToken).ConfigureAwait(false);
+        if (!write.IsSuccess)
+        {
+            if (write.State == AtomicTomlWriteState.Conflict)
+            {
+                IsStale = true;
+            }
+
+            return new(
+                write.State,
+                Plan: plan,
+                BackupPath: write.BackupPath,
+                ValidationError: write.ValidationError,
+                Error: write.Error);
+        }
+
+        snapshot = new ConfigurationDocumentSnapshot(snapshot.Path, edit.Contents);
+        baseline = SyncTopologyTomlAdapter.Load(edit.Contents);
+        Desired = baseline.Topology!;
+        renames = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.Ordinal));
+        kindChangeDecisions = new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+        HasPendingChanges = false;
+        IsStale = false;
+        return new(write.State, snapshot, plan, write.BackupPath);
+    }
+}

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyTomlAdapter.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyTomlAdapter.cs
@@ -1,0 +1,370 @@
+using System.Collections.ObjectModel;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public sealed record SyncTopologyTomlLoadResult(
+    bool IsValid,
+    SyncDesiredTopology? Topology,
+    IReadOnlyList<SyncTopologyDiagnostic> Diagnostics,
+    bool HasLegacyRootTarget,
+    SparseTomlError? Error = null);
+
+public static class SyncTopologyTomlAdapter
+{
+    private static readonly ReadOnlyDictionary<SyncDataKind, string> DataKindKeys =
+        new(
+            new Dictionary<SyncDataKind, string>
+            {
+                [SyncDataKind.Battlelogs] = "battlelogs",
+                [SyncDataKind.BattlelogsRealtime] = "battlelogs_realtime",
+                [SyncDataKind.Buffs] = "buffs",
+                [SyncDataKind.Buildings] = "buildings",
+                [SyncDataKind.Inventory] = "inventory",
+                [SyncDataKind.Jobs] = "jobs",
+                [SyncDataKind.Missions] = "missions",
+                [SyncDataKind.Officer] = "officer",
+                [SyncDataKind.Research] = "research",
+                [SyncDataKind.Resources] = "resources",
+                [SyncDataKind.Ships] = "ships",
+                [SyncDataKind.Slots] = "slots",
+                [SyncDataKind.Tech] = "tech",
+                [SyncDataKind.Traits] = "traits",
+                [SyncDataKind.FleetRuntime] = "fleet_runtime",
+            });
+
+    public static SyncGlobalDefaults NativeGlobalDefaults { get; } =
+        new SyncGlobalDefaults(
+            string.Empty,
+            true,
+            false,
+            new Dictionary<SyncDataKind, bool>
+            {
+                [SyncDataKind.Battlelogs] = true,
+                [SyncDataKind.BattlelogsRealtime] = false,
+                [SyncDataKind.Buffs] = true,
+                [SyncDataKind.Buildings] = true,
+                [SyncDataKind.FleetRuntime] = false,
+                [SyncDataKind.Inventory] = true,
+                [SyncDataKind.Jobs] = true,
+                [SyncDataKind.Missions] = true,
+                [SyncDataKind.Officer] = true,
+                [SyncDataKind.Research] = true,
+                [SyncDataKind.Resources] = true,
+                [SyncDataKind.Ships] = true,
+                [SyncDataKind.Slots] = true,
+                [SyncDataKind.Tech] = true,
+                [SyncDataKind.Traits] = true,
+            });
+
+    public static IReadOnlyDictionary<SyncDataKind, string> DataKeys => DataKindKeys;
+
+    public static SyncTopologyTomlLoadResult Load(
+        byte[] contents,
+        SyncGlobalDefaults? nativeDefaults = null)
+    {
+        ArgumentNullException.ThrowIfNull(contents);
+        var load = SparseTomlDocument.Load(contents, out var document);
+        if (!load.IsValid || document is null)
+        {
+            return Invalid(load.Error);
+        }
+
+        var read = document.ReadOverrides();
+        if (!read.IsValid || read.Overrides is null)
+        {
+            return Invalid(read.Error);
+        }
+
+        var diagnostics = new List<SyncTopologyDiagnostic>();
+        var overrides = read.Overrides;
+        var globals = ReadGlobals(overrides, nativeDefaults ?? NativeGlobalDefaults, diagnostics);
+        var targets = new Dictionary<string, SyncTargetDraft>(StringComparer.Ordinal);
+
+        ReadSidecar(overrides, targets, diagnostics);
+        ReadExternalTargets(overrides, read.Tables ?? [], targets, diagnostics);
+        var hasLegacyRootTarget = ReadLegacyRootTarget(overrides, targets, diagnostics);
+
+        return new(
+            true,
+            new SyncDesiredTopology(globals, targets),
+            diagnostics.AsReadOnly(),
+            hasLegacyRootTarget);
+    }
+
+    internal static string DataKey(SyncDataKind kind) => DataKindKeys[kind];
+
+    private static SyncGlobalDefaults ReadGlobals(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        SyncGlobalDefaults defaults,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var proxy = ReadString(overrides, "sync.proxy", defaults.Proxy, diagnostics, null);
+        var verifySsl = ReadBoolean(overrides, "sync.verify_ssl", defaults.VerifySsl, diagnostics, null);
+        var unsafeTls = ReadBoolean(
+            overrides,
+            "sync.allow_unsafe_tls_without_certificate_validation",
+            defaults.AllowUnsafeTlsWithoutCertificateValidation,
+            diagnostics,
+            null);
+        var dataKinds = defaults.DataKinds.ToDictionary(item => item.Key, item => item.Value);
+        foreach (var (kind, key) in DataKindKeys)
+        {
+            dataKinds[kind] = ReadBoolean(overrides, $"sync.{key}", dataKinds[kind], diagnostics, null);
+        }
+
+        return new(proxy, verifySsl, unsafeTls, dataKinds);
+    }
+
+    private static void ReadSidecar(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        Dictionary<string, SyncTargetDraft> targets,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        const string prefix = "sidecar.sync.";
+        if (!overrides.Keys.Any(path => path.StartsWith(prefix, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        var target = SyncTargetDraft.Create(
+            SyncDesiredTopology.LocalSidecarIdentity,
+            SyncTargetKind.LocalSidecar);
+        var url = ReadString(overrides, prefix + "url", target.Url, diagnostics, target.Name);
+        var token = ReadSecret(overrides, prefix + "token", diagnostics, target.Name);
+        target = target
+            .WithEnabled(ReadBoolean(overrides, prefix + "enabled", false, diagnostics, target.Name))
+            .WithConnection(url, token)
+            .WithProxy(ReadStringOverride(overrides, prefix + "proxy", diagnostics, target.Name))
+            .WithVerifySsl(ReadBooleanOverride(overrides, prefix + "verify_ssl", diagnostics, target.Name))
+            .WithUnsafeTls(ReadBooleanOverride(
+                overrides,
+                prefix + "allow_unsafe_tls_without_certificate_validation",
+                diagnostics,
+                target.Name))
+            .WithDataOverride(
+                SyncDataKind.BattlelogsRealtime,
+                ReadBooleanOverride(overrides, prefix + "battlelogs_realtime", diagnostics, target.Name))
+            .WithDataOverride(
+                SyncDataKind.FleetRuntime,
+                ReadBooleanOverride(overrides, prefix + "fleet_runtime", diagnostics, target.Name))
+            .WithBattlelogEnrichment(
+                ReadBooleanOverride(overrides, prefix + "battlelog_enrichment", diagnostics, target.Name))
+            .WithFleetRuntimeMode(
+                ReadStringOverride(overrides, prefix + "fleet_runtime_mode", diagnostics, target.Name));
+        targets.Add(target.Name, target);
+    }
+
+    private static void ReadExternalTargets(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        IReadOnlyList<SparseTomlTable> tables,
+        Dictionary<string, SyncTargetDraft> targets,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var names = overrides.Keys
+            .Where(path => path.StartsWith("sync.targets.", StringComparison.Ordinal))
+            .Select(path => path.Split('.'))
+            .Where(parts => parts.Length >= 4)
+            .Select(parts => parts[2])
+            .Concat(
+                tables
+                    .Select(table => table.CanonicalPath.Split('.'))
+                    .Where(parts => parts.Length >= 3
+                        && parts[0] == "sync"
+                        && parts[1] == "targets")
+                    .Select(parts => parts[2]))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal);
+        foreach (var name in names)
+        {
+            var prefix = $"sync.targets.{name}.";
+            var mode = ReadString(overrides, prefix + "mode", "legacy", diagnostics, name);
+            var kind = mode switch
+            {
+                "majel" => SyncTargetKind.MajelIngest,
+                "legacy" or "" => SyncTargetKind.LegacyCommunity,
+                _ => SyncTargetKind.LegacyCommunity,
+            };
+            if (mode == "sidecar_broker")
+            {
+                diagnostics.Add(new(
+                    "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID",
+                    SyncTopologyDiagnosticSeverity.Error,
+                    "Sidecar broker mode is invalid under external sync targets; use the local Sidecar target.",
+                    name,
+                    "mode"));
+            }
+            else if (mode is not ("legacy" or "majel" or ""))
+            {
+                diagnostics.Add(new(
+                    "SYNC_TARGET_MODE_INVALID",
+                    SyncTopologyDiagnosticSeverity.Warning,
+                    "The target mode is unknown and resolves as legacy until explicitly corrected.",
+                    name,
+                    "mode"));
+            }
+
+            var target = SyncTargetDraft.Create(name, kind)
+                .WithEnabled(true)
+                .WithConnection(
+                    ReadString(overrides, prefix + "url", string.Empty, diagnostics, name),
+                    ReadSecret(overrides, prefix + "token", diagnostics, name))
+                .WithProxy(ReadStringOverride(overrides, prefix + "proxy", diagnostics, name))
+                .WithVerifySsl(ReadBooleanOverride(overrides, prefix + "verify_ssl", diagnostics, name))
+                .WithUnsafeTls(ReadBooleanOverride(
+                    overrides,
+                    prefix + "allow_unsafe_tls_without_certificate_validation",
+                    diagnostics,
+                    name));
+            foreach (var (dataKind, key) in DataKindKeys)
+            {
+                target = target.WithDataOverride(
+                    dataKind,
+                    ReadBooleanOverride(overrides, prefix + key, diagnostics, name));
+            }
+
+            targets[name] = target;
+        }
+    }
+
+    private static bool ReadLegacyRootTarget(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        Dictionary<string, SyncTargetDraft> targets,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var hasUrl = TryReadString(overrides, "sync.url", out var url, diagnostics, null);
+        var hasToken = TryReadString(overrides, "sync.token", out var token, diagnostics, null);
+        if (!hasUrl && !hasToken)
+        {
+            return false;
+        }
+
+        if (!hasUrl || !hasToken || string.IsNullOrEmpty(url) || string.IsNullOrEmpty(token))
+        {
+            diagnostics.Add(new(
+                "SYNC_LEGACY_ROOT_INCOMPLETE",
+                SyncTopologyDiagnosticSeverity.Warning,
+                "Legacy root sync credentials are incomplete and do not create a target."));
+            return false;
+        }
+
+        if (targets.ContainsKey("default"))
+        {
+            diagnostics.Add(new(
+                "SYNC_LEGACY_ROOT_CONFLICT",
+                SyncTopologyDiagnosticSeverity.Error,
+                "Legacy root credentials conflict with the named default target.",
+                "default"));
+            return false;
+        }
+
+        var target = SyncTargetDraft.Create("default", SyncTargetKind.LegacyCommunity)
+            .WithEnabled(true)
+            .WithConnection(url, SyncSecret.FromPlainText(token));
+        targets.Add(target.Name, target);
+        diagnostics.Add(new(
+            "SYNC_LEGACY_ROOT_CONVERTED",
+            SyncTopologyDiagnosticSeverity.Info,
+            "Legacy root credentials are represented as a virtual default target without changing the source.",
+            "default"));
+        return true;
+    }
+
+    private static SyncOverride<string> ReadStringOverride(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadString(overrides, path, out var value, diagnostics, targetName)
+            ? SyncOverride.Explicit(value)
+            : SyncOverride.Inherited<string>();
+
+    private static SyncOverride<bool> ReadBooleanOverride(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadBoolean(overrides, path, out var value, diagnostics, targetName)
+            ? SyncOverride.Explicit(value)
+            : SyncOverride.Inherited<bool>();
+
+    private static SyncSecret ReadSecret(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string targetName) =>
+        TryReadString(overrides, path, out var value, diagnostics, targetName)
+            ? SyncSecret.FromPlainText(value)
+            : SyncSecret.Missing;
+
+    private static string ReadString(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        string fallback,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadString(overrides, path, out var value, diagnostics, targetName) ? value : fallback;
+
+    private static bool ReadBoolean(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        bool fallback,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadBoolean(overrides, path, out var value, diagnostics, targetName) ? value : fallback;
+
+    private static bool TryReadString(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        out string value,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName)
+    {
+        value = string.Empty;
+        if (!overrides.TryGetValue(path, out var configured))
+        {
+            return false;
+        }
+
+        if (LauncherTomlValue.TryReadString(configured.RenderedValue, out value))
+        {
+            return true;
+        }
+
+        diagnostics.Add(InvalidValue(path, configured.LineNumber, targetName));
+        return false;
+    }
+
+    private static bool TryReadBoolean(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        out bool value,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName)
+    {
+        value = false;
+        if (!overrides.TryGetValue(path, out var configured))
+        {
+            return false;
+        }
+
+        if (configured.RenderedValue is "true" or "false")
+        {
+            value = configured.RenderedValue == "true";
+            return true;
+        }
+
+        diagnostics.Add(InvalidValue(path, configured.LineNumber, targetName));
+        return false;
+    }
+
+    private static SyncTopologyDiagnostic InvalidValue(string path, int lineNumber, string? targetName) =>
+        new(
+            "SYNC_TOML_VALUE_INVALID",
+            SyncTopologyDiagnosticSeverity.Error,
+            $"'{path}' has an invalid value at line {lineNumber}.",
+            targetName,
+            path[(path.LastIndexOf('.') + 1)..]);
+
+    private static SyncTopologyTomlLoadResult Invalid(SparseTomlError? error) =>
+        new(false, null, [], false, error);
+}

--- a/windows-launcher/src/STFCCommunityMod.Launcher/MainWindow.xaml
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/MainWindow.xaml
@@ -659,7 +659,7 @@
                 </Style>
               </TextBlock.Style>
             </TextBlock>
-            <Button Style="{StaticResource QuietButtonStyle}"
+            <Button MinWidth="124"
                     Click="LaunchGameButton_Click"
                     Content="{Binding LaunchActionLabel}"
                     IsEnabled="{Binding CanLaunchGame}"

--- a/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SettingsViewModel.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SettingsViewModel.cs
@@ -66,6 +66,10 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         discardCommand = new SettingsActionCommand(Discard, () => HasPendingChanges);
         saveCommand = new AsyncSettingsActionCommand(SaveAsync, () => CanSave);
 
+        SyncWorkspace = new(configurationPathProvider, this.repository, () => HasPendingChanges);
+        SyncWorkspace.StateChanged += SyncWorkspace_StateChanged;
+        SyncWorkspace.Committed += SyncWorkspace_Committed;
+
         TryLoadConfiguration();
         projectionQuery = new(catalog, layoutProvider);
         RefreshKeybindingConflicts();
@@ -95,6 +99,8 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
     public ICommand SaveCommand => saveCommand;
 
     public ICommand SearchToggleCommand { get; }
+
+    public SyncWorkspaceViewModel SyncWorkspace { get; }
 
     public string SearchText
     {
@@ -154,7 +160,12 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
     public bool IsGeneralSelected =>
         !IsSearchActive && selectedSection == LauncherSettingsSection.General;
 
-    public bool IsSettingsListVisible => !IsAboutSelected;
+    public bool IsDataSyncSelected =>
+        !IsSearchActive && selectedSection == LauncherSettingsSection.DataSync;
+
+    public bool IsSettingsListVisible => !IsAboutSelected && !IsDataSyncSelected;
+
+    public bool IsSettingsFooterVisible => HasPendingChanges && !IsDataSyncSelected;
 
     public int VisibleSettingCount =>
         projectedItems.OfType<SettingsRowViewModel>().Count();
@@ -228,10 +239,13 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         IsConfigurationReady
         && HasPendingChanges
         && !HasInvalidInput
+        && !SyncWorkspace.HasPendingChanges
         && ConfigurationPathMatchesLoadedSession();
 
     public string SaveAvailability =>
-        HasInvalidInput
+        SyncWorkspace.HasPendingChanges
+            ? "Save or discard the pending sync setup before saving other settings."
+            : HasInvalidInput
             ? "Fix the highlighted setting before saving."
             : CanSave
                 ? "Save all staged configuration changes."
@@ -268,6 +282,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
 
         ClearEditorDrafts();
         TryLoadConfiguration();
+        SyncWorkspace.Reload();
         RefreshAllStates();
         NotifySessionChanged();
     }
@@ -327,7 +342,13 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(VisibleItemsSummary));
         OnPropertyChanged(nameof(IsAboutSelected));
         OnPropertyChanged(nameof(IsGeneralSelected));
+        OnPropertyChanged(nameof(IsDataSyncSelected));
         OnPropertyChanged(nameof(IsSettingsListVisible));
+        OnPropertyChanged(nameof(IsSettingsFooterVisible));
+        if (section == LauncherSettingsSection.DataSync)
+        {
+            SyncWorkspace.Reload();
+        }
         RebuildProjection();
     }
 
@@ -519,6 +540,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         if (selectedConfigurationChanged)
         {
             TryLoadConfiguration();
+            SyncWorkspace.Reload();
         }
 
         ClearEditorDrafts();
@@ -526,6 +548,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
             ? "Unsaved changes discarded and the selected configuration reloaded."
             : "Unsaved changes discarded.";
         RefreshAllStates();
+        SyncWorkspace.Reload();
         NotifySessionChanged();
     }
 
@@ -560,6 +583,10 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         };
 
         RefreshAllStates();
+        if (result.IsSuccess)
+        {
+            SyncWorkspace.Reload();
+        }
         NotifySessionChanged();
     }
 
@@ -670,6 +697,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(ConfigurationStatus));
         OnPropertyChanged(nameof(PendingChangeCount));
         OnPropertyChanged(nameof(HasPendingChanges));
+        OnPropertyChanged(nameof(IsSettingsFooterVisible));
         OnPropertyChanged(nameof(PendingChangesText));
         OnPropertyChanged(nameof(PendingApplyTimingText));
         OnPropertyChanged(nameof(HasInvalidInput));
@@ -702,6 +730,26 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         {
             return false;
         }
+    }
+
+    private void SyncWorkspace_StateChanged(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        NotifySessionChanged();
+    }
+
+    private void SyncWorkspace_Committed(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        if (!HasPendingChanges)
+        {
+            TryLoadConfiguration();
+            RefreshAllStates();
+        }
+
+        NotifySessionChanged();
     }
 
     private void RebuildProjection()

--- a/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SyncWorkspaceViewModel.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SyncWorkspaceViewModel.cs
@@ -1,0 +1,621 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.ViewModels;
+
+public enum SyncBooleanOverrideChoice
+{
+    UseGlobal,
+    Enabled,
+    Disabled,
+}
+
+public sealed record SyncOverrideChoice(SyncBooleanOverrideChoice Value, string Label);
+
+public sealed record SyncFleetRuntimeModeOption(string Value, string Label);
+
+public sealed class SyncWorkspaceViewModel : INotifyPropertyChanged
+{
+    private static readonly IReadOnlyList<SyncOverrideChoice> OverrideChoices =
+    [
+        new(SyncBooleanOverrideChoice.UseGlobal, "Use inherited"),
+        new(SyncBooleanOverrideChoice.Enabled, "On"),
+        new(SyncBooleanOverrideChoice.Disabled, "Off"),
+    ];
+
+    private readonly Func<string?> configurationPathProvider;
+    private readonly Func<bool> hasSiblingPendingChanges;
+    private readonly IConfigurationRepository repository;
+    private readonly SettingsActionCommand discardCommand;
+    private readonly AsyncSettingsActionCommand saveCommand;
+    private SyncTopologyPersistenceWorkspace? workspace;
+    private string operationStatus = string.Empty;
+    private string newTargetName = string.Empty;
+    private bool migrateLegacyRoot;
+
+    public SyncWorkspaceViewModel(
+        Func<string?> configurationPathProvider,
+        IConfigurationRepository repository,
+        Func<bool>? hasSiblingPendingChanges = null)
+    {
+        this.configurationPathProvider =
+            configurationPathProvider ?? throw new ArgumentNullException(nameof(configurationPathProvider));
+        this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        this.hasSiblingPendingChanges = hasSiblingPendingChanges ?? (() => false);
+        discardCommand = new(Discard, () => HasPendingChanges);
+        saveCommand = new(SaveAsync, () => CanSave);
+        AddSidecarCommand = new SettingsActionCommand(AddSidecar, () => CanAddSidecar);
+        AddMajelCommand = new SettingsActionCommand(() => AddExternal(SyncTargetKind.MajelIngest));
+        AddLegacyCommand = new SettingsActionCommand(() => AddExternal(SyncTargetKind.LegacyCommunity));
+        AddSpocksClubCommand = new SettingsActionCommand(() => AddPreset("spocks_club"));
+        Reload();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public event EventHandler? StateChanged;
+
+    public event EventHandler? Committed;
+
+    public ObservableCollection<SyncTargetCardViewModel> Targets { get; } = [];
+
+    public ObservableCollection<SyncGlobalFeedViewModel> GlobalFeeds { get; } = [];
+
+    internal static IReadOnlyList<SyncOverrideChoice> BooleanOverrideChoices => OverrideChoices;
+
+    public ICommand AddSidecarCommand { get; }
+
+    public ICommand AddMajelCommand { get; }
+
+    public ICommand AddLegacyCommand { get; }
+
+    public ICommand AddSpocksClubCommand { get; }
+
+    public ICommand DiscardCommand => discardCommand;
+
+    public ICommand SaveCommand => saveCommand;
+
+    public bool IsConfigurationReady => workspace is not null;
+
+    public bool HasPendingChanges => workspace?.HasPendingChanges ?? false;
+
+    public bool IsStale => workspace?.IsStale ?? false;
+
+    public bool IsCommittable =>
+        workspace is not null
+        && workspace.Desired.Resolve().IsCommittable
+        && workspace.PreparePlan(MigrateLegacyRoot).IsValid;
+
+    public bool HasLegacyRootTarget => workspace?.HasLegacyRootTarget ?? false;
+
+    public bool MigrateLegacyRoot
+    {
+        get => migrateLegacyRoot;
+        set
+        {
+            if (SetField(ref migrateLegacyRoot, value))
+            {
+                Rebuild();
+            }
+        }
+    }
+
+    public bool CanSave =>
+        IsConfigurationReady
+        && HasPendingChanges
+        && IsCommittable
+        && !IsStale
+        && !hasSiblingPendingChanges();
+
+    public bool CanAddSidecar =>
+        workspace is not null
+        && !workspace.Desired.Targets.Values.Any(target => target.Kind == SyncTargetKind.LocalSidecar);
+
+    public string ConfigurationStatus => IsConfigurationReady
+        ? "Changes are staged until Save. The running game keeps its startup topology until restart."
+        : "Select a game folder with a supported configuration to set up sync.";
+
+    public string PendingChangesText => HasPendingChanges ? "Unsaved sync changes" : "No unsaved sync changes";
+
+    public string SaveAvailability => IsStale
+        ? "The TOML changed outside the launcher. Reload before saving."
+        : hasSiblingPendingChanges()
+            ? "Save or discard the pending non-sync settings before saving sync setup."
+        : !IsCommittable
+            ? "Fix the target validation errors before saving."
+            : CanSave
+                ? "Save all staged sync changes atomically."
+                : "Stage a valid sync change before saving.";
+
+    public string OperationStatus
+    {
+        get => operationStatus;
+        private set => SetField(ref operationStatus, value);
+    }
+
+    public string NewTargetName
+    {
+        get => newTargetName;
+        set => SetField(ref newTargetName, value?.Trim() ?? string.Empty);
+    }
+
+    public string GlobalProxy
+    {
+        get => workspace?.Desired.GlobalDefaults.Proxy ?? string.Empty;
+        set
+        {
+            if (workspace is null || value == GlobalProxy)
+            {
+                return;
+            }
+
+            Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithProxy(value ?? string.Empty)));
+        }
+    }
+
+    public bool GlobalVerifySsl
+    {
+        get => workspace?.Desired.GlobalDefaults.VerifySsl ?? true;
+        set
+        {
+            if (workspace is null || value == GlobalVerifySsl)
+            {
+                return;
+            }
+
+            Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithVerifySsl(value)));
+        }
+    }
+
+    public bool GlobalUnsafeTls
+    {
+        get => workspace?.Desired.GlobalDefaults.AllowUnsafeTlsWithoutCertificateValidation ?? false;
+        set
+        {
+            if (workspace is null || value == GlobalUnsafeTls)
+            {
+                return;
+            }
+
+            Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithUnsafeTls(value)));
+        }
+    }
+
+    public void Reload()
+    {
+        if (HasPendingChanges)
+        {
+            return;
+        }
+
+        workspace = null;
+        var read = repository.Read(configurationPathProvider());
+        if (!read.IsSuccess || read.Snapshot is null)
+        {
+            OperationStatus = read.State == ConfigurationRepositoryReadState.Invalid
+                ? $"Sync setup is unavailable because the TOML is unsafe to edit: {read.ValidationError?.Message}"
+                : read.State == ConfigurationRepositoryReadState.IoFailure
+                    ? $"Sync setup is unavailable: {read.Error}"
+                    : string.Empty;
+            Rebuild();
+            return;
+        }
+
+        var load = SyncTopologyPersistenceWorkspace.Load(read.Snapshot, out workspace);
+        if (!load.IsValid || workspace is null)
+        {
+            OperationStatus = $"Sync setup is unavailable because the topology could not be loaded: {load.Error?.Message}";
+        }
+        else
+        {
+            OperationStatus = load.Diagnostics.FirstOrDefault(item => item.Severity == SyncTopologyDiagnosticSeverity.Error)?.Message
+                ?? string.Empty;
+        }
+
+        Rebuild();
+    }
+
+    internal SyncTargetDraft? GetTarget(string name) =>
+        workspace?.Desired.Targets.GetValueOrDefault(name);
+
+    internal SyncResolvedTarget? GetResolvedTarget(string name) =>
+        workspace?.Desired.Resolve().Targets.FirstOrDefault(target => target.Name == name);
+
+    internal bool GetGlobalFeed(SyncDataKind kind) =>
+        workspace?.Desired.GlobalDefaults.DataKinds.GetValueOrDefault(kind) ?? false;
+
+    internal string GetGlobalProxy() => workspace?.Desired.GlobalDefaults.Proxy ?? string.Empty;
+
+    internal bool GetGlobalVerifySsl() => workspace?.Desired.GlobalDefaults.VerifySsl ?? true;
+
+    internal bool GetGlobalUnsafeTls() =>
+        workspace?.Desired.GlobalDefaults.AllowUnsafeTlsWithoutCertificateValidation ?? false;
+
+    internal IReadOnlyList<SyncTopologyDiagnostic> GetDiagnostics(string name) =>
+        workspace?.Desired.Resolve().Diagnostics.Where(item => item.TargetName == name).ToArray() ?? [];
+
+    internal void UpdateTarget(string name, Func<SyncTargetDraft, SyncTargetDraft> update)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        Apply(workspace.Desired.UpdateTarget(name, update));
+    }
+
+    internal void RemoveTarget(string name)
+    {
+        if (workspace is not null)
+        {
+            Apply(workspace.Desired.RemoveTarget(name));
+        }
+    }
+
+    internal void SetGlobalFeed(SyncDataKind kind, bool enabled)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithDataKind(kind, enabled)));
+    }
+
+    private void AddSidecar()
+    {
+        if (workspace is not null)
+        {
+            Apply(workspace.Desired.AddTarget(SyncDesiredTopology.LocalSidecarIdentity, SyncTargetKind.LocalSidecar));
+        }
+    }
+
+    private void AddPreset(string preset)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        Apply(workspace.Desired.AddPreset(preset), enableExternal: true);
+    }
+
+    private void AddExternal(SyncTargetKind kind)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        var name = string.IsNullOrWhiteSpace(NewTargetName)
+            ? kind == SyncTargetKind.MajelIngest ? "majel" : "community"
+            : NewTargetName;
+        Apply(workspace.Desired.AddTarget(name, kind), enableExternal: true);
+    }
+
+    private void Apply(SyncTopologyTransitionResult transition, bool enableExternal = false)
+    {
+        if (!transition.Succeeded)
+        {
+            OperationStatus = transition.Diagnostic?.Message ?? "The sync change could not be staged.";
+            return;
+        }
+
+        var desired = transition.Topology;
+        if (enableExternal)
+        {
+            var added = desired.Targets.Values.ExceptBy(workspace!.Desired.Targets.Keys, target => target.Name).Single();
+            desired = desired.SetTargetEnabled(added.Name, true).Topology;
+            NewTargetName = string.Empty;
+        }
+
+        Stage(desired);
+    }
+
+    private void Stage(SyncDesiredTopology desired)
+    {
+        workspace!.Stage(desired);
+        OperationStatus = string.Empty;
+        Rebuild();
+    }
+
+    private void Discard()
+    {
+        workspace?.Discard();
+        OperationStatus = "Unsaved sync changes discarded.";
+        Rebuild();
+    }
+
+    private async Task SaveAsync()
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        OperationStatus = "Saving sync setup…";
+        var result = await workspace.CommitAsync(MigrateLegacyRoot);
+        OperationStatus = result.State switch
+        {
+            AtomicTomlWriteState.Succeeded => "Sync setup saved. Restart the game to activate the new topology.",
+            AtomicTomlWriteState.NoChange => "No sync changes were needed.",
+            AtomicTomlWriteState.Conflict => "The TOML changed outside the launcher. External edits were preserved; reload before saving.",
+            AtomicTomlWriteState.Invalid => $"Nothing was written: {result.ValidationError?.Message ?? FirstPlanDiagnostic(result)}",
+            _ => $"Sync setup could not be saved: {result.Error}",
+        };
+        if (result.State is AtomicTomlWriteState.Succeeded or AtomicTomlWriteState.NoChange)
+        {
+            migrateLegacyRoot = false;
+            Committed?.Invoke(this, EventArgs.Empty);
+        }
+        Rebuild();
+    }
+
+    private void Rebuild()
+    {
+        Targets.Clear();
+        GlobalFeeds.Clear();
+        if (workspace is not null)
+        {
+            foreach (var kind in Enum.GetValues<SyncDataKind>().Where(kind => kind != SyncDataKind.FleetRuntime))
+            {
+                GlobalFeeds.Add(new(this, kind));
+            }
+
+            foreach (var target in workspace.Desired.Targets.Values.OrderBy(target => target.Name, StringComparer.Ordinal))
+            {
+                Targets.Add(new(this, target.Name));
+            }
+        }
+
+        OnPropertyChanged(string.Empty);
+        discardCommand.RaiseCanExecuteChanged();
+        saveCommand.RaiseCanExecuteChanged();
+        (AddSidecarCommand as SettingsActionCommand)?.RaiseCanExecuteChanged();
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static string? FirstPlanDiagnostic(SyncTopologyPersistenceCommitResult result) =>
+        result.Plan is { Diagnostics.Count: > 0 } plan ? plan.Diagnostics[0].Message : null;
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new(propertyName));
+}
+
+public sealed class SyncGlobalFeedViewModel(SyncWorkspaceViewModel owner, SyncDataKind kind) : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public string Label => SyncPresentation.FeedLabel(kind);
+    public bool IsEnabled
+    {
+        get => owner.IsConfigurationReady && owner.GetGlobalFeed(kind);
+        set
+        {
+            owner.SetGlobalFeed(kind, value);
+            PropertyChanged?.Invoke(this, new(nameof(IsEnabled)));
+        }
+    }
+}
+
+public sealed class SyncTargetCardViewModel : INotifyPropertyChanged
+{
+    private static readonly IReadOnlyList<SyncFleetRuntimeModeOption> FleetRuntimeModes =
+    [
+        new(string.Empty, "Use target default (Normal)"),
+        new("normal", "Normal"),
+        new("request_only", "Requests only"),
+        new("snapshot_only", "Snapshots only"),
+        new("enqueue_no_transport", "Queue without transport"),
+    ];
+
+    private readonly SyncWorkspaceViewModel owner;
+    private readonly string name;
+    private string replacementToken = string.Empty;
+
+    internal SyncTargetCardViewModel(SyncWorkspaceViewModel owner, string name)
+    {
+        this.owner = owner;
+        this.name = name;
+        RemoveCommand = new SettingsActionCommand(() => owner.RemoveTarget(name));
+        UseInheritedProxyCommand = new SettingsActionCommand(
+            () => owner.UpdateTarget(name, target => target.WithProxy(SyncOverride.Inherited<string>())));
+        ClearTokenCommand = new SettingsActionCommand(ClearToken);
+        ReplaceTokenCommand = new SettingsActionCommand(ReplaceToken, () => !string.IsNullOrWhiteSpace(replacementToken));
+        Feeds = SyncTargetTypeCatalog.Get(Draft.Kind).SupportedDataKinds
+            .OrderBy(SyncPresentation.FeedLabel, StringComparer.Ordinal)
+            .Select(kind => new SyncTargetFeedViewModel(owner, name, kind))
+            .ToArray();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private SyncTargetDraft Draft => owner.GetTarget(name)!;
+    public string Name => name;
+    public string KindLabel => SyncPresentation.KindLabel(Draft.Kind);
+    public string WireContract => SyncTargetTypeCatalog.Get(Draft.Kind).WireContract;
+    public bool CanDisable => Draft.Kind == SyncTargetKind.LocalSidecar;
+    public bool ShowSidecarControls => Draft.Kind == SyncTargetKind.LocalSidecar;
+    public bool IsEnabled
+    {
+        get => Draft.Enabled;
+        set { owner.UpdateTarget(name, target => target.WithEnabled(value)); NotifyAll(); }
+    }
+    public string Url
+    {
+        get => Draft.Url;
+        set { owner.UpdateTarget(name, target => target.WithConnection(value ?? string.Empty, target.Token)); NotifyAll(); }
+    }
+    public string TokenStatus => Draft.Token.IsConfigured ? "Saved token configured" : "No token configured";
+    public string ProxyText
+    {
+        get => Draft.Proxy.IsExplicit ? Draft.Proxy.Value : string.Empty;
+        set { owner.UpdateTarget(name, target => target.WithProxy(SyncOverride.Explicit(value ?? string.Empty))); NotifyAll(); }
+    }
+    public string ProxySummary
+    {
+        get
+        {
+            if (!Draft.Proxy.IsExplicit)
+            {
+                var inherited = SyncTargetTypeCatalog.Get(Draft.Kind).InheritsGlobalSync ? owner.GetGlobalProxy() : string.Empty;
+                return $"Inherited: {(string.IsNullOrEmpty(inherited) ? "no proxy" : inherited)}";
+            }
+
+            return string.IsNullOrEmpty(Draft.Proxy.Value) ? "Explicitly cleared" : "Target override";
+        }
+    }
+    public SyncBooleanOverrideChoice VerifySslChoice
+    {
+        get => ToChoice(Draft.VerifySsl);
+        set { owner.UpdateTarget(name, target => target.WithVerifySsl(FromChoice(value))); NotifyAll(); }
+    }
+    public SyncBooleanOverrideChoice UnsafeTlsChoice
+    {
+        get => ToChoice(Draft.AllowUnsafeTlsWithoutCertificateValidation);
+        set { owner.UpdateTarget(name, target => target.WithUnsafeTls(FromChoice(value))); NotifyAll(); }
+    }
+    public SyncBooleanOverrideChoice BattlelogEnrichmentChoice
+    {
+        get => ToChoice(Draft.BattlelogEnrichment);
+        set { owner.UpdateTarget(name, target => target.WithBattlelogEnrichment(FromChoice(value))); NotifyAll(); }
+    }
+    public string FleetRuntimeModeChoice
+    {
+        get => Draft.FleetRuntimeMode.IsExplicit ? Draft.FleetRuntimeMode.Value : string.Empty;
+        set
+        {
+            owner.UpdateTarget(
+                name,
+                target => target.WithFleetRuntimeMode(
+                    string.IsNullOrEmpty(value) ? SyncOverride.Inherited<string>() : SyncOverride.Explicit(value)));
+            NotifyAll();
+        }
+    }
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "WPF binds this property through each target card instance.")]
+    public IReadOnlyList<SyncOverrideChoice> BooleanChoices => SyncWorkspaceViewModel.BooleanOverrideChoices;
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "WPF binds this property through each target card instance.")]
+    public IReadOnlyList<SyncFleetRuntimeModeOption> FleetRuntimeModeChoices => FleetRuntimeModes;
+    public string ValidationSummary
+    {
+        get
+        {
+            var errors = owner.GetDiagnostics(name).Where(item => item.Severity == SyncTopologyDiagnosticSeverity.Error).ToArray();
+            return errors.Length == 0 ? "Ready" : string.Join(" ", errors.Select(item => item.Message));
+        }
+    }
+    public bool HasValidationError => owner.GetDiagnostics(name).Any(item => item.Severity == SyncTopologyDiagnosticSeverity.Error);
+    public string EffectiveFeeds => string.Join(", ", Feeds.Where(feed => feed.EffectiveEnabled).Select(feed => feed.Label).DefaultIfEmpty("None"));
+    public IReadOnlyList<SyncTargetFeedViewModel> Feeds { get; }
+    public ICommand RemoveCommand { get; }
+    public ICommand UseInheritedProxyCommand { get; }
+    public ICommand ClearTokenCommand { get; }
+    public ICommand ReplaceTokenCommand { get; }
+
+    public void SetReplacementToken(string value)
+    {
+        replacementToken = value ?? string.Empty;
+        (ReplaceTokenCommand as SettingsActionCommand)?.RaiseCanExecuteChanged();
+    }
+
+    private void ReplaceToken()
+    {
+        owner.UpdateTarget(name, target => target.WithConnection(target.Url, SyncSecret.FromPlainText(replacementToken)));
+        replacementToken = string.Empty;
+        NotifyAll();
+    }
+
+    private void ClearToken()
+    {
+        owner.UpdateTarget(name, target => target.WithConnection(target.Url, SyncSecret.Missing));
+        replacementToken = string.Empty;
+        NotifyAll();
+    }
+
+    private void NotifyAll() => PropertyChanged?.Invoke(this, new(string.Empty));
+
+    private static SyncBooleanOverrideChoice ToChoice(SyncOverride<bool> value) =>
+        !value.IsExplicit
+            ? SyncBooleanOverrideChoice.UseGlobal
+            : value.Value ? SyncBooleanOverrideChoice.Enabled : SyncBooleanOverrideChoice.Disabled;
+
+    private static SyncOverride<bool> FromChoice(SyncBooleanOverrideChoice value) => value switch
+    {
+        SyncBooleanOverrideChoice.Enabled => SyncOverride.Explicit(true),
+        SyncBooleanOverrideChoice.Disabled => SyncOverride.Explicit(false),
+        _ => SyncOverride.Inherited<bool>(),
+    };
+}
+
+public sealed class SyncTargetFeedViewModel(
+    SyncWorkspaceViewModel owner,
+    string targetName,
+    SyncDataKind kind) : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public string Label => SyncPresentation.FeedLabel(kind);
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "WPF binds this property through each feed row instance.")]
+    public IReadOnlyList<SyncOverrideChoice> Choices => SyncWorkspaceViewModel.BooleanOverrideChoices;
+    public SyncBooleanOverrideChoice Choice
+    {
+        get
+        {
+            var target = owner.GetTarget(targetName)!;
+            var configured = target.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>());
+            return !configured.IsExplicit
+                ? SyncBooleanOverrideChoice.UseGlobal
+                : configured.Value ? SyncBooleanOverrideChoice.Enabled : SyncBooleanOverrideChoice.Disabled;
+        }
+        set
+        {
+            var configured = value switch
+            {
+                SyncBooleanOverrideChoice.Enabled => SyncOverride.Explicit(true),
+                SyncBooleanOverrideChoice.Disabled => SyncOverride.Explicit(false),
+                _ => SyncOverride.Inherited<bool>(),
+            };
+            owner.UpdateTarget(targetName, target => target.WithDataOverride(kind, configured));
+            PropertyChanged?.Invoke(this, new(string.Empty));
+        }
+    }
+    public bool EffectiveEnabled
+    {
+        get
+        {
+            var target = owner.GetTarget(targetName)!;
+            var configured = target.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>());
+            var inherited = SyncTargetTypeCatalog.Get(target.Kind).InheritsGlobalSync
+                && owner.GetGlobalFeed(kind);
+            return configured.IsExplicit ? configured.Value : inherited;
+        }
+    }
+    public string EffectiveSummary => $"Effective: {(EffectiveEnabled ? "On" : "Off")} · {(Choice == SyncBooleanOverrideChoice.UseGlobal ? "inherited" : "target override")}";
+}
+
+internal static class SyncPresentation
+{
+    public static string KindLabel(SyncTargetKind kind) => kind switch
+    {
+        SyncTargetKind.LocalSidecar => "Local Sidecar",
+        SyncTargetKind.MajelIngest => "Majel",
+        _ => "Community / legacy",
+    };
+
+    public static string FeedLabel(SyncDataKind kind) => string.Concat(
+        kind.ToString().SelectMany((character, index) => index > 0 && char.IsUpper(character) ? new[] { ' ', character } : new[] { character }));
+}

--- a/windows-launcher/src/STFCCommunityMod.Launcher/Views/SettingsView.xaml
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/Views/SettingsView.xaml
@@ -6,6 +6,7 @@
              xmlns:controls="clr-namespace:STFCCommunityMod.Launcher.Controls"
              xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework"
              xmlns:viewModels="clr-namespace:STFCCommunityMod.Launcher.ViewModels"
+             xmlns:views="clr-namespace:STFCCommunityMod.Launcher.Views"
              MinWidth="760"
              Background="{DynamicResource WindowBackgroundBrush}"
              Foreground="{DynamicResource TextPrimaryBrush}"
@@ -1138,13 +1139,18 @@
       </Grid>
     </Grid>
 
+    <views:SyncView Grid.Row="0"
+                    Grid.Column="1"
+                    DataContext="{Binding SyncWorkspace}"
+                    Visibility="{Binding IsDataSyncSelected, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
     <Border Grid.Row="1"
             Grid.Column="1"
             Padding="20,8,24,8"
             Background="{DynamicResource SurfaceBrush}"
             BorderBrush="{DynamicResource BorderBrush}"
             BorderThickness="0,1,0,0"
-            Visibility="{Binding HasPendingChanges, Converter={StaticResource BooleanToVisibilityConverter}}"
+            Visibility="{Binding IsSettingsFooterVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
             automation:AutomationProperties.Name="{Binding PendingChangesText}">
       <Grid>
         <Grid.ColumnDefinitions>

--- a/windows-launcher/src/STFCCommunityMod.Launcher/Views/SettingsView.xaml
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/Views/SettingsView.xaml
@@ -1,4 +1,5 @@
 <UserControl x:Class="STFCCommunityMod.Launcher.Views.SettingsView"
+             x:Name="SettingsRoot"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:automation="clr-namespace:System.Windows.Automation;assembly=PresentationCore"
@@ -1142,7 +1143,7 @@
     <views:SyncView Grid.Row="0"
                     Grid.Column="1"
                     DataContext="{Binding SyncWorkspace}"
-                    Visibility="{Binding IsDataSyncSelected, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                    Visibility="{Binding DataContext.IsDataSyncSelected, ElementName=SettingsRoot, Converter={StaticResource BooleanToVisibilityConverter}}" />
 
     <Border Grid.Row="1"
             Grid.Column="1"

--- a/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml
@@ -1,0 +1,281 @@
+<UserControl x:Class="STFCCommunityMod.Launcher.Views.SyncView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:automation="clr-namespace:System.Windows.Automation;assembly=PresentationCore"
+             xmlns:viewModels="clr-namespace:STFCCommunityMod.Launcher.ViewModels"
+             Background="{DynamicResource WindowBackgroundBrush}"
+             Foreground="{DynamicResource TextPrimaryBrush}"
+             automation:AutomationProperties.Name="Sync setup workspace">
+  <UserControl.Resources>
+    <Style x:Key="SyncTextBox" TargetType="TextBox">
+      <Setter Property="MinHeight" Value="34" />
+      <Setter Property="Padding" Value="9,6" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
+    </Style>
+    <Style x:Key="SyncComboBox" TargetType="ComboBox">
+      <Setter Property="MinHeight" Value="34" />
+      <Setter Property="Padding" Value="8,4" />
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+    </Style>
+  </UserControl.Resources>
+
+  <Grid Margin="24,10,24,0">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <StackPanel>
+        <TextBlock FontSize="22" FontWeight="SemiBold" Text="Sync setup" />
+        <TextBlock Margin="0,4,0,0"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="Set shared defaults, then connect one or more typed destinations."
+                   TextWrapping="Wrap" />
+        <TextBlock Margin="0,4,0,0"
+                   FontSize="12"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="{Binding ConfigurationStatus}"
+                   automation:AutomationProperties.LiveSetting="Polite" />
+        <CheckBox Margin="0,7,0,0"
+                  Content="Migrate legacy root sync credentials to a named default target when saving"
+                  IsChecked="{Binding MigrateLegacyRoot}"
+                  Visibility="{Binding HasLegacyRootTarget, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  automation:AutomationProperties.Name="Confirm legacy sync target migration"
+                  automation:AutomationProperties.HelpText="This moves sync.url and sync.token into sync.targets.default in the same atomic save." />
+      </StackPanel>
+      <StackPanel Grid.Column="1" Margin="20,0,0,0" HorizontalAlignment="Right">
+        <TextBlock HorizontalAlignment="Right" FontSize="11"
+                   Foreground="{DynamicResource TextSecondaryBrush}" Text="Add destination" />
+        <StackPanel Margin="0,5,0,0" Orientation="Horizontal">
+          <TextBox Width="145" Style="{StaticResource SyncTextBox}"
+                   Text="{Binding NewTargetName, UpdateSourceTrigger=PropertyChanged}"
+                   ToolTip="Optional custom target name"
+                   automation:AutomationProperties.Name="New sync target name" />
+          <Button Margin="6,0,0,0" Command="{Binding AddLegacyCommand}" Content="Community"
+                  automation:AutomationProperties.Name="Add community sync target" />
+          <Button Margin="6,0,0,0" Command="{Binding AddMajelCommand}" Content="Majel"
+                  automation:AutomationProperties.Name="Add Majel sync target" />
+          <Button Margin="6,0,0,0" Command="{Binding AddSpocksClubCommand}" Content="Spocks Club"
+                  automation:AutomationProperties.Name="Add Spocks Club preset" />
+          <Button Margin="6,0,0,0" Command="{Binding AddSidecarCommand}" Content="Sidecar"
+                  automation:AutomationProperties.Name="Add local Sidecar target" />
+        </StackPanel>
+      </StackPanel>
+    </Grid>
+
+    <Border Grid.Row="1" Margin="0,12,0,10" Padding="14"
+            Background="{DynamicResource SurfaceBrush}"
+            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="8"
+            automation:AutomationProperties.Name="Global sync defaults">
+      <Grid>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock FontSize="17" FontWeight="SemiBold" Text="Global defaults" />
+        <Grid Grid.Row="1" Margin="0,9,0,0">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="80" />
+            <ColumnDefinition Width="260" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+          </Grid.ColumnDefinitions>
+          <TextBlock VerticalAlignment="Center" Text="Proxy" />
+          <TextBox Grid.Column="1" Style="{StaticResource SyncTextBox}"
+                   Text="{Binding GlobalProxy, UpdateSourceTrigger=LostFocus}"
+                   automation:AutomationProperties.Name="Global sync proxy" />
+          <CheckBox Grid.Column="2" Margin="18,0,0,0" VerticalAlignment="Center"
+                    Content="Verify TLS" IsChecked="{Binding GlobalVerifySsl}"
+                    automation:AutomationProperties.Name="Verify TLS by default" />
+          <CheckBox Grid.Column="3" Margin="18,0,0,0" VerticalAlignment="Center"
+                    Content="Acknowledge unsafe TLS" IsChecked="{Binding GlobalUnsafeTls}"
+                    automation:AutomationProperties.Name="Acknowledge unsafe TLS without certificate validation" />
+        </Grid>
+        <ItemsControl Grid.Row="2" Margin="0,10,0,0" ItemsSource="{Binding GlobalFeeds}">
+          <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate DataType="{x:Type viewModels:SyncGlobalFeedViewModel}">
+              <CheckBox MinWidth="120" Margin="0,3,14,3" Content="{Binding Label}"
+                        IsChecked="{Binding IsEnabled}"
+                        automation:AutomationProperties.Name="{Binding Label, StringFormat='Global {0} feed'}" />
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </Grid>
+    </Border>
+
+    <Grid Grid.Row="2">
+      <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center"
+                 FontSize="15" Foreground="{DynamicResource TextSecondaryBrush}"
+                 Text="No sync destinations yet. Add Sidecar, Majel, a provider preset, or a custom community target.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock">
+            <Setter Property="Visibility" Value="Collapsed" />
+            <Style.Triggers><DataTrigger Binding="{Binding Targets.Count}" Value="0"><Setter Property="Visibility" Value="Visible" /></DataTrigger></Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+      <ListBox ItemsSource="{Binding Targets}" Background="Transparent" BorderThickness="0"
+               ScrollViewer.CanContentScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto"
+               VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling"
+               KeyboardNavigation.TabNavigation="Continue"
+               automation:AutomationProperties.Name="Configured sync targets">
+        <ListBox.ItemsPanel><ItemsPanelTemplate><VirtualizingStackPanel /></ItemsPanelTemplate></ListBox.ItemsPanel>
+        <ListBox.ItemContainerStyle>
+          <Style TargetType="ListBoxItem">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="IsTabStop" Value="False" />
+            <Setter Property="Margin" Value="0,0,0,10" />
+          </Style>
+        </ListBox.ItemContainerStyle>
+        <ListBox.ItemTemplate>
+          <DataTemplate DataType="{x:Type viewModels:SyncTargetCardViewModel}">
+            <Border Padding="15" Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="8"
+                    automation:AutomationProperties.Name="{Binding Name, StringFormat='Sync target {0}'}"
+                    automation:AutomationProperties.HelpText="{Binding ValidationSummary}">
+              <StackPanel>
+                <Grid>
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                  <StackPanel Orientation="Horizontal">
+                    <TextBlock FontSize="18" FontWeight="SemiBold" Text="{Binding Name}" TextTrimming="CharacterEllipsis" />
+                    <Border Margin="10,0,0,0" Padding="7,2" Background="{DynamicResource SurfaceMutedBrush}" CornerRadius="4">
+                      <TextBlock FontSize="11" Text="{Binding KindLabel}" />
+                    </Border>
+                    <TextBlock Margin="10,2,0,0" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding WireContract}" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <CheckBox Margin="0,0,12,0" VerticalAlignment="Center" Content="Enabled"
+                              IsChecked="{Binding IsEnabled}" IsEnabled="{Binding CanDisable}"
+                              ToolTip="External targets are active when present; remove one to disable it." />
+                    <Button Command="{Binding RemoveCommand}" Content="Remove"
+                            automation:AutomationProperties.Name="{Binding Name, StringFormat='Remove sync target {0}'}" />
+                  </StackPanel>
+                </Grid>
+
+                <TextBlock Margin="0,5,0,0" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="{Binding EffectiveFeeds, StringFormat='Effective feeds: {0}'}" TextWrapping="Wrap" />
+                <TextBlock Margin="0,4,0,0" FontSize="12" Text="{Binding ValidationSummary}"
+                           TextWrapping="Wrap" automation:AutomationProperties.LiveSetting="Polite" />
+
+                <Grid Margin="0,10,0,0">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="70" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                  <TextBlock VerticalAlignment="Center" Text="Endpoint" />
+                  <TextBox Grid.Column="1" Style="{StaticResource SyncTextBox}"
+                           Text="{Binding Url, UpdateSourceTrigger=LostFocus}"
+                           automation:AutomationProperties.Name="{Binding Name, StringFormat='Endpoint for {0}'}" />
+                </Grid>
+
+                <Grid Margin="0,8,0,0">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="70" /><ColumnDefinition Width="220" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                  <TextBlock VerticalAlignment="Center" Text="Token" />
+                  <PasswordBox Grid.Column="1" MinHeight="34" Padding="9,6"
+                               PasswordChanged="ReplacementToken_PasswordChanged"
+                               automation:AutomationProperties.Name="{Binding Name, StringFormat='Replacement token for {0}'}"
+                               automation:AutomationProperties.HelpText="Saved tokens are never displayed. Enter a new token, then choose Replace." />
+                  <Button Grid.Column="2" Margin="7,0,0,0" Command="{Binding ReplaceTokenCommand}" Content="Replace" />
+                  <Button Grid.Column="3" Margin="7,0,0,0" Command="{Binding ClearTokenCommand}" Content="Clear" />
+                  <TextBlock Grid.Column="4" Margin="12,0,0,0" VerticalAlignment="Center"
+                             FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding TokenStatus}" />
+                </Grid>
+
+                <Grid Margin="0,8,0,0">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="70" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="240" /><ColumnDefinition Width="240" /></Grid.ColumnDefinitions>
+                  <TextBlock VerticalAlignment="Center" Text="Proxy" />
+                  <TextBox Grid.Column="1" Style="{StaticResource SyncTextBox}"
+                           Text="{Binding ProxyText, UpdateSourceTrigger=LostFocus}"
+                           automation:AutomationProperties.Name="{Binding Name, StringFormat='Proxy override for {0}'}"
+                           automation:AutomationProperties.HelpText="An empty saved value explicitly clears the inherited proxy." />
+                  <Button Grid.Column="2" Margin="7,0,14,0" Command="{Binding UseInheritedProxyCommand}" Content="Use inherited" />
+                  <ComboBox Grid.Column="3" Margin="0,0,8,0" Style="{StaticResource SyncComboBox}"
+                            ItemsSource="{Binding BooleanChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                            SelectedValue="{Binding VerifySslChoice, UpdateSourceTrigger=PropertyChanged}"
+                            automation:AutomationProperties.Name="TLS verification override" />
+                  <ComboBox Grid.Column="4" Style="{StaticResource SyncComboBox}"
+                            ItemsSource="{Binding BooleanChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                            SelectedValue="{Binding UnsafeTlsChoice, UpdateSourceTrigger=PropertyChanged}"
+                            automation:AutomationProperties.Name="Unsafe TLS acknowledgement override" />
+                </Grid>
+                <TextBlock Margin="70,3,0,0" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="{Binding ProxySummary}" />
+
+                <Grid Margin="70,8,0,0"
+                      Visibility="{Binding ShowSidecarControls, Converter={StaticResource BooleanToVisibilityConverter}}">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="255" /><ColumnDefinition Width="300" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                  <StackPanel>
+                    <TextBlock FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Text="Battle-log enrichment" />
+                    <ComboBox Margin="0,3,8,0" Style="{StaticResource SyncComboBox}"
+                              ItemsSource="{Binding BooleanChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                              SelectedValue="{Binding BattlelogEnrichmentChoice, UpdateSourceTrigger=PropertyChanged}"
+                              automation:AutomationProperties.Name="Sidecar battle-log enrichment override" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="1">
+                    <TextBlock FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Text="Fleet runtime mode" />
+                    <ComboBox Margin="0,3,8,0" Style="{StaticResource SyncComboBox}"
+                              ItemsSource="{Binding FleetRuntimeModeChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                              SelectedValue="{Binding FleetRuntimeModeChoice, UpdateSourceTrigger=PropertyChanged}"
+                              automation:AutomationProperties.Name="Sidecar fleet runtime mode" />
+                  </StackPanel>
+                  <TextBlock Grid.Column="2" Margin="8,15,0,0" VerticalAlignment="Center"
+                             FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
+                             Text="These controls exist only for the local Sidecar wire contract." TextWrapping="Wrap" />
+                </Grid>
+
+                <ItemsControl Margin="0,10,0,0" ItemsSource="{Binding Feeds}">
+                  <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type viewModels:SyncTargetFeedViewModel}">
+                      <Border Width="255" Margin="0,0,8,8" Padding="9"
+                              Background="{DynamicResource SurfaceMutedBrush}" CornerRadius="6">
+                        <Grid>
+                          <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="112" /></Grid.ColumnDefinitions>
+                          <StackPanel>
+                            <TextBlock FontWeight="SemiBold" Text="{Binding Label}" />
+                            <TextBlock Margin="0,3,0,0" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding EffectiveSummary}" />
+                          </StackPanel>
+                          <ComboBox Grid.Column="1" Style="{StaticResource SyncComboBox}"
+                                    ItemsSource="{Binding Choices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                                    SelectedValue="{Binding Choice, UpdateSourceTrigger=PropertyChanged}"
+                                    automation:AutomationProperties.Name="{Binding Label}" />
+                        </Grid>
+                      </Border>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
+            </Border>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </Grid>
+
+    <Border Grid.Row="3" Margin="0,8,0,0" Padding="0,8,0,8" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
+      <Grid>
+        <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+        <StackPanel>
+          <TextBlock FontWeight="SemiBold" Text="{Binding PendingChangesText}" />
+          <TextBlock Margin="0,3,0,0" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
+                     Text="{Binding OperationStatus}" automation:AutomationProperties.LiveSetting="Polite" />
+        </StackPanel>
+        <StackPanel Grid.Column="1" Orientation="Horizontal">
+          <Button Margin="0,0,8,0" Command="{Binding DiscardCommand}" Content="Discard" />
+          <Button Command="{Binding SaveCommand}" Content="Save sync setup" ToolTip="{Binding SaveAvailability}"
+                  automation:AutomationProperties.HelpText="{Binding SaveAvailability}" />
+        </StackPanel>
+      </Grid>
+    </Border>
+  </Grid>
+</UserControl>

--- a/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using System.Windows.Controls;
+using STFCCommunityMod.Launcher.ViewModels;
+
+namespace STFCCommunityMod.Launcher.Views;
+
+public partial class SyncView : UserControl
+{
+    public SyncView()
+    {
+        InitializeComponent();
+    }
+
+    private void ReplacementToken_PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is PasswordBox { DataContext: SyncTargetCardViewModel target } passwordBox)
+        {
+            target.SetReplacementToken(passwordBox.Password);
+        }
+    }
+}

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/GameLaunchHandoffTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/GameLaunchHandoffTests.cs
@@ -42,6 +42,26 @@ public sealed class GameLaunchHandoffTests
     }
 
     [TestMethod]
+    public async Task ExistingManualInstallIsLaunchableWithoutAdoption()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var gameDirectory = CreateGameDirectory(temporaryDirectory);
+        File.WriteAllBytes(Path.Combine(gameDirectory, "version.dll"), ArtifactContents);
+        var fixture = CreateFixture(temporaryDirectory);
+
+        var presentation = fixture.Coordinator.CapturePresentation(gameDirectory);
+        var launchTask = fixture.Coordinator.LaunchAsync(gameDirectory);
+        await fixture.LauncherService.WaitUntilStartedAsync();
+
+        Assert.AreEqual("Ready to play", presentation.Status);
+        Assert.IsTrue(presentation.CanExecute);
+        Assert.AreEqual(1, fixture.LauncherService.StartCount);
+        fixture.LauncherService.CompleteExit();
+        var result = await launchTask;
+        Assert.AreEqual(GameLaunchHandoffState.Completed, result.State);
+    }
+
+    [TestMethod]
     public async Task OfficialLauncherMustBeAvailable()
     {
         using var temporaryDirectory = new TemporaryDirectory();

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SparseTomlDocumentTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SparseTomlDocumentTests.cs
@@ -231,6 +231,9 @@ public sealed class SparseTomlDocumentTests
             """{ system = true, audio = true, sound = "alarm" }""",
             result.Overrides["notifications.incoming_attack_player"].RenderedValue);
         Assert.AreEqual(4, result.Overrides["notifications.incoming_attack_player"].LineNumber);
+        Assert.AreEqual(1, result.Tables?.Count);
+        Assert.AreEqual("notifications", result.Tables![0].CanonicalPath);
+        Assert.AreEqual(3, result.Tables[0].LineNumber);
     }
 
     [TestMethod]
@@ -248,6 +251,108 @@ public sealed class SparseTomlDocumentTests
         Assert.AreEqual(2, result.Overrides?.Count);
         Assert.AreEqual("1", result.Overrides!["FutureKey"].RenderedValue);
         Assert.AreEqual("2", result.Overrides["futurekey"].RenderedValue);
+    }
+
+    [TestMethod]
+    public void RenameTablePreservesBodyUnknownFieldsCommentsAndChildTables()
+    {
+        const string source = """
+            # target heading stays outside the table body
+            [sync.targets.old] # provider note
+            url = "https://example.invalid/sync"
+            future = "keep"
+
+            [sync.targets.old.metadata]
+            label = "keep child"
+
+            [unrelated]
+            value = true
+            """;
+        var document = Load(source);
+
+        var result = document.RenameTable("sync.targets.old", "sync.targets.renamed");
+
+        Assert.IsTrue(result.IsValid, result.Error?.Message);
+        Assert.IsTrue(result.Changed);
+        Assert.AreEqual(
+            source
+                .Replace("[sync.targets.old]", "[sync.targets.renamed]", StringComparison.Ordinal)
+                .Replace("[sync.targets.old.metadata]", "[sync.targets.renamed.metadata]", StringComparison.Ordinal),
+            Decode(result.Contents!));
+    }
+
+    [TestMethod]
+    public void RenameTableRejectsDestinationAndDottedAssignmentCollisions()
+    {
+        var destination = Load(
+            """
+            [sync.targets.old]
+            value = true
+            [sync.targets.new]
+            value = false
+            """);
+        var destinationResult = destination.RenameTable("sync.targets.old", "sync.targets.new");
+        Assert.IsFalse(destinationResult.IsValid);
+        Assert.AreEqual(SparseTomlErrorCode.DuplicateTarget, destinationResult.Error?.Code);
+        Assert.IsNull(destinationResult.Contents);
+
+        var dotted = Load(
+            """
+            sync.targets.new.value = false
+            [sync.targets.old]
+            value = true
+            """);
+        var dottedResult = dotted.RenameTable("sync.targets.old", "sync.targets.new");
+        Assert.IsFalse(dottedResult.IsValid);
+        Assert.AreEqual(SparseTomlErrorCode.UnsupportedTarget, dottedResult.Error?.Code);
+        Assert.IsNull(dottedResult.Contents);
+    }
+
+    [TestMethod]
+    public void RemoveTableRemovesItsDescendantsAndPreservesUnrelatedTables()
+    {
+        const string source = """
+            [sync.targets.remove]
+            url = "https://example.invalid/sync"
+            unknown = "remove with owner"
+
+            [unrelated]
+            value = true
+
+            [sync.targets.remove.metadata]
+            label = "also remove"
+
+            [sync.targets.keep]
+            url = "https://keep.example.invalid/sync"
+            """;
+        var document = Load(source);
+
+        var result = document.RemoveTable("sync.targets.remove");
+
+        Assert.IsTrue(result.IsValid, result.Error?.Message);
+        var updated = Decode(result.Contents!);
+        Assert.IsFalse(updated.Contains("sync.targets.remove", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("unknown", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "[unrelated]");
+        StringAssert.Contains(updated, "[sync.targets.keep]");
+    }
+
+    [TestMethod]
+    public void TableOperationsPreserveBomAndCrLf()
+    {
+        const string source = "[sync.targets.old]\r\nurl = \"https://example.invalid\"\r\n";
+        var contents = new byte[] { 0xef, 0xbb, 0xbf }
+            .Concat(Encoding.UTF8.GetBytes(source))
+            .ToArray();
+        var document = Load(contents);
+
+        var result = document.RenameTable("sync.targets.old", "sync.targets.new");
+
+        CollectionAssert.AreEqual(
+            new byte[] { 0xef, 0xbb, 0xbf }
+                .Concat(Encoding.UTF8.GetBytes(source.Replace("old", "new", StringComparison.Ordinal)))
+                .ToArray(),
+            result.Contents!);
     }
 
     private static SparseTomlDocument Load(string source) =>

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
@@ -1,0 +1,380 @@
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.Core.Tests;
+
+[TestClass]
+public sealed class SyncDesiredTopologyTests
+{
+    [TestMethod]
+    public void CatalogSeparatesConcreteKindsFromProviderPresets()
+    {
+        Assert.AreEqual(3, SyncTargetTypeCatalog.All.Count);
+        Assert.AreEqual("sidecar.sync", SyncTargetTypeCatalog.Get(SyncTargetKind.LocalSidecar).PersistencePattern);
+        Assert.AreEqual("sidecar_local_ingest", SyncTargetTypeCatalog.Get(SyncTargetKind.LocalSidecar).WireContract);
+        Assert.IsFalse(SyncTargetTypeCatalog.Get(SyncTargetKind.LocalSidecar).InheritsGlobalSync);
+        Assert.AreEqual("sync.targets.*", SyncTargetTypeCatalog.Get(SyncTargetKind.MajelIngest).PersistencePattern);
+        Assert.AreEqual("majel.ingest.v1", SyncTargetTypeCatalog.Get(SyncTargetKind.MajelIngest).WireContract);
+
+        var spocks = SyncTargetTypeCatalog.GetPreset("spocks_club");
+        Assert.AreEqual(SyncTargetKind.LegacyCommunity, spocks.TargetKind);
+        Assert.AreEqual("spocksclub", spocks.SuggestedIdentity);
+    }
+
+    [TestMethod]
+    public void OverridePresenceParticipatesInEqualityAndResolutionProvenance()
+    {
+        var inherited = SyncOverride.Inherited<bool>();
+        var explicitFalse = SyncOverride.Explicit(false);
+
+        Assert.AreNotEqual(inherited, explicitFalse);
+        Assert.AreEqual(
+            new SyncResolvedValue<bool>(false, SyncValueProvenance.Inherited, SyncValueSource.GlobalDefault),
+            inherited.Resolve(false, SyncValueSource.GlobalDefault));
+        Assert.AreEqual(
+            new SyncResolvedValue<bool>(false, SyncValueProvenance.ExplicitFalse, SyncValueSource.Target),
+            explicitFalse.Resolve(true, SyncValueSource.GlobalDefault));
+
+        var explicitEmpty = SyncOverride.Explicit(string.Empty).Resolve(
+            "http://proxy.example.invalid:8080",
+            SyncValueSource.GlobalDefault);
+        Assert.AreEqual(SyncValueProvenance.ExplicitEmpty, explicitEmpty.Provenance);
+        Assert.AreEqual(string.Empty, explicitEmpty.Value);
+    }
+
+    [TestMethod]
+    public void MixedTopologyResolvesCapabilitiesAndProvenance()
+    {
+        var globals = new SyncGlobalDefaults(
+                "http://proxy.example.invalid:8080",
+                true,
+                false)
+            .WithDataKind(SyncDataKind.Battlelogs, true);
+        var topology = new SyncDesiredTopology(globals);
+        topology = AddConfigured(
+            topology,
+            "ignored-for-sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://127.0.0.1:43127/api/sidecar/ingest",
+            target => target
+                .WithProxy(SyncOverride.Explicit(string.Empty))
+                .WithDataOverride(SyncDataKind.BattlelogsRealtime, SyncOverride.Explicit(true))
+                .WithBattlelogEnrichment(SyncOverride.Explicit(true))
+                .WithFleetRuntimeMode(SyncOverride.Explicit("snapshot_only")));
+        topology = AddConfigured(
+            topology,
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync");
+        topology = AddConfigured(
+            topology,
+            "majel",
+            SyncTargetKind.MajelIngest,
+            "https://majel.example.invalid/api/ingest/events",
+            target => target.WithDataOverride(SyncDataKind.Battlelogs, SyncOverride.Explicit(false)));
+
+        var resolved = topology.Resolve();
+
+        Assert.IsTrue(resolved.IsCommittable);
+        Assert.AreEqual(3, resolved.Targets.Count);
+        var sidecar = resolved.Targets.Single(target => target.Kind == SyncTargetKind.LocalSidecar);
+        Assert.AreEqual(string.Empty, sidecar.Proxy.Value);
+        Assert.AreEqual(SyncValueProvenance.ExplicitEmpty, sidecar.Proxy.Provenance);
+        Assert.AreEqual(SyncValueSource.Target, sidecar.Proxy.Source);
+        Assert.AreEqual(
+            SyncValueSource.TargetTypeDefault,
+            sidecar.DataKinds[SyncDataKind.FleetRuntime].Source);
+        Assert.IsTrue(sidecar.BattlelogEnrichment!.Value);
+        Assert.AreEqual("snapshot_only", sidecar.FleetRuntimeMode!.Value);
+
+        var community = resolved.Targets.Single(target => target.Name == "community");
+        Assert.AreEqual(globals.Proxy, community.Proxy.Value);
+        Assert.AreEqual(SyncValueProvenance.Inherited, community.Proxy.Provenance);
+        Assert.AreEqual(SyncValueSource.GlobalDefault, community.Proxy.Source);
+        Assert.IsTrue(community.DataKinds[SyncDataKind.Battlelogs].Value);
+
+        var majel = resolved.Targets.Single(target => target.Name == "majel");
+        Assert.IsFalse(majel.DataKinds[SyncDataKind.Battlelogs].Value);
+        Assert.AreEqual(
+            SyncValueProvenance.ExplicitFalse,
+            majel.DataKinds[SyncDataKind.Battlelogs].Provenance);
+    }
+
+    [TestMethod]
+    public void GlobalChangesFlowOnlyToCompatibleInheritedFields()
+    {
+        var topology = new SyncDesiredTopology(new SyncGlobalDefaults("proxy-one", true, false));
+        topology = AddConfigured(
+            topology,
+            "inherited",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/inherited");
+        topology = AddConfigured(
+            topology,
+            "explicit",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/explicit",
+            target => target.WithProxy(SyncOverride.Explicit("target-proxy")));
+        topology = AddConfigured(
+            topology,
+            "sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://localhost:43127/api/sidecar/ingest");
+
+        topology = topology.WithGlobalDefaults(topology.GlobalDefaults.WithProxy("proxy-two"));
+        var resolved = topology.Resolve();
+
+        Assert.AreEqual("proxy-two", resolved.Targets.Single(target => target.Name == "inherited").Proxy.Value);
+        Assert.AreEqual("target-proxy", resolved.Targets.Single(target => target.Name == "explicit").Proxy.Value);
+        Assert.AreEqual(
+            string.Empty,
+            resolved.Targets.Single(target => target.Kind == SyncTargetKind.LocalSidecar).Proxy.Value);
+    }
+
+    [TestMethod]
+    public void SidecarDoesNotInheritExternalProxyOrUnsafeTlsPolicy()
+    {
+        var topology = new SyncDesiredTopology(
+            new SyncGlobalDefaults("http://external-proxy.example.invalid:8080", false, true));
+        topology = AddConfigured(
+            topology,
+            "sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://127.0.0.1:43127/api/sidecar/ingest");
+        topology = AddConfigured(
+            topology,
+            "external",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync");
+
+        var resolved = topology.Resolve();
+        var sidecar = resolved.Targets.Single(target => target.Kind == SyncTargetKind.LocalSidecar);
+        var external = resolved.Targets.Single(target => target.Kind == SyncTargetKind.LegacyCommunity);
+
+        Assert.AreEqual(string.Empty, sidecar.Proxy.Value);
+        Assert.IsTrue(sidecar.VerifySsl.Value);
+        Assert.IsFalse(sidecar.AllowUnsafeTlsWithoutCertificateValidation.Value);
+        Assert.AreEqual(SyncValueSource.TargetTypeDefault, sidecar.VerifySsl.Source);
+        Assert.AreEqual("http://external-proxy.example.invalid:8080", external.Proxy.Value);
+        Assert.IsFalse(external.VerifySsl.Value);
+        Assert.IsTrue(external.AllowUnsafeTlsWithoutCertificateValidation.Value);
+        Assert.AreEqual(SyncValueSource.GlobalDefault, external.VerifySsl.Source);
+    }
+
+    [TestMethod]
+    public void LifecycleTransitionsAreImmutableAndDuplicateClearsCredentials()
+    {
+        var topology = SyncDesiredTopology.Empty;
+        var added = topology.AddPreset("spocks_club");
+        Assert.IsTrue(added.Succeeded);
+        Assert.AreEqual(0, topology.Targets.Count);
+        topology = added.Topology;
+        topology = RequireSuccess(
+            topology.UpdateTarget(
+                "spocksclub",
+                target => target
+                    .WithConnection(
+                        "https://community.example.invalid/sync",
+                        SyncSecret.FromPlainText("secret-one"))
+                    .WithEnabled(true)));
+
+        topology = RequireSuccess(topology.RenameTarget("spocksclub", "primary"));
+        topology = RequireSuccess(topology.DuplicateTarget("primary", "backup"));
+        var duplicate = topology.Targets["backup"];
+        Assert.IsFalse(duplicate.Enabled);
+        Assert.IsFalse(duplicate.Token.IsConfigured);
+        Assert.AreEqual(topology.Targets["primary"].Url, duplicate.Url);
+
+        topology = RequireSuccess(topology.ChangeTargetKind("backup", SyncTargetKind.MajelIngest));
+        Assert.AreEqual(SyncTargetKind.MajelIngest, topology.Targets["backup"].Kind);
+        topology = RequireSuccess(topology.SetTargetEnabled("backup", true));
+        Assert.IsTrue(topology.Targets["backup"].Enabled);
+        topology = RequireSuccess(topology.RemoveTarget("backup"));
+        Assert.IsFalse(topology.Targets.ContainsKey("backup"));
+    }
+
+    [TestMethod]
+    public void SidecarCardinalityIdentityAndDuplicationAreGuarded()
+    {
+        var topology = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("anything", SyncTargetKind.LocalSidecar));
+
+        Assert.AreEqual(SyncDesiredTopology.LocalSidecarIdentity, topology.Targets.Keys.Single());
+        Assert.IsFalse(topology.AddTarget("second", SyncTargetKind.LocalSidecar).Succeeded);
+        Assert.IsFalse(topology.RenameTarget(SyncDesiredTopology.LocalSidecarIdentity, "other").Succeeded);
+        Assert.IsFalse(topology.DuplicateTarget(SyncDesiredTopology.LocalSidecarIdentity, "other").Succeeded);
+        Assert.IsFalse(
+            topology.ChangeTargetKind(
+                SyncDesiredTopology.LocalSidecarIdentity,
+                SyncTargetKind.LegacyCommunity).Succeeded);
+    }
+
+    [TestMethod]
+    public void ResolverRejectsCardinalityViolationsFromUntrustedConstruction()
+    {
+        var sidecar = SyncTargetDraft.Create("ignored", SyncTargetKind.LocalSidecar)
+            .WithConnection(
+                "http://127.0.0.1:43127/api/sidecar/ingest",
+                SyncSecret.FromPlainText("fixture-sidecar"));
+        var topology = new SyncDesiredTopology(
+            new SyncGlobalDefaults(string.Empty, true, false),
+            new Dictionary<string, SyncTargetDraft>
+            {
+                ["first"] = sidecar,
+                ["second"] = sidecar,
+            });
+
+        var resolved = topology.Resolve();
+
+        Assert.IsFalse(resolved.IsCommittable);
+        Assert.AreEqual(0, resolved.Targets.Count);
+        Assert.IsTrue(resolved.Diagnostics.Any(item => item.Code == "SYNC_TARGET_CARDINALITY"));
+    }
+
+    [TestMethod]
+    public void InvalidNamesCredentialsAndEndpointOwnershipBlockCommit()
+    {
+        Assert.IsFalse(SyncDesiredTopology.Empty.AddTarget("bad.target", SyncTargetKind.LegacyCommunity).Succeeded);
+        Assert.IsFalse(SyncDesiredTopology.Empty.AddTarget("sidecar", SyncTargetKind.LegacyCommunity).Succeeded);
+
+        var external = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("external", SyncTargetKind.LegacyCommunity));
+        external = RequireSuccess(
+            external.UpdateTarget(
+                "external",
+                target => target.WithConnection(
+                    "http://127.0.0.1:43127/api/sidecar/ingest",
+                    SyncSecret.FromPlainText("hidden-value"))));
+        var externalResolved = external.Resolve();
+        Assert.IsFalse(externalResolved.IsCommittable);
+        Assert.IsTrue(externalResolved.Diagnostics.Any(item => item.Code == "SYNC_LOOPBACK_TARGET_INVALID"));
+
+        var missing = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("missing", SyncTargetKind.MajelIngest));
+        missing = RequireSuccess(
+            missing.UpdateTarget(
+                "missing",
+                target => target.WithConnection(
+                    "https://majel.example.invalid/api/ingest/events",
+                    SyncSecret.Missing)));
+        Assert.IsTrue(missing.Resolve().Diagnostics.Any(item => item.Code == "SYNC_CREDENTIALS_INCOMPLETE"));
+
+        var sidecar = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("sidecar", SyncTargetKind.LocalSidecar));
+        sidecar = RequireSuccess(
+            sidecar.UpdateTarget(
+                SyncDesiredTopology.LocalSidecarIdentity,
+                target => target.WithConnection(
+                    "https://sidecar.example.invalid/ingest",
+                    SyncSecret.FromPlainText("hidden-value"))));
+        Assert.IsTrue(sidecar.Resolve().Diagnostics.Any(item => item.Code == "SYNC_SIDECAR_ENDPOINT_NOT_LOOPBACK"));
+    }
+
+    [TestMethod]
+    public void UnsupportedCapabilitiesAndUnsafeTlsCannotEnterACommittableSet()
+    {
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "external",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync",
+            target => target
+                .WithDataOverride(SyncDataKind.FleetRuntime, SyncOverride.Explicit(true))
+                .WithBattlelogEnrichment(SyncOverride.Explicit(true))
+                .WithVerifySsl(SyncOverride.Explicit(false)));
+
+        var blocked = topology.Resolve();
+        Assert.IsFalse(blocked.IsCommittable);
+        Assert.IsTrue(blocked.Diagnostics.Any(item => item.Code == "SYNC_CAPABILITY_UNSUPPORTED"));
+        Assert.IsTrue(blocked.Diagnostics.Any(item => item.Code == "SYNC_UNSAFE_TLS_PAIR_REQUIRED"));
+
+        topology = RequireSuccess(
+            topology.UpdateTarget(
+                "external",
+                target => target
+                    .WithDataOverride(SyncDataKind.FleetRuntime, SyncOverride.Inherited<bool>())
+                    .WithBattlelogEnrichment(SyncOverride.Inherited<bool>())
+                    .WithUnsafeTls(SyncOverride.Explicit(true))));
+        Assert.IsTrue(topology.Resolve().IsCommittable);
+    }
+
+    [TestMethod]
+    public void InvalidSidecarRuntimeModeBlocksCommit()
+    {
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://127.0.0.1:43127/api/sidecar/ingest",
+            target => target.WithFleetRuntimeMode(SyncOverride.Explicit("surprise")));
+
+        var resolved = topology.Resolve();
+
+        Assert.IsFalse(resolved.IsCommittable);
+        Assert.IsTrue(resolved.Diagnostics.Any(item => item.Code == "SYNC_FLEET_RUNTIME_MODE_INVALID"));
+    }
+
+    [TestMethod]
+    public void SecretsRemainOpaqueInDisplayAndDiagnostics()
+    {
+        const string secretValue = "do-not-display-this-token";
+        var secret = SyncSecret.FromPlainText(secretValue);
+        Assert.AreEqual("[configured]", secret.ToString());
+        Assert.AreEqual(secret, SyncSecret.FromPlainText(secretValue));
+
+        var topology = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("external", SyncTargetKind.LegacyCommunity));
+        topology = RequireSuccess(
+            topology.UpdateTarget(
+                "external",
+                target => target.WithConnection("not-a-url", secret)));
+
+        var diagnostics = topology.Resolve().Diagnostics;
+        Assert.IsTrue(diagnostics.Count > 0);
+        Assert.IsFalse(diagnostics.Any(item => item.Message.Contains(secretValue, StringComparison.Ordinal)));
+        Assert.IsFalse(diagnostics.Any(item => item.ToString().Contains(secretValue, StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void StartupRuntimeTopologyDoesNotChangeWithDesiredEdits()
+    {
+        var desired = AddConfigured(
+            new SyncDesiredTopology(new SyncGlobalDefaults("proxy-one", true, false)),
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync");
+        var workspace = SyncTopologyWorkspace.Begin(desired);
+        var startup = workspace.StartupRuntime;
+
+        var changedDesired = desired.WithGlobalDefaults(desired.GlobalDefaults.WithProxy("proxy-two"));
+        workspace = workspace.Apply(new(true, changedDesired));
+
+        Assert.AreSame(startup, workspace.StartupRuntime);
+        Assert.AreEqual("proxy-one", workspace.StartupRuntime.Targets.Single().Proxy.Value);
+        Assert.AreEqual("proxy-two", workspace.Preview.Targets.Single().Proxy.Value);
+    }
+
+    private static SyncDesiredTopology AddConfigured(
+        SyncDesiredTopology topology,
+        string name,
+        SyncTargetKind kind,
+        string url,
+        Func<SyncTargetDraft, SyncTargetDraft>? configure = null)
+    {
+        topology = RequireSuccess(topology.AddTarget(name, kind));
+        var identity = kind == SyncTargetKind.LocalSidecar
+            ? SyncDesiredTopology.LocalSidecarIdentity
+            : name;
+        return RequireSuccess(
+            topology.UpdateTarget(
+                identity,
+                target => (configure?.Invoke(target) ?? target)
+                    .WithConnection(url, SyncSecret.FromPlainText($"fixture-{identity}"))
+                    .WithEnabled(true)));
+    }
+
+    private static SyncDesiredTopology RequireSuccess(SyncTopologyTransitionResult result)
+    {
+        Assert.IsTrue(result.Succeeded, result.Diagnostic?.Message);
+        return result.Topology;
+    }
+}

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
@@ -193,6 +193,33 @@ public sealed class SyncDesiredTopologyTests
     }
 
     [TestMethod]
+    public void KindChangeResetPolicyClearsTargetOverridesButKeepsConnection()
+    {
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync",
+            target => target
+                .WithProxy(SyncOverride.Explicit("target-proxy"))
+                .WithDataOverride(SyncDataKind.Jobs, SyncOverride.Explicit(false)));
+        var original = topology.Targets["community"];
+
+        topology = RequireSuccess(
+            topology.ChangeTargetKind(
+                "community",
+                SyncTargetKind.MajelIngest,
+                SyncTargetKindChangePolicy.ResetOverrides));
+        var changed = topology.Targets["community"];
+
+        Assert.AreEqual(SyncTargetKind.MajelIngest, changed.Kind);
+        Assert.AreEqual(original.Url, changed.Url);
+        Assert.AreEqual(original.Token, changed.Token);
+        Assert.IsFalse(changed.Proxy.IsExplicit);
+        Assert.AreEqual(0, changed.DataOverrides.Count);
+    }
+
+    [TestMethod]
     public void SidecarCardinalityIdentityAndDuplicationAreGuarded()
     {
         var topology = RequireSuccess(
@@ -243,10 +270,22 @@ public sealed class SyncDesiredTopologyTests
                 "external",
                 target => target.WithConnection(
                     "http://127.0.0.1:43127/api/sidecar/ingest",
-                    SyncSecret.FromPlainText("hidden-value"))));
+                    SyncSecret.FromPlainText("hidden-value")).WithEnabled(true)));
         var externalResolved = external.Resolve();
         Assert.IsFalse(externalResolved.IsCommittable);
         Assert.IsTrue(externalResolved.Diagnostics.Any(item => item.Code == "SYNC_LOOPBACK_TARGET_INVALID"));
+
+        var embeddedCredentials = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("embedded", SyncTargetKind.LegacyCommunity));
+        embeddedCredentials = RequireSuccess(
+            embeddedCredentials.UpdateTarget(
+                "embedded",
+                target => target.WithConnection(
+                    "https://username:password@community.example.invalid/sync",
+                    SyncSecret.FromPlainText("hidden-value")).WithEnabled(true)));
+        Assert.IsTrue(
+            embeddedCredentials.Resolve().Diagnostics.Any(
+                item => item.Code == "SYNC_ENDPOINT_EMBEDDED_CREDENTIALS"));
 
         var missing = RequireSuccess(
             SyncDesiredTopology.Empty.AddTarget("missing", SyncTargetKind.MajelIngest));
@@ -255,7 +294,7 @@ public sealed class SyncDesiredTopologyTests
                 "missing",
                 target => target.WithConnection(
                     "https://majel.example.invalid/api/ingest/events",
-                    SyncSecret.Missing)));
+                    SyncSecret.Missing).WithEnabled(true)));
         Assert.IsTrue(missing.Resolve().Diagnostics.Any(item => item.Code == "SYNC_CREDENTIALS_INCOMPLETE"));
 
         var sidecar = RequireSuccess(
@@ -265,7 +304,7 @@ public sealed class SyncDesiredTopologyTests
                 SyncDesiredTopology.LocalSidecarIdentity,
                 target => target.WithConnection(
                     "https://sidecar.example.invalid/ingest",
-                    SyncSecret.FromPlainText("hidden-value"))));
+                    SyncSecret.FromPlainText("hidden-value")).WithEnabled(true)));
         Assert.IsTrue(sidecar.Resolve().Diagnostics.Any(item => item.Code == "SYNC_SIDECAR_ENDPOINT_NOT_LOOPBACK"));
     }
 
@@ -326,12 +365,30 @@ public sealed class SyncDesiredTopologyTests
         topology = RequireSuccess(
             topology.UpdateTarget(
                 "external",
-                target => target.WithConnection("not-a-url", secret)));
+                target => target.WithConnection("not-a-url", secret).WithEnabled(true)));
 
         var diagnostics = topology.Resolve().Diagnostics;
         Assert.IsTrue(diagnostics.Count > 0);
         Assert.IsFalse(diagnostics.Any(item => item.Message.Contains(secretValue, StringComparison.Ordinal)));
         Assert.IsFalse(diagnostics.Any(item => item.ToString().Contains(secretValue, StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void ProxyUserInfoDoesNotAppearInDomainDisplayStrings()
+    {
+        const string proxy = "http://proxy-user:proxy-password@example.invalid:8080";
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync",
+            target => target.WithProxy(SyncOverride.Explicit(proxy)));
+        var draft = topology.Targets["community"];
+        var resolved = topology.Resolve().Targets.Single();
+
+        Assert.IsFalse(draft.Proxy.ToString().Contains("proxy-password", StringComparison.Ordinal));
+        Assert.IsFalse(resolved.Proxy.ToString().Contains("proxy-password", StringComparison.Ordinal));
+        Assert.IsFalse(resolved.ToString().Contains("proxy-password", StringComparison.Ordinal));
     }
 
     [TestMethod]

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.Core.Tests;
+
+[TestClass]
+public sealed class SyncTargetContractCorpusTests
+{
+    private static readonly string[] RequiredCaseIds =
+    [
+        "canonical-local-sidecar",
+        "explicit-empty-proxy",
+        "explicit-false-overrides-global",
+        "global-only-defaults",
+        "invalid-loopback-external-target",
+        "legacy-root-conversion",
+        "legacy-spocks-presets",
+        "majel-realtime",
+        "missing-partial-credentials",
+        "mixed-multiple-targets",
+        "unknown-source-content-preserved",
+        "unsupported-external-fleet-runtime",
+    ];
+
+    private static readonly string[] LockedProvenanceStates =
+    [
+        "inherited",
+        "explicit_value",
+        "explicit_false",
+        "explicit_empty",
+    ];
+
+    private static readonly string[] LocalSidecarKindOnly = ["local_sidecar"];
+
+    [TestMethod]
+    public void CorpusCoversLockedCompatibilityCasesAndPreservesEveryFixtureByte()
+    {
+        using var corpus = LoadJson("docs", "windows-launcher", "sync-target-corpus", "cases.json");
+        var cases = corpus.RootElement.GetProperty("cases").EnumerateArray().ToArray();
+
+        CollectionAssert.AreEquivalent(
+            RequiredCaseIds,
+            cases.Select(item => item.GetProperty("id").GetString()).ToArray());
+
+        foreach (var corpusCase in cases)
+        {
+            var id = corpusCase.GetProperty("id").GetString();
+            var fixturePath = FindRepositoryFile(
+                "docs",
+                "windows-launcher",
+                "sync-target-corpus",
+                corpusCase.GetProperty("file").GetString()!);
+            var contents = File.ReadAllBytes(fixturePath);
+
+            var load = SparseTomlDocument.Load(contents, out var document);
+            Assert.IsTrue(load.IsValid, $"{id}: {load.Error?.Message}");
+            Assert.IsNotNull(document, id);
+
+            var validation = document.ValidateForMutation();
+            Assert.IsTrue(validation.IsValid, $"{id}: {validation.Error?.Message}");
+            Assert.IsFalse(validation.Changed, id);
+            CollectionAssert.AreEqual(contents, validation.Contents, id);
+
+            var read = document.ReadOverrides();
+            Assert.IsTrue(read.IsValid, $"{id}: {read.Error?.Message}");
+            CollectionAssert.AreEquivalent(
+                corpusCase.GetProperty("expectedPaths")
+                    .EnumerateArray()
+                    .Select(item => item.GetString())
+                    .ToArray(),
+                read.Overrides!.Keys.ToArray(),
+                id);
+
+            foreach (var token in read.Overrides.Values.Where(
+                         value => value.CanonicalPath.EndsWith(".token", StringComparison.Ordinal)))
+            {
+                StringAssert.Contains(token.RenderedValue, "fixture-redacted-", id);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ContractLocksInheritanceSecurityAndSidecarBoundaries()
+    {
+        using var contract = LoadJson(
+            "docs",
+            "windows-launcher",
+            "sync-target-contract.guffawaffle.v1.json");
+        var root = contract.RootElement;
+
+        CollectionAssert.AreEquivalent(
+            LockedProvenanceStates,
+            root.GetProperty("provenanceStates").EnumerateArray().Select(item => item.GetString()).ToArray());
+
+        var kinds = root.GetProperty("targetKinds");
+        Assert.IsFalse(kinds.GetProperty("local_sidecar").GetProperty("inheritsGlobalSync").GetBoolean());
+        Assert.IsTrue(kinds.GetProperty("legacy_community").GetProperty("inheritsGlobalSync").GetBoolean());
+        Assert.IsTrue(kinds.GetProperty("majel_ingest").GetProperty("inheritsGlobalSync").GetBoolean());
+
+        var fields = root.GetProperty("fields");
+        foreach (var field in new[] { "identity", "enabled", "url", "token", "mode" })
+        {
+            Assert.AreEqual("never", fields.GetProperty(field).GetProperty("inheritance").GetString(), field);
+        }
+
+        Assert.AreEqual("external_only", fields.GetProperty("proxy").GetProperty("inheritance").GetString());
+        Assert.IsTrue(fields.GetProperty("proxy").GetProperty("allowsExplicitEmpty").GetBoolean());
+        Assert.IsTrue(fields.GetProperty("token").GetProperty("secret").GetBoolean());
+
+        var fleetRuntime = fields.GetProperty("fleet_runtime");
+        Assert.IsTrue(fleetRuntime.GetProperty("sidecarOnly").GetBoolean());
+        CollectionAssert.AreEqual(
+            LocalSidecarKindOnly,
+            fleetRuntime.GetProperty("kinds").EnumerateArray().Select(item => item.GetString()).ToArray());
+
+        var mutation = root.GetProperty("mutationPolicy");
+        Assert.AreEqual("never", mutation.GetProperty("load").GetString());
+        Assert.AreEqual("never", mutation.GetProperty("resolve").GetString());
+        Assert.IsTrue(mutation.GetProperty("preserveUnknownKeys").GetBoolean());
+        Assert.IsTrue(mutation.GetProperty("preserveComments").GetBoolean());
+        Assert.IsTrue(mutation.GetProperty("preserveOrdering").GetBoolean());
+
+        var security = root.GetProperty("security");
+        Assert.IsFalse(security.GetProperty("sidecarInheritsExternalNetworkPolicy").GetBoolean());
+        Assert.IsTrue(security.GetProperty("unsafeTlsRequiresExplicitPair").GetBoolean());
+        CollectionAssert.Contains(
+            security.GetProperty("redactFields").EnumerateArray().Select(item => item.GetString()).ToArray(),
+            "token");
+    }
+
+    [TestMethod]
+    public void CorpusUsesOnlyContractVocabulary()
+    {
+        using var contract = LoadJson(
+            "docs",
+            "windows-launcher",
+            "sync-target-contract.guffawaffle.v1.json");
+        using var corpus = LoadJson("docs", "windows-launcher", "sync-target-corpus", "cases.json");
+
+        var targetKinds = contract.RootElement.GetProperty("targetKinds")
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        var provenanceStates = contract.RootElement.GetProperty("provenanceStates")
+            .EnumerateArray()
+            .Select(item => item.GetString()!)
+            .ToHashSet(StringComparer.Ordinal);
+        var diagnostics = contract.RootElement.GetProperty("diagnostics")
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var corpusCase in corpus.RootElement.GetProperty("cases").EnumerateArray())
+        {
+            var id = corpusCase.GetProperty("id").GetString();
+            foreach (var targetKind in corpusCase.GetProperty("expectedTargetKinds").EnumerateArray())
+            {
+                Assert.IsTrue(targetKinds.Contains(targetKind.GetString()!), $"{id}: unknown target kind");
+            }
+
+            foreach (var provenance in corpusCase.GetProperty("provenance").EnumerateObject())
+            {
+                Assert.IsTrue(
+                    provenanceStates.Contains(provenance.Value.GetString()!),
+                    $"{id}: unknown provenance state for {provenance.Name}");
+            }
+
+            foreach (var diagnostic in corpusCase.GetProperty("diagnostics").EnumerateArray())
+            {
+                Assert.IsTrue(diagnostics.Contains(diagnostic.GetString()!), $"{id}: unknown diagnostic");
+            }
+        }
+    }
+
+    private static JsonDocument LoadJson(params string[] relativeParts) =>
+        JsonDocument.Parse(File.ReadAllBytes(FindRepositoryFile(relativeParts)));
+
+    private static string FindRepositoryFile(params string[] relativeParts)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine([directory.FullName, .. relativeParts]);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail($"Could not find repository file '{Path.Combine(relativeParts)}'.");
+        return string.Empty;
+    }
+}

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
@@ -32,6 +32,13 @@ public sealed class SyncTargetContractCorpusTests
 
     private static readonly string[] LocalSidecarKindOnly = ["local_sidecar"];
 
+    private static readonly string[] LockedResolutionSources =
+    [
+        "global_default",
+        "target_type_default",
+        "target",
+    ];
+
     [TestMethod]
     public void CorpusCoversLockedCompatibilityCasesAndPreservesEveryFixtureByte()
     {
@@ -91,6 +98,9 @@ public sealed class SyncTargetContractCorpusTests
         CollectionAssert.AreEquivalent(
             LockedProvenanceStates,
             root.GetProperty("provenanceStates").EnumerateArray().Select(item => item.GetString()).ToArray());
+        CollectionAssert.AreEquivalent(
+            LockedResolutionSources,
+            root.GetProperty("resolutionSources").EnumerateArray().Select(item => item.GetString()).ToArray());
 
         var kinds = root.GetProperty("targetKinds");
         Assert.IsFalse(kinds.GetProperty("local_sidecar").GetProperty("inheritsGlobalSync").GetBoolean());

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTopologyPersistenceTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTopologyPersistenceTests.cs
@@ -1,0 +1,536 @@
+using System.Text;
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.Core.Tests;
+
+[TestClass]
+public sealed class SyncTopologyPersistenceTests
+{
+    [TestMethod]
+    public void LockedCorpusLoadsWithoutChangingAnySourceBytes()
+    {
+        var corpusDirectory = Path.GetDirectoryName(
+            FindRepositoryFile("docs", "windows-launcher", "sync-target-corpus", "cases.json"))!;
+        foreach (var path in Directory.GetFiles(corpusDirectory, "*.toml"))
+        {
+            var contents = File.ReadAllBytes(path);
+
+            var load = SyncTopologyTomlAdapter.Load(contents);
+            var sparseLoad = SparseTomlDocument.Load(contents, out var document);
+            var validation = document!.ValidateForMutation();
+
+            Assert.IsTrue(load.IsValid, Path.GetFileName(path));
+            Assert.IsNotNull(load.Topology, Path.GetFileName(path));
+            Assert.IsTrue(sparseLoad.IsValid, Path.GetFileName(path));
+            Assert.IsFalse(validation.Changed, Path.GetFileName(path));
+            CollectionAssert.AreEqual(contents, validation.Contents, Path.GetFileName(path));
+        }
+    }
+
+    [TestMethod]
+    public void AdapterNativeDefaultsMatchTheGeneratedRuntimeSchema()
+    {
+        var catalog = LauncherConfigurationSchemaLoader.LoadFile(
+            FindRepositoryFile("docs", "windows-launcher", "config-schema.guffawaffle.v1.json"));
+        var defaults = SyncTopologyTomlAdapter.NativeGlobalDefaults;
+
+        Assert.AreEqual(
+            defaults.Proxy,
+            catalog.Settings.Single(item => item.Path == "sync.proxy").DefaultValue.GetString());
+        Assert.AreEqual(
+            defaults.VerifySsl,
+            catalog.Settings.Single(item => item.Path == "sync.verify_ssl").DefaultValue.GetBoolean());
+        Assert.AreEqual(
+            defaults.AllowUnsafeTlsWithoutCertificateValidation,
+            catalog.Settings.Single(
+                item => item.Path == "sync.allow_unsafe_tls_without_certificate_validation").DefaultValue.GetBoolean());
+        foreach (var (kind, key) in SyncTopologyTomlAdapter.DataKeys)
+        {
+            Assert.AreEqual(
+                defaults.DataKinds[kind],
+                catalog.Settings.Single(item => item.Path == $"sync.{key}").DefaultValue.GetBoolean(),
+                key);
+        }
+    }
+
+    [TestMethod]
+    public void AdapterPreservesExplicitFalseEmptyAndInheritedResolution()
+    {
+        var load = Load(
+            """
+            [sync]
+            proxy = "http://proxy.example.invalid:8080"
+            battlelogs = true
+
+            [sync.targets.direct]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            proxy = ""
+            battlelogs = false
+            """);
+
+        var target = load.Topology!.Targets["direct"];
+        Assert.AreEqual(SyncOverride.Explicit(string.Empty), target.Proxy);
+        Assert.AreEqual(SyncOverride.Explicit(false), target.DataOverrides[SyncDataKind.Battlelogs]);
+        var resolved = load.Topology.Resolve().Targets.Single();
+        Assert.AreEqual(SyncValueProvenance.ExplicitEmpty, resolved.Proxy.Provenance);
+        Assert.AreEqual(SyncValueProvenance.ExplicitFalse, resolved.DataKinds[SyncDataKind.Battlelogs].Provenance);
+    }
+
+    [TestMethod]
+    public void SidecarBrokerModeIsABlockingExternalTargetDiagnostic()
+    {
+        var load = Load(
+            """
+            [sync.targets.external]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "sidecar_broker"
+            """);
+
+        var plan = SyncTopologyPersistencePlanner.Build(load, load.Topology!);
+
+        Assert.IsFalse(plan.IsValid);
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID"));
+    }
+
+    [TestMethod]
+    public void EmptyTargetTableIsDiscoveredAndRejectedAsMalformed()
+    {
+        var load = Load(
+            """
+            [sync.targets.empty]
+            # An explicitly declared target cannot disappear merely because it has no assignments.
+            """);
+
+        Assert.IsTrue(load.Topology!.Targets.ContainsKey("empty"));
+        var plan = SyncTopologyPersistencePlanner.Build(load, load.Topology);
+        Assert.IsFalse(plan.IsValid);
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_ENDPOINT_INVALID"));
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_CREDENTIALS_INCOMPLETE"));
+    }
+
+    [TestMethod]
+    public void ClearingOverridesRemovesOnlyOwnedAssignments()
+    {
+        const string source = """
+            [sync]
+            proxy = "http://proxy.example.invalid:8080"
+            battlelogs = true
+
+            [sync.targets.direct]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            proxy = ""
+            battlelogs = false
+            future = "preserve" # unknown ownership
+            """;
+        var baseline = Load(source);
+        var desired = RequireSuccess(
+            baseline.Topology!.UpdateTarget(
+                "direct",
+                target => target
+                    .WithProxy(SyncOverride.Inherited<string>())
+                    .WithDataOverride(SyncDataKind.Battlelogs, SyncOverride.Inherited<bool>())));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var edit = plan.Apply(Encoding.UTF8.GetBytes(source));
+        var updated = Encoding.UTF8.GetString(edit.Contents!);
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.IsTrue(edit.IsValid, edit.Error?.Message);
+        Assert.IsFalse(updated.Contains("proxy = \"\"", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("battlelogs = false", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "proxy = \"http://proxy.example.invalid:8080\"");
+        StringAssert.Contains(updated, "battlelogs = true");
+        StringAssert.Contains(updated, "future = \"preserve\" # unknown ownership");
+    }
+
+    [TestMethod]
+    public void AddingTargetWritesExplicitModeAndKeepsSecretsOutOfPlanDisplay()
+    {
+        const string secret = "never-show-this-token";
+        var baseline = Load("# empty sync topology\n");
+        var desired = RequireSuccess(
+            baseline.Topology!.AddTarget("majel", SyncTargetKind.MajelIngest));
+        desired = RequireSuccess(
+            desired.UpdateTarget(
+                "majel",
+                target => target
+                    .WithConnection(
+                        "https://majel.example.invalid/api/ingest/events",
+                        SyncSecret.FromPlainText(secret))
+                    .WithEnabled(true)
+                    .WithDataOverride(SyncDataKind.BattlelogsRealtime, SyncOverride.Explicit(true))));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var display = string.Join('\n', plan.Mutations.Select(mutation => mutation.ToString()));
+        var edit = plan.Apply(Encoding.UTF8.GetBytes("# empty sync topology\n"));
+        var updated = Encoding.UTF8.GetString(edit.Contents!);
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.IsFalse(display.Contains(secret, StringComparison.Ordinal));
+        StringAssert.Contains(display, "[secret]");
+        StringAssert.Contains(updated, "[sync.targets.majel]");
+        StringAssert.Contains(updated, "mode = \"majel\"");
+        StringAssert.Contains(updated, "battlelogs_realtime = true");
+        StringAssert.Contains(updated, $"token = \"{secret}\"");
+    }
+
+    [TestMethod]
+    public void UnchangedSecretProducesNoSecretMutation()
+    {
+        var baseline = Load(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            """);
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, baseline.Topology!);
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.AreEqual(0, plan.Mutations.Count);
+    }
+
+    [TestMethod]
+    public void RenamePreservesUnknownTargetBodyAndComments()
+    {
+        const string source = """
+            # provider target
+            [sync.targets.old]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            future = "preserve" # exact comment
+            """;
+        var baseline = Load(source);
+        var desired = RequireSuccess(baseline.Topology!.RenameTarget("old", "renamed"));
+
+        var plan = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            desired,
+            new Dictionary<string, string> { ["old"] = "renamed" });
+        var edit = plan.Apply(Encoding.UTF8.GetBytes(source));
+        var updated = Encoding.UTF8.GetString(edit.Contents!);
+
+        Assert.IsTrue(plan.IsValid);
+        StringAssert.Contains(updated, "[sync.targets.renamed]");
+        Assert.IsFalse(updated.Contains("[sync.targets.old]", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "future = \"preserve\" # exact comment");
+    }
+
+    [TestMethod]
+    public void RemovingTargetRemovesWholeOwnedTableOnly()
+    {
+        const string source = """
+            [sync.targets.remove]
+            url = "https://remove.example.invalid/sync"
+            token = "fixture-remove"
+            unknown = "remove too"
+
+            [sync.targets.keep]
+            url = "https://keep.example.invalid/sync"
+            token = "fixture-keep"
+            unknown = "keep"
+            """;
+        var baseline = Load(source);
+        var desired = RequireSuccess(baseline.Topology!.RemoveTarget("remove"));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var updated = Encoding.UTF8.GetString(plan.Apply(Encoding.UTF8.GetBytes(source)).Contents!);
+
+        Assert.IsFalse(updated.Contains("sync.targets.remove", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("remove too", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "[sync.targets.keep]");
+        StringAssert.Contains(updated, "unknown = \"keep\"");
+    }
+
+    [TestMethod]
+    public void LegacyRootIsVirtualUntilMigrationIsExplicitlyConfirmed()
+    {
+        const string source = """
+            [sync]
+            url = "https://legacy.example.invalid/sync"
+            token = "fixture-legacy"
+            battlelogs = true
+            """;
+        var baseline = Load(source);
+        Assert.IsTrue(baseline.HasLegacyRootTarget);
+        var desired = RequireSuccess(
+            baseline.Topology!.UpdateTarget(
+                "default",
+                target => target.WithDataOverride(SyncDataKind.Battlelogs, SyncOverride.Explicit(false))));
+
+        var blocked = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var migration = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            desired,
+            migrateLegacyRoot: true);
+        var updated = Encoding.UTF8.GetString(migration.Apply(Encoding.UTF8.GetBytes(source)).Contents!);
+
+        Assert.IsFalse(blocked.IsValid);
+        Assert.IsTrue(blocked.Diagnostics.Any(item => item.Code == "SYNC_LEGACY_MIGRATION_REQUIRED"));
+        Assert.IsTrue(migration.IsValid);
+        StringAssert.Contains(updated, "[sync.targets.default]");
+        StringAssert.Contains(updated, "battlelogs = false");
+        var migrated = Load(updated);
+        var sparseLoad = SparseTomlDocument.Load(Encoding.UTF8.GetBytes(updated), out var document);
+        var overrides = document!.ReadOverrides();
+        Assert.IsTrue(sparseLoad.IsValid);
+        Assert.IsFalse(overrides.Overrides!.ContainsKey("sync.url"));
+        Assert.IsFalse(overrides.Overrides.ContainsKey("sync.token"));
+        Assert.IsTrue(overrides.Overrides.ContainsKey("sync.targets.default.url"));
+        Assert.IsFalse(migrated.HasLegacyRootTarget);
+    }
+
+    [TestMethod]
+    public void ExternalDisabledDraftRequiresAnExplicitPersistenceChoice()
+    {
+        var baseline = Load(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var desired = RequireSuccess(baseline.Topology!.SetTargetEnabled("community", false));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+
+        Assert.IsFalse(plan.IsValid);
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_EXTERNAL_DISABLED_PERSISTENCE_REQUIRED"));
+    }
+
+    [TestMethod]
+    public void KindChangeRequiresExplicitCompatibleOrResetDecision()
+    {
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            proxy = "target-proxy"
+            jobs = false
+            """;
+        var baseline = Load(source);
+        var preserved = RequireSuccess(
+            baseline.Topology!.ChangeTargetKind("community", SyncTargetKind.MajelIngest));
+        var reset = RequireSuccess(
+            baseline.Topology.ChangeTargetKind(
+                "community",
+                SyncTargetKind.MajelIngest,
+                SyncTargetKindChangePolicy.ResetOverrides));
+
+        var missingDecision = SyncTopologyPersistencePlanner.Build(baseline, preserved);
+        var mismatchedReset = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            preserved,
+            kindChangeDecisions: new Dictionary<string, SyncTargetKindChangePolicy>
+            {
+                ["community"] = SyncTargetKindChangePolicy.ResetOverrides,
+            });
+        var validReset = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            reset,
+            kindChangeDecisions: new Dictionary<string, SyncTargetKindChangePolicy>
+            {
+                ["community"] = SyncTargetKindChangePolicy.ResetOverrides,
+            });
+        var updated = Encoding.UTF8.GetString(validReset.Apply(Encoding.UTF8.GetBytes(source)).Contents!);
+
+        Assert.IsFalse(missingDecision.IsValid);
+        Assert.IsTrue(missingDecision.Diagnostics.Any(item => item.Code == "SYNC_KIND_CHANGE_DECISION_REQUIRED"));
+        Assert.IsFalse(mismatchedReset.IsValid);
+        Assert.IsTrue(mismatchedReset.Diagnostics.Any(item => item.Code == "SYNC_KIND_CHANGE_RESET_MISMATCH"));
+        Assert.IsTrue(validReset.IsValid);
+        StringAssert.Contains(updated, "mode = \"majel\"");
+        Assert.IsFalse(updated.Contains("proxy =", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("jobs = false", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void PersistedEffectiveValuesMatchTheLauncherPreviewAfterReload()
+    {
+        const string source = """
+            [sync]
+            proxy = "global-proxy"
+            jobs = true
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            """;
+        var baseline = Load(source);
+        var desired = baseline.Topology!.WithGlobalDefaults(
+            baseline.Topology.GlobalDefaults.WithDataKind(SyncDataKind.Jobs, false));
+        desired = RequireSuccess(
+            desired.UpdateTarget(
+                "community",
+                target => target
+                    .WithProxy(SyncOverride.Explicit(string.Empty))
+                    .WithVerifySsl(SyncOverride.Explicit(false))
+                    .WithUnsafeTls(SyncOverride.Explicit(true))));
+        var preview = desired.Resolve().Targets.Single();
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var edit = plan.Apply(Encoding.UTF8.GetBytes(source));
+        var reloaded = SyncTopologyTomlAdapter.Load(edit.Contents!).Topology!.Resolve().Targets.Single();
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.AreEqual(preview.Kind, reloaded.Kind);
+        Assert.AreEqual(preview.Url, reloaded.Url);
+        Assert.AreEqual(preview.CredentialsConfigured, reloaded.CredentialsConfigured);
+        Assert.AreEqual(preview.Proxy, reloaded.Proxy);
+        Assert.AreEqual(preview.VerifySsl, reloaded.VerifySsl);
+        Assert.AreEqual(
+            preview.AllowUnsafeTlsWithoutCertificateValidation,
+            reloaded.AllowUnsafeTlsWithoutCertificateValidation);
+        Assert.AreEqual(preview.DataKinds[SyncDataKind.Jobs], reloaded.DataKinds[SyncDataKind.Jobs]);
+    }
+
+    [TestMethod]
+    public async Task WorkspaceCommitUsesAtomicBackupAndDiscardRestoresBaseline()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var path = Path.Combine(temporaryDirectory.Path, "settings.toml");
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            """;
+        await File.WriteAllTextAsync(path, source);
+        var snapshot = new ConfigurationDocumentSnapshot(path, Encoding.UTF8.GetBytes(source));
+        var load = SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+        Assert.IsTrue(load.IsValid, load.Error?.Message);
+
+        var staged = RequireSuccess(
+            workspace!.Desired.UpdateTarget(
+                "community",
+                target => target.WithProxy(SyncOverride.Explicit(string.Empty))));
+        workspace.Stage(staged);
+        Assert.IsTrue(workspace.HasPendingChanges);
+        workspace.Discard();
+        Assert.IsFalse(workspace.HasPendingChanges);
+        Assert.IsFalse(workspace.Desired.Targets["community"].Proxy.IsExplicit);
+
+        workspace.Stage(staged);
+        var result = await workspace.CommitAsync();
+
+        Assert.AreEqual(AtomicTomlWriteState.Succeeded, result.State, result.Error);
+        Assert.IsFalse(workspace.HasPendingChanges);
+        StringAssert.Contains(await File.ReadAllTextAsync(path), "proxy = \"\"");
+        Assert.AreEqual(source, await File.ReadAllTextAsync(path + ".bak"));
+    }
+
+    [TestMethod]
+    public async Task WorkspaceConflictPreservesExternalFileAndPendingDraft()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var path = Path.Combine(temporaryDirectory.Path, "settings.toml");
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """;
+        await File.WriteAllTextAsync(path, source);
+        var snapshot = new ConfigurationDocumentSnapshot(path, Encoding.UTF8.GetBytes(source));
+        SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+        var staged = RequireSuccess(
+            workspace!.Desired.UpdateTarget(
+                "community",
+                target => target.WithDataOverride(SyncDataKind.Jobs, SyncOverride.Explicit(false))));
+        workspace.Stage(staged);
+        const string external = "# external change\n" + source;
+        await File.WriteAllTextAsync(path, external);
+
+        var result = await workspace.CommitAsync();
+
+        Assert.AreEqual(AtomicTomlWriteState.Conflict, result.State);
+        Assert.IsTrue(workspace.IsStale);
+        Assert.IsTrue(workspace.HasPendingChanges);
+        Assert.AreEqual(external, await File.ReadAllTextAsync(path));
+        Assert.IsFalse(File.Exists(path + ".bak"));
+    }
+
+    [TestMethod]
+    public void WorkspaceSemanticNoOpDoesNotCreatePendingChanges()
+    {
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """;
+        var snapshot = new ConfigurationDocumentSnapshot(
+            "settings.toml",
+            Encoding.UTF8.GetBytes(source));
+        SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+
+        workspace!.Stage(workspace.Desired);
+
+        Assert.IsFalse(workspace.HasPendingChanges);
+    }
+
+    [TestMethod]
+    public async Task WorkspaceConflictRemainsStaleAcrossStageAndDiscard()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var path = Path.Combine(temporaryDirectory.Path, "settings.toml");
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """;
+        await File.WriteAllTextAsync(path, source);
+        var snapshot = new ConfigurationDocumentSnapshot(path, Encoding.UTF8.GetBytes(source));
+        SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+        var staged = RequireSuccess(
+            workspace!.Desired.UpdateTarget(
+                "community",
+                target => target.WithDataOverride(SyncDataKind.Jobs, SyncOverride.Explicit(false))));
+        workspace.Stage(staged);
+        await File.WriteAllTextAsync(path, "# external change\n" + source);
+        Assert.AreEqual(AtomicTomlWriteState.Conflict, (await workspace.CommitAsync()).State);
+
+        workspace.Stage(staged);
+        Assert.IsTrue(workspace.IsStale);
+        workspace.Discard();
+
+        Assert.IsTrue(workspace.IsStale);
+        Assert.IsFalse(workspace.HasPendingChanges);
+    }
+
+    private static SyncTopologyTomlLoadResult Load(string source)
+    {
+        var load = SyncTopologyTomlAdapter.Load(Encoding.UTF8.GetBytes(source));
+        Assert.IsTrue(load.IsValid, load.Error?.Message);
+        Assert.IsNotNull(load.Topology);
+        return load;
+    }
+
+    private static SyncDesiredTopology RequireSuccess(SyncTopologyTransitionResult result)
+    {
+        Assert.IsTrue(result.Succeeded, result.Diagnostic?.Message);
+        return result.Topology;
+    }
+
+    private static string FindRepositoryFile(params string[] relativeParts)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine([directory.FullName, .. relativeParts]);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail($"Could not find repository file '{Path.Combine(relativeParts)}'.");
+        return string.Empty;
+    }
+}

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Tests/SyncWorkspaceViewModelTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Tests/SyncWorkspaceViewModelTests.cs
@@ -1,0 +1,255 @@
+using System.Text;
+using STFCCommunityMod.Launcher.Core;
+using STFCCommunityMod.Launcher.ViewModels;
+
+namespace STFCCommunityMod.Launcher.Tests;
+
+[TestClass]
+public sealed class SyncWorkspaceViewModelTests
+{
+    [TestMethod]
+    public void OpeningExistingTopologyDoesNotMutateSourceOrRevealSavedToken()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            # source must remain byte-identical
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "vip-secret-value"
+            """);
+        var before = File.ReadAllBytes(fixture.Path);
+
+        var viewModel = fixture.CreateViewModel();
+        var target = viewModel.Targets.Single();
+
+        CollectionAssert.AreEqual(before, File.ReadAllBytes(fixture.Path));
+        Assert.AreEqual("community", target.Name);
+        Assert.AreEqual("Saved token configured", target.TokenStatus);
+        Assert.IsFalse(target.TokenStatus.Contains("vip-secret-value", StringComparison.Ordinal));
+        Assert.IsFalse(target.ValidationSummary.Contains("vip-secret-value", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void AddSurfaceSupportsMixedTypedTargetsAndSidecarSingleton()
+    {
+        using var fixture = SyncFixture.Create("# empty\n");
+        var viewModel = fixture.CreateViewModel();
+
+        viewModel.AddSidecarCommand.Execute(null);
+        viewModel.NewTargetName = "majel-vip";
+        viewModel.AddMajelCommand.Execute(null);
+        viewModel.AddSpocksClubCommand.Execute(null);
+
+        Assert.AreEqual(3, viewModel.Targets.Count);
+        Assert.IsTrue(viewModel.Targets.Any(target => target.Name == "local-sidecar"));
+        Assert.IsTrue(viewModel.Targets.Any(target => target.Name == "majel-vip"));
+        Assert.IsTrue(viewModel.Targets.Any(target => target.Name == "spocksclub"));
+        Assert.IsFalse(viewModel.AddSidecarCommand.CanExecute(null));
+        Assert.AreEqual("Local Sidecar", viewModel.Targets.Single(target => target.Name == "local-sidecar").KindLabel);
+        Assert.AreEqual("Majel", viewModel.Targets.Single(target => target.Name == "majel-vip").KindLabel);
+    }
+
+    [TestMethod]
+    public void FeedOverrideShowsEffectiveValueAndProvenance()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            jobs = false
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var target = fixture.CreateViewModel().Targets.Single();
+        var jobs = target.Feeds.Single(feed => feed.Label == "Jobs");
+
+        Assert.AreEqual(SyncBooleanOverrideChoice.UseGlobal, jobs.Choice);
+        Assert.IsFalse(jobs.EffectiveEnabled);
+        StringAssert.Contains(jobs.EffectiveSummary, "inherited");
+
+        jobs.Choice = SyncBooleanOverrideChoice.Enabled;
+
+        Assert.IsTrue(jobs.EffectiveEnabled);
+        StringAssert.Contains(jobs.EffectiveSummary, "target override");
+    }
+
+    [TestMethod]
+    public void SecretReplacementRequiresExplicitActionAndDisplayRemainsOpaque()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "old-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        var target = viewModel.Targets.Single();
+        target.SetReplacementToken("new-secret");
+
+        Assert.IsFalse(viewModel.HasPendingChanges);
+        target.ReplaceTokenCommand.Execute(null);
+
+        Assert.IsTrue(viewModel.HasPendingChanges);
+        Assert.AreEqual("Saved token configured", viewModel.Targets.Single().TokenStatus);
+        Assert.IsFalse(viewModel.Targets.Single().TokenStatus.Contains("new-secret", StringComparison.Ordinal));
+        Assert.IsFalse(File.ReadAllText(fixture.Path).Contains("new-secret", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void TargetOverridesRepresentInheritedExplicitFalseAndExplicitClear()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            proxy = "http://global-proxy.example.invalid:8080"
+            verify_ssl = true
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var target = fixture.CreateViewModel().Targets.Single();
+
+        StringAssert.Contains(target.ProxySummary, "Inherited");
+        Assert.AreEqual(SyncBooleanOverrideChoice.UseGlobal, target.VerifySslChoice);
+
+        target.ProxyText = string.Empty;
+        target.VerifySslChoice = SyncBooleanOverrideChoice.Disabled;
+        target.UnsafeTlsChoice = SyncBooleanOverrideChoice.Enabled;
+
+        Assert.AreEqual("Explicitly cleared", target.ProxySummary);
+        Assert.AreEqual(SyncBooleanOverrideChoice.Disabled, target.VerifySslChoice);
+        Assert.AreEqual(SyncBooleanOverrideChoice.Enabled, target.UnsafeTlsChoice);
+    }
+
+    [TestMethod]
+    public void SidecarOnlyControlsAreExposedOnlyForSidecar()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sidecar.sync]
+            enabled = true
+            url = "http://127.0.0.1:43127/api/sidecar/ingest"
+            token = "fixture-sidecar-secret"
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-community-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        var sidecar = viewModel.Targets.Single(target => target.Name == "local-sidecar");
+        var community = viewModel.Targets.Single(target => target.Name == "community");
+
+        Assert.IsTrue(sidecar.ShowSidecarControls);
+        Assert.IsFalse(community.ShowSidecarControls);
+        sidecar.BattlelogEnrichmentChoice = SyncBooleanOverrideChoice.Enabled;
+        sidecar.FleetRuntimeModeChoice = "request_only";
+        Assert.AreEqual(SyncBooleanOverrideChoice.Enabled, sidecar.BattlelogEnrichmentChoice);
+        Assert.AreEqual("request_only", sidecar.FleetRuntimeModeChoice);
+    }
+
+    [TestMethod]
+    public void SiblingDraftBlocksSyncSaveWithoutDiscardingEitherDraft()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var siblingPending = false;
+        var viewModel = fixture.CreateViewModel(() => siblingPending);
+        viewModel.GlobalVerifySsl = false;
+        viewModel.GlobalUnsafeTls = true;
+        Assert.IsTrue(viewModel.CanSave);
+
+        siblingPending = true;
+
+        Assert.IsFalse(viewModel.CanSave);
+        Assert.IsTrue(viewModel.HasPendingChanges);
+        StringAssert.Contains(viewModel.SaveAvailability, "non-sync settings");
+    }
+
+    [TestMethod]
+    public void LegacyRootEditRequiresExplicitMigrationConfirmation()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-legacy-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        viewModel.Targets.Single().Url = "https://replacement.example.invalid/sync";
+
+        Assert.IsTrue(viewModel.HasLegacyRootTarget);
+        Assert.IsFalse(viewModel.CanSave);
+
+        viewModel.MigrateLegacyRoot = true;
+
+        Assert.IsTrue(viewModel.CanSave);
+    }
+
+    [TestMethod]
+    public async Task SaveUsesAtomicWorkspaceAndReloadsCommittedTopology()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            jobs = true
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        viewModel.GlobalFeeds.Single(feed => feed.Label == "Jobs").IsEnabled = false;
+
+        viewModel.SaveCommand.Execute(null);
+        await WaitUntilAsync(() => !viewModel.HasPendingChanges);
+
+        StringAssert.Contains(File.ReadAllText(fixture.Path), "jobs = false");
+        Assert.IsTrue(File.Exists(fixture.Path + ".bak"));
+        StringAssert.Contains(viewModel.OperationStatus, "Restart the game");
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        for (var attempt = 0; attempt < 100 && !condition(); ++attempt)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.IsTrue(condition(), "The asynchronous view-model action did not finish.");
+    }
+
+    private sealed class SyncFixture : IDisposable
+    {
+        private SyncFixture(string path) => Path = path;
+        public string Path { get; }
+
+        public static SyncFixture Create(string contents)
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"stfc-launcher-sync-{Guid.NewGuid():N}.toml");
+            File.WriteAllText(path, contents, new UTF8Encoding(false));
+            return new(path);
+        }
+
+        public SyncWorkspaceViewModel CreateViewModel(Func<bool>? siblingPending = null) =>
+            new(() => Path, new TomlConfigurationRepository(), siblingPending);
+
+        public void Dispose()
+        {
+            foreach (var path in new[] { Path, Path + ".bak" })
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #222
Closes #221

## Outcome

This umbrella completes the Windows launcher campaign:

- one human-facing install artifact: `STFCCommunityMod.Launcher.Setup.exe`
- a prominent working Launch Game action that accepts an existing manual mod install
- a locked target/provider compatibility corpus
- immutable typed desired topology with capability-aware inheritance
- source-preserving atomic TOML persistence with optimistic conflict protection
- a dedicated accessible WPF Sync workspace for global defaults and multiple Sidecar, Majel, preset, and custom community targets
- packaged live and disposable dogfood evidence

The machine-consumed self-update ZIP remains internal to signing/release assembly and is embedded by Setup; it is not exposed as a second public installation choice. Portable delivery remains deferred.

## Sync workspace

Data Sync now opens a dedicated workspace with:

- visually separate global defaults and virtualized target cards
- Local Sidecar singleton, Majel, Spocks Club preset, and custom community add paths
- effective feed summaries and inherited/on/off/value/clear provenance
- opaque unchanged/replace/clear token intent
- target validation, Sidecar-only controls, and explicit legacy-root migration
- coordinated ordinary-settings and Sync drafts so two document baselines cannot race
- atomic Save/Discard with restart timing and stale-file conflict feedback

## Release-equivalent validation

- 275 launcher tests passed (263 core + 12 WPF)
- 21 schema tests passed; generated schema current at 333 settings
- warning-free Windows Release solution build and clean format/diff checks
- Windows native release build passed
- complete launcher publish and one-file Setup inspection passed
- packaged UI Automation passed against the active manual configuration with unchanged TOML SHA-256
- packaged UI Automation passed against an isolated mixed-target fixture with unchanged TOML SHA-256
- the real launcher selection was restored byte-for-byte after disposable dogfood
- LexRunner discovered and ordered every child correctly; its configured-gate projection defect is documented on #221, and placeholder gates were never counted as evidence

PR builds remain unsigned by policy. The final tag workflow supplies the usable signed installer.