### PR TITLE
Lock launcher sync target contract and compatibility corpus

### DIFF
--- a/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
+++ b/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
@@ -1,0 +1,155 @@
+# Windows Launcher Sync Target Contract
+
+Status: locked for the `Windows Launcher: Sync Setup` campaign
+
+Contract artifact: `sync-target-contract.guffawaffle.v1.json`
+
+Compatibility corpus: `sync-target-corpus/cases.json`
+
+## Purpose
+
+This contract fixes the vocabulary and resolution rules shared by the native mod and Windows launcher before the
+launcher grows a multi-target editor. It separates what the user wrote from what the runtime can use, and prevents the
+UI, persistence layer, and native parser from independently inventing sync semantics.
+
+This slice is descriptive and executable evidence. It does not add target editing, migration writes, or new native
+transport behavior.
+
+## Topology
+
+The launcher owns two related views:
+
+- **Desired topology** is a source-faithful projection of the TOML. It includes global defaults, the fixed local
+  sidecar slot, named external targets, explicit values, and invalid or unsupported entries with diagnostics.
+- **Resolved topology** contains only runnable targets after validation, inheritance, safety policy, and legacy
+  compatibility have been applied. It records the source provenance of every effective value.
+
+Loading configuration never changes the desired topology or the TOML. A resolved target synthesized from legacy
+`[sync].url` and `[sync].token` is compatibility state, not permission to rewrite the source.
+
+## Target kinds and presets
+
+| Kind | Persistence | Cardinality | Wire contract | Notes |
+|---|---|---:|---|---|
+| Local Sidecar | `[sidecar.sync]` | Zero or one | Local sidecar ingest | Fixed launcher identity; not an external target and never receives external network policy by inheritance. |
+| Legacy/community | `[sync.targets.<name>]` | Zero or more | Legacy STFC sync JSON | `mode` absent, empty, or `legacy`. Spocks Club presets use this kind. |
+| Majel ingest | `[sync.targets.<name>]` | Zero or more | `majel.ingest.v1` envelopes | `mode = "majel"`; one-way event ingest only. |
+
+Provider names are presets, not protocol types:
+
+- **Spocks Club** creates a legacy/community target with the suggested identity `spocksclub`.
+- **Next Spocks Club** creates a legacy/community target with the suggested identity `nextspocksclub`.
+- **Custom legacy/community** and **Custom Majel** use the same concrete kinds without provider branding.
+
+The local sidecar appears as a target card in the launcher, but persists to the singleton `[sidecar.sync]` table. It is
+not represented as `[sync.targets.sidecar]`.
+
+## Field and capability matrix
+
+`I` means the external target may inherit the global value when absent. `E` means the setting is explicit on that
+target kind. `F` means forbidden. A dash means the field is not part of that target kind.
+
+| Field/capability | Global `[sync]` | Local Sidecar | Legacy/community | Majel ingest |
+|---|---:|---:|---:|---:|
+| Target identity | - | Fixed | E | E |
+| Enabled state | - | E | Launcher desired state | Launcher desired state |
+| URL | Compatibility only | E | E | E |
+| Token | Compatibility only | E | E | E |
+| Mode | - | - | E (`legacy`) | E (`majel`) |
+| Proxy | Default | E, never inherited | I | I |
+| Verify TLS | Default | E, never inherited | I | I |
+| Unsafe TLS opt-in | Default | E, never inherited | I | I |
+| Standard sync categories | Defaults | - | I | I, transport-filtered |
+| Realtime battle logs | Default | E, never inherited | I | I |
+| Fleet runtime | Not routable externally | E, never inherited | F | F |
+| Battle-log enrichment | - | E, never inherited | - | - |
+| Fleet runtime mode | - | E, never inherited | - | - |
+
+External `enabled` is launcher desired-state metadata until the native config grows a canonical persisted field. The
+launcher must not invent an unrecognized TOML key. In the initial editor, disabling an existing external target is a
+pending edit that requires an explicitly selected supported persistence strategy; merely viewing or loading it does
+nothing.
+
+Majel targets use the same category inputs as legacy targets, followed by the native transport capability filter.
+Majel-only capability and fleet-assignment snapshots are transport behavior and are not new inherited user fields.
+
+## Inheritance and provenance
+
+Inheritance is field-scoped, not table-scoped. For each resolved field the launcher records one of:
+
+- `inherited`: the target omitted an inheritable field and uses `[sync]`.
+- `explicit_value`: the target supplied a value, including `true` and non-empty strings.
+- `explicit_false`: the target explicitly supplied boolean `false`; it overrides global `true`.
+- `explicit_empty`: the target explicitly supplied an empty string where empty is meaningful; it overrides a non-empty
+  global value. This is permitted for `proxy` and means no proxy.
+
+URL, token, target identity, enabled state, mode, and type-only settings never inherit. An absent required URL or token
+is not equivalent to an inherited credential. Secrets must not flow between targets.
+
+The local sidecar never inherits external proxy, TLS, unsafe-TLS, or category defaults. Its values come only from
+`[sidecar.sync]` and native sidecar defaults. This prevents an internet proxy or relaxed external TLS policy from being
+silently applied to loopback ingest.
+
+## Validation and compatibility rules
+
+Resolution uses these stable outcomes:
+
+- `error`: target is retained in desired topology but excluded from resolved topology.
+- `warning`: target may resolve, but a field is ignored, normalized, or deprecated.
+- `info`: compatibility behavior was applied without changing the source.
+
+Rules:
+
+1. An external target requires string `url` and string `token` assignments. Missing or invalid credentials produce an
+   error and the target is not runnable. Empty credentials are displayed as incomplete and are never inherited.
+2. External loopback sidecar ingest URLs, `[sync.targets.sidecar]`, and `mode = "sidecar_broker"` are errors. The
+   corrective destination is `[sidecar.sync]`.
+3. External `fleet_runtime = true` produces a warning and resolves to false. Fleet runtime is sidecar-only.
+4. Unknown target modes warn and resolve as legacy for native compatibility. The launcher must not silently rewrite the
+   unknown source value; an explicit user correction is required.
+5. When both non-empty legacy `[sync].url` and `[sync].token` are present and the URL is not a rejected loopback sidecar
+   endpoint, resolved topology synthesizes a legacy/community target named `default`. The source remains untouched.
+6. One missing legacy root credential produces a warning and no synthesized target.
+7. If both a named `sync.targets.default` and legacy root credentials exist, the named target wins and the failed
+   conversion is diagnosed.
+8. Unknown keys, comments, ordering, line endings, and supported formatting survive all unrelated edits.
+
+## Migration and mutation policy
+
+- Reads, validation, preview, target selection, and resolved-value display are non-mutating.
+- Existing valid TOML is never normalized merely because the launcher opened it.
+- Legacy root conversion is virtual until the user requests migration, reviews a source diff, and confirms one atomic
+  write.
+- Invalid and unsupported entries remain in the source unless the user explicitly edits or removes them.
+- Sparse writes touch only the selected assignment or target block and preserve unknown content.
+- A stale revision, duplicate table, unsupported TOML construct, failed backup, or failed verification aborts the
+  entire write.
+- Presets create a desired draft. They do not send traffic or persist credentials before confirmation.
+
+## Security and secret display
+
+- Tokens are secrets. List and summary views show only configured/missing state, never token contents.
+- A detail editor may reveal a token only through a deliberate transient action; it must not place the value in logs,
+  diagnostics, telemetry, error text, screenshots generated by automation, or campaign fixtures.
+- Proxy user information is masked in summaries and logs.
+- Copying or exporting diagnostics always redacts tokens and proxy credentials.
+- `verify_ssl = false` is effective only with the explicit unsafe-TLS opt-in accepted by native policy. The launcher
+  presents this as a high-risk pair, not as an ordinary convenience toggle.
+- Sidecar loopback credentials remain secret even though the endpoint is local.
+- Presets contain no real URLs or credentials unless the provider contract publishes a stable public endpoint.
+
+## Corpus authority
+
+`sync-target-corpus/cases.json` enumerates the compatibility cases required by issue #223. Each TOML fixture is valid,
+source-preserving input. Its expected target kinds, provenance states, and diagnostic codes are declarative inputs for
+the LS-003 domain resolver and LS-004 persistence tests.
+
+The LS-002 test suite currently enforces:
+
+- every required case and fixture exists;
+- every fixture is readable by the launcher's conservative TOML surface without byte mutation;
+- declared paths exist exactly as written;
+- diagnostic identifiers and provenance states come from the locked machine contract;
+- security, non-inheritance, and sidecar-only invariants cannot drift unnoticed.
+
+Later slices must consume this corpus rather than copying the examples into new private test data.

--- a/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
+++ b/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
@@ -1,0 +1,139 @@
+{
+  "schemaVersion": "1.0.0",
+  "provenanceStates": [
+    "inherited",
+    "explicit_value",
+    "explicit_false",
+    "explicit_empty"
+  ],
+  "diagnosticSeverities": [
+    "info",
+    "warning",
+    "error"
+  ],
+  "targetKinds": {
+    "local_sidecar": {
+      "persistencePattern": "sidecar.sync",
+      "cardinality": "zero_or_one",
+      "wireContract": "sidecar_local_ingest",
+      "inheritsGlobalSync": false
+    },
+    "legacy_community": {
+      "persistencePattern": "sync.targets.*",
+      "cardinality": "zero_or_more",
+      "wireContract": "legacy_sync_json",
+      "inheritsGlobalSync": true
+    },
+    "majel_ingest": {
+      "persistencePattern": "sync.targets.*",
+      "cardinality": "zero_or_more",
+      "wireContract": "majel.ingest.v1",
+      "inheritsGlobalSync": true
+    }
+  },
+  "presets": {
+    "spocks_club": {
+      "targetKind": "legacy_community",
+      "suggestedIdentity": "spocksclub"
+    },
+    "next_spocks_club": {
+      "targetKind": "legacy_community",
+      "suggestedIdentity": "nextspocksclub"
+    }
+  },
+  "fields": {
+    "identity": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "enabled": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "url": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "token": {
+      "inheritance": "never",
+      "secret": true,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "mode": {
+      "inheritance": "never",
+      "secret": false,
+      "kinds": ["legacy_community", "majel_ingest"]
+    },
+    "proxy": {
+      "inheritance": "external_only",
+      "allowsExplicitEmpty": true,
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "verify_ssl": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "allow_unsafe_tls_without_certificate_validation": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "sync_categories": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["legacy_community", "majel_ingest"]
+    },
+    "battlelogs_realtime": {
+      "inheritance": "external_only",
+      "secret": false,
+      "kinds": ["local_sidecar", "legacy_community", "majel_ingest"]
+    },
+    "fleet_runtime": {
+      "inheritance": "never",
+      "secret": false,
+      "sidecarOnly": true,
+      "kinds": ["local_sidecar"]
+    },
+    "battlelog_enrichment": {
+      "inheritance": "never",
+      "secret": false,
+      "sidecarOnly": true,
+      "kinds": ["local_sidecar"]
+    },
+    "fleet_runtime_mode": {
+      "inheritance": "never",
+      "secret": false,
+      "sidecarOnly": true,
+      "kinds": ["local_sidecar"]
+    }
+  },
+  "diagnostics": {
+    "SYNC_CREDENTIALS_INCOMPLETE": "error",
+    "SYNC_EXTERNAL_FLEET_RUNTIME_UNSUPPORTED": "warning",
+    "SYNC_LEGACY_ROOT_CONVERTED": "info",
+    "SYNC_LEGACY_ROOT_INCOMPLETE": "warning",
+    "SYNC_LOOPBACK_TARGET_INVALID": "error",
+    "SYNC_TARGET_MODE_INVALID": "warning",
+    "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID": "error",
+    "SYNC_UNKNOWN_KEY_PRESERVED": "warning"
+  },
+  "mutationPolicy": {
+    "load": "never",
+    "resolve": "never",
+    "legacyConversion": "preview_then_explicit_atomic_write",
+    "preserveUnknownKeys": true,
+    "preserveComments": true,
+    "preserveOrdering": true
+  },
+  "security": {
+    "redactFields": ["token"],
+    "maskProxyUserInfo": true,
+    "unsafeTlsRequiresExplicitPair": true,
+    "sidecarInheritsExternalNetworkPolicy": false
+  }
+}

--- a/docs/windows-launcher/sync-target-corpus/canonical-local-sidecar.toml
+++ b/docs/windows-launcher/sync-target-corpus/canonical-local-sidecar.toml
@@ -1,0 +1,15 @@
+[sync]
+proxy = "http://external-proxy.example.invalid:8080"
+verify_ssl = false
+
+[sidecar.sync]
+enabled = true
+url = "http://127.0.0.1:43127/api/sidecar/ingest"
+token = "fixture-redacted-sidecar"
+proxy = ""
+verify_ssl = true
+allow_unsafe_tls_without_certificate_validation = false
+battlelogs_realtime = true
+battlelog_enrichment = true
+fleet_runtime = true
+fleet_runtime_mode = "normal"

--- a/docs/windows-launcher/sync-target-corpus/cases.json
+++ b/docs/windows-launcher/sync-target-corpus/cases.json
@@ -1,0 +1,205 @@
+{
+  "schemaVersion": "1.0.0",
+  "contract": "../sync-target-contract.guffawaffle.v1.json",
+  "cases": [
+    {
+      "id": "global-only-defaults",
+      "file": "global-only-defaults.toml",
+      "expectedTargetKinds": [],
+      "expectedPaths": [
+        "sync.allow_unsafe_tls_without_certificate_validation",
+        "sync.battlelogs",
+        "sync.jobs",
+        "sync.proxy",
+        "sync.verify_ssl"
+      ],
+      "provenance": {},
+      "diagnostics": []
+    },
+    {
+      "id": "legacy-spocks-presets",
+      "file": "legacy-spocks-presets.toml",
+      "expectedTargetKinds": ["legacy_community", "legacy_community"],
+      "expectedPaths": [
+        "sync.battlelogs",
+        "sync.targets.nextspocksclub.mode",
+        "sync.targets.nextspocksclub.token",
+        "sync.targets.nextspocksclub.url",
+        "sync.targets.spocksclub.mode",
+        "sync.targets.spocksclub.token",
+        "sync.targets.spocksclub.url"
+      ],
+      "provenance": {
+        "nextspocksclub.battlelogs": "inherited",
+        "nextspocksclub.mode": "explicit_value",
+        "spocksclub.battlelogs": "inherited",
+        "spocksclub.mode": "explicit_value"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "majel-realtime",
+      "file": "majel-realtime.toml",
+      "expectedTargetKinds": ["majel_ingest"],
+      "expectedPaths": [
+        "sync.battlelogs_realtime",
+        "sync.targets.majel.battlelogs",
+        "sync.targets.majel.mode",
+        "sync.targets.majel.token",
+        "sync.targets.majel.url"
+      ],
+      "provenance": {
+        "majel.battlelogs": "explicit_false",
+        "majel.battlelogs_realtime": "inherited",
+        "majel.mode": "explicit_value"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "canonical-local-sidecar",
+      "file": "canonical-local-sidecar.toml",
+      "expectedTargetKinds": ["local_sidecar"],
+      "expectedPaths": [
+        "sidecar.sync.allow_unsafe_tls_without_certificate_validation",
+        "sidecar.sync.battlelog_enrichment",
+        "sidecar.sync.battlelogs_realtime",
+        "sidecar.sync.enabled",
+        "sidecar.sync.fleet_runtime",
+        "sidecar.sync.fleet_runtime_mode",
+        "sidecar.sync.proxy",
+        "sidecar.sync.token",
+        "sidecar.sync.url",
+        "sidecar.sync.verify_ssl",
+        "sync.proxy",
+        "sync.verify_ssl"
+      ],
+      "provenance": {
+        "local_sidecar.proxy": "explicit_empty",
+        "local_sidecar.verify_ssl": "explicit_value"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "mixed-multiple-targets",
+      "file": "mixed-multiple-targets.toml",
+      "expectedTargetKinds": ["local_sidecar", "legacy_community", "majel_ingest"],
+      "expectedPaths": [
+        "sidecar.sync.battlelogs_realtime",
+        "sidecar.sync.enabled",
+        "sidecar.sync.token",
+        "sidecar.sync.url",
+        "sync.jobs",
+        "sync.targets.community.jobs",
+        "sync.targets.community.mode",
+        "sync.targets.community.token",
+        "sync.targets.community.url",
+        "sync.targets.majel.battlelogs_realtime",
+        "sync.targets.majel.mode",
+        "sync.targets.majel.token",
+        "sync.targets.majel.url"
+      ],
+      "provenance": {
+        "community.jobs": "explicit_false",
+        "majel.jobs": "inherited"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "explicit-false-overrides-global",
+      "file": "explicit-false-overrides-global.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.battlelogs",
+        "sync.targets.optout.battlelogs",
+        "sync.targets.optout.token",
+        "sync.targets.optout.url"
+      ],
+      "provenance": {
+        "optout.battlelogs": "explicit_false"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "explicit-empty-proxy",
+      "file": "explicit-empty-proxy.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.proxy",
+        "sync.targets.direct.proxy",
+        "sync.targets.direct.token",
+        "sync.targets.direct.url"
+      ],
+      "provenance": {
+        "direct.proxy": "explicit_empty"
+      },
+      "diagnostics": []
+    },
+    {
+      "id": "missing-partial-credentials",
+      "file": "missing-partial-credentials.toml",
+      "expectedTargetKinds": [],
+      "expectedPaths": [
+        "sync.targets.missing_token.url",
+        "sync.targets.missing_url.token"
+      ],
+      "provenance": {},
+      "diagnostics": ["SYNC_CREDENTIALS_INCOMPLETE"]
+    },
+    {
+      "id": "unsupported-external-fleet-runtime",
+      "file": "unsupported-external-fleet-runtime.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.targets.external.fleet_runtime",
+        "sync.targets.external.token",
+        "sync.targets.external.url"
+      ],
+      "provenance": {
+        "external.fleet_runtime": "explicit_value"
+      },
+      "diagnostics": ["SYNC_EXTERNAL_FLEET_RUNTIME_UNSUPPORTED"]
+    },
+    {
+      "id": "legacy-root-conversion",
+      "file": "legacy-root-conversion.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "sync.battlelogs",
+        "sync.token",
+        "sync.url"
+      ],
+      "provenance": {
+        "default.identity": "explicit_value"
+      },
+      "diagnostics": ["SYNC_LEGACY_ROOT_CONVERTED"]
+    },
+    {
+      "id": "invalid-loopback-external-target",
+      "file": "invalid-loopback-external-target.toml",
+      "expectedTargetKinds": [],
+      "expectedPaths": [
+        "sync.targets.sidecar.mode",
+        "sync.targets.sidecar.token",
+        "sync.targets.sidecar.url"
+      ],
+      "provenance": {},
+      "diagnostics": [
+        "SYNC_LOOPBACK_TARGET_INVALID",
+        "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID"
+      ]
+    },
+    {
+      "id": "unknown-source-content-preserved",
+      "file": "unknown-source-content-preserved.toml",
+      "expectedTargetKinds": ["legacy_community"],
+      "expectedPaths": [
+        "future_sync_setting",
+        "sync.targets.future.future_transport_option",
+        "sync.targets.future.token",
+        "sync.targets.future.url"
+      ],
+      "provenance": {},
+      "diagnostics": ["SYNC_UNKNOWN_KEY_PRESERVED"]
+    }
+  ]
+}

--- a/docs/windows-launcher/sync-target-corpus/explicit-empty-proxy.toml
+++ b/docs/windows-launcher/sync-target-corpus/explicit-empty-proxy.toml
@@ -1,0 +1,7 @@
+[sync]
+proxy = "http://proxy.example.invalid:8080"
+
+[sync.targets.direct]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-direct"
+proxy = ""

--- a/docs/windows-launcher/sync-target-corpus/explicit-false-overrides-global.toml
+++ b/docs/windows-launcher/sync-target-corpus/explicit-false-overrides-global.toml
@@ -1,0 +1,7 @@
+[sync]
+battlelogs = true
+
+[sync.targets.optout]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-optout"
+battlelogs = false

--- a/docs/windows-launcher/sync-target-corpus/global-only-defaults.toml
+++ b/docs/windows-launcher/sync-target-corpus/global-only-defaults.toml
@@ -1,0 +1,7 @@
+# Defaults without a target are valid desired state and create no runnable target.
+[sync]
+proxy = "http://proxy.example.invalid:8080"
+verify_ssl = true
+allow_unsafe_tls_without_certificate_validation = false
+battlelogs = true
+jobs = false

--- a/docs/windows-launcher/sync-target-corpus/invalid-loopback-external-target.toml
+++ b/docs/windows-launcher/sync-target-corpus/invalid-loopback-external-target.toml
@@ -1,0 +1,4 @@
+[sync.targets.sidecar]
+url = "http://127.0.0.1:43127/api/sidecar/ingest"
+token = "fixture-redacted-invalid"
+mode = "sidecar_broker"

--- a/docs/windows-launcher/sync-target-corpus/legacy-root-conversion.toml
+++ b/docs/windows-launcher/sync-target-corpus/legacy-root-conversion.toml
@@ -1,0 +1,4 @@
+[sync]
+url = "https://legacy.example.invalid/sync"
+token = "fixture-redacted-legacy"
+battlelogs = true

--- a/docs/windows-launcher/sync-target-corpus/legacy-spocks-presets.toml
+++ b/docs/windows-launcher/sync-target-corpus/legacy-spocks-presets.toml
@@ -1,0 +1,12 @@
+[sync]
+battlelogs = true
+
+[sync.targets.spocksclub]
+url = "https://legacy.example.invalid/sync"
+token = "fixture-redacted-spocks"
+mode = "legacy"
+
+[sync.targets.nextspocksclub]
+url = "https://next.example.invalid/sync"
+token = "fixture-redacted-next"
+mode = "legacy"

--- a/docs/windows-launcher/sync-target-corpus/majel-realtime.toml
+++ b/docs/windows-launcher/sync-target-corpus/majel-realtime.toml
@@ -1,0 +1,8 @@
+[sync]
+battlelogs_realtime = true
+
+[sync.targets.majel]
+url = "https://majel.example.invalid/api/ingest/events"
+token = "fixture-redacted-majel"
+mode = "majel"
+battlelogs = false

--- a/docs/windows-launcher/sync-target-corpus/missing-partial-credentials.toml
+++ b/docs/windows-launcher/sync-target-corpus/missing-partial-credentials.toml
@@ -1,0 +1,5 @@
+[sync.targets.missing_token]
+url = "https://community.example.invalid/sync"
+
+[sync.targets.missing_url]
+token = "fixture-redacted-partial"

--- a/docs/windows-launcher/sync-target-corpus/mixed-multiple-targets.toml
+++ b/docs/windows-launcher/sync-target-corpus/mixed-multiple-targets.toml
@@ -1,0 +1,20 @@
+[sync]
+jobs = true
+
+[sidecar.sync]
+enabled = true
+url = "http://localhost:43127/api/sidecar/ingest"
+token = "fixture-redacted-sidecar"
+battlelogs_realtime = true
+
+[sync.targets.community]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-community"
+mode = "legacy"
+jobs = false
+
+[sync.targets.majel]
+url = "https://majel.example.invalid/api/ingest/events"
+token = "fixture-redacted-majel"
+mode = "majel"
+battlelogs_realtime = true

--- a/docs/windows-launcher/sync-target-corpus/unknown-source-content-preserved.toml
+++ b/docs/windows-launcher/sync-target-corpus/unknown-source-content-preserved.toml
@@ -1,0 +1,7 @@
+# The launcher does not own this root key.
+future_sync_setting = "keep exactly"
+
+[sync.targets.future]
+url = "https://future.example.invalid/sync"
+token = "fixture-redacted-future"
+future_transport_option = "preserve me" # including this comment

--- a/docs/windows-launcher/sync-target-corpus/unsupported-external-fleet-runtime.toml
+++ b/docs/windows-launcher/sync-target-corpus/unsupported-external-fleet-runtime.toml
@@ -1,0 +1,4 @@
+[sync.targets.external]
+url = "https://community.example.invalid/sync"
+token = "fixture-redacted-external"
+fleet_runtime = true

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.Core.Tests;
+
+[TestClass]
+public sealed class SyncTargetContractCorpusTests
+{
+    private static readonly string[] RequiredCaseIds =
+    [
+        "canonical-local-sidecar",
+        "explicit-empty-proxy",
+        "explicit-false-overrides-global",
+        "global-only-defaults",
+        "invalid-loopback-external-target",
+        "legacy-root-conversion",
+        "legacy-spocks-presets",
+        "majel-realtime",
+        "missing-partial-credentials",
+        "mixed-multiple-targets",
+        "unknown-source-content-preserved",
+        "unsupported-external-fleet-runtime",
+    ];
+
+    private static readonly string[] LockedProvenanceStates =
+    [
+        "inherited",
+        "explicit_value",
+        "explicit_false",
+        "explicit_empty",
+    ];
+
+    private static readonly string[] LocalSidecarKindOnly = ["local_sidecar"];
+
+    [TestMethod]
+    public void CorpusCoversLockedCompatibilityCasesAndPreservesEveryFixtureByte()
+    {
+        using var corpus = LoadJson("docs", "windows-launcher", "sync-target-corpus", "cases.json");
+        var cases = corpus.RootElement.GetProperty("cases").EnumerateArray().ToArray();
+
+        CollectionAssert.AreEquivalent(
+            RequiredCaseIds,
+            cases.Select(item => item.GetProperty("id").GetString()).ToArray());
+
+        foreach (var corpusCase in cases)
+        {
+            var id = corpusCase.GetProperty("id").GetString();
+            var fixturePath = FindRepositoryFile(
+                "docs",
+                "windows-launcher",
+                "sync-target-corpus",
+                corpusCase.GetProperty("file").GetString()!);
+            var contents = File.ReadAllBytes(fixturePath);
+
+            var load = SparseTomlDocument.Load(contents, out var document);
+            Assert.IsTrue(load.IsValid, $"{id}: {load.Error?.Message}");
+            Assert.IsNotNull(document, id);
+
+            var validation = document.ValidateForMutation();
+            Assert.IsTrue(validation.IsValid, $"{id}: {validation.Error?.Message}");
+            Assert.IsFalse(validation.Changed, id);
+            CollectionAssert.AreEqual(contents, validation.Contents, id);
+
+            var read = document.ReadOverrides();
+            Assert.IsTrue(read.IsValid, $"{id}: {read.Error?.Message}");
+            CollectionAssert.AreEquivalent(
+                corpusCase.GetProperty("expectedPaths")
+                    .EnumerateArray()
+                    .Select(item => item.GetString())
+                    .ToArray(),
+                read.Overrides!.Keys.ToArray(),
+                id);
+
+            foreach (var token in read.Overrides.Values.Where(
+                         value => value.CanonicalPath.EndsWith(".token", StringComparison.Ordinal)))
+            {
+                StringAssert.Contains(token.RenderedValue, "fixture-redacted-", id);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ContractLocksInheritanceSecurityAndSidecarBoundaries()
+    {
+        using var contract = LoadJson(
+            "docs",
+            "windows-launcher",
+            "sync-target-contract.guffawaffle.v1.json");
+        var root = contract.RootElement;
+
+        CollectionAssert.AreEquivalent(
+            LockedProvenanceStates,
+            root.GetProperty("provenanceStates").EnumerateArray().Select(item => item.GetString()).ToArray());
+
+        var kinds = root.GetProperty("targetKinds");
+        Assert.IsFalse(kinds.GetProperty("local_sidecar").GetProperty("inheritsGlobalSync").GetBoolean());
+        Assert.IsTrue(kinds.GetProperty("legacy_community").GetProperty("inheritsGlobalSync").GetBoolean());
+        Assert.IsTrue(kinds.GetProperty("majel_ingest").GetProperty("inheritsGlobalSync").GetBoolean());
+
+        var fields = root.GetProperty("fields");
+        foreach (var field in new[] { "identity", "enabled", "url", "token", "mode" })
+        {
+            Assert.AreEqual("never", fields.GetProperty(field).GetProperty("inheritance").GetString(), field);
+        }
+
+        Assert.AreEqual("external_only", fields.GetProperty("proxy").GetProperty("inheritance").GetString());
+        Assert.IsTrue(fields.GetProperty("proxy").GetProperty("allowsExplicitEmpty").GetBoolean());
+        Assert.IsTrue(fields.GetProperty("token").GetProperty("secret").GetBoolean());
+
+        var fleetRuntime = fields.GetProperty("fleet_runtime");
+        Assert.IsTrue(fleetRuntime.GetProperty("sidecarOnly").GetBoolean());
+        CollectionAssert.AreEqual(
+            LocalSidecarKindOnly,
+            fleetRuntime.GetProperty("kinds").EnumerateArray().Select(item => item.GetString()).ToArray());
+
+        var mutation = root.GetProperty("mutationPolicy");
+        Assert.AreEqual("never", mutation.GetProperty("load").GetString());
+        Assert.AreEqual("never", mutation.GetProperty("resolve").GetString());
+        Assert.IsTrue(mutation.GetProperty("preserveUnknownKeys").GetBoolean());
+        Assert.IsTrue(mutation.GetProperty("preserveComments").GetBoolean());
+        Assert.IsTrue(mutation.GetProperty("preserveOrdering").GetBoolean());
+
+        var security = root.GetProperty("security");
+        Assert.IsFalse(security.GetProperty("sidecarInheritsExternalNetworkPolicy").GetBoolean());
+        Assert.IsTrue(security.GetProperty("unsafeTlsRequiresExplicitPair").GetBoolean());
+        CollectionAssert.Contains(
+            security.GetProperty("redactFields").EnumerateArray().Select(item => item.GetString()).ToArray(),
+            "token");
+    }
+
+    [TestMethod]
+    public void CorpusUsesOnlyContractVocabulary()
+    {
+        using var contract = LoadJson(
+            "docs",
+            "windows-launcher",
+            "sync-target-contract.guffawaffle.v1.json");
+        using var corpus = LoadJson("docs", "windows-launcher", "sync-target-corpus", "cases.json");
+
+        var targetKinds = contract.RootElement.GetProperty("targetKinds")
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        var provenanceStates = contract.RootElement.GetProperty("provenanceStates")
+            .EnumerateArray()
+            .Select(item => item.GetString()!)
+            .ToHashSet(StringComparer.Ordinal);
+        var diagnostics = contract.RootElement.GetProperty("diagnostics")
+            .EnumerateObject()
+            .Select(property => property.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var corpusCase in corpus.RootElement.GetProperty("cases").EnumerateArray())
+        {
+            var id = corpusCase.GetProperty("id").GetString();
+            foreach (var targetKind in corpusCase.GetProperty("expectedTargetKinds").EnumerateArray())
+            {
+                Assert.IsTrue(targetKinds.Contains(targetKind.GetString()!), $"{id}: unknown target kind");
+            }
+
+            foreach (var provenance in corpusCase.GetProperty("provenance").EnumerateObject())
+            {
+                Assert.IsTrue(
+                    provenanceStates.Contains(provenance.Value.GetString()!),
+                    $"{id}: unknown provenance state for {provenance.Name}");
+            }
+
+            foreach (var diagnostic in corpusCase.GetProperty("diagnostics").EnumerateArray())
+            {
+                Assert.IsTrue(diagnostics.Contains(diagnostic.GetString()!), $"{id}: unknown diagnostic");
+            }
+        }
+    }
+
+    private static JsonDocument LoadJson(params string[] relativeParts) =>
+        JsonDocument.Parse(File.ReadAllBytes(FindRepositoryFile(relativeParts)));
+
+    private static string FindRepositoryFile(params string[] relativeParts)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine([directory.FullName, .. relativeParts]);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail($"Could not find repository file '{Path.Combine(relativeParts)}'.");
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary

- lock the launcher vocabulary for local Sidecar, legacy/community, and Majel ingest targets
- distinguish provider presets from transport kinds
- define desired-versus-resolved topology, field-scoped inheritance, and four provenance states
- freeze mutation, migration, TLS, proxy, and secret-display rules
- add a machine-readable contract and twelve compatibility TOML fixtures
- add executable tests that enforce corpus completeness, byte-preserving reads, path inventories, and contract vocabulary

## Why

Sync behavior already existed across the native parser, sidecar parser, transport policy, example TOML, and launcher sparse editor, but no single contract prevented later domain, persistence, and WPF slices from inventing different semantics. This captures those boundaries before implementation.

## Impact

Later campaign work can consume one shared corpus for topology resolution and persistence. Loading or validating a configuration remains non-mutating. Local Sidecar is modeled as a launcher target card but stays in the singleton `[sidecar.sync]` namespace and never inherits external proxy or unsafe TLS policy.

This is a child PR into the launcher campaign umbrella. It does not target `main` and does not require the final GitHub CI boundary.

## Validation

- `dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release --no-restore` — 226 core + 3 WPF tests
- `node --test scripts/test_config_schema.mjs` — 21 tests
- `node scripts/generate_config_schema.mjs --check`
- `xmake f -p windows -m release -y && xmake -y stfc-community-mod`
- `dotnet format windows-launcher/STFCCommunityMod.Launcher.sln --no-restore`
- `git diff --check`

Closes #223
Parent campaign: #221
Umbrella PR: #227