### PR TITLE
Implement launcher desired sync topology domain

### DIFF
--- a/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
+++ b/docs/windows-launcher/SYNC_TARGET_CONTRACT.md
@@ -77,7 +77,8 @@ Majel-only capability and fleet-assignment snapshots are transport behavior and 
 
 Inheritance is field-scoped, not table-scoped. For each resolved field the launcher records one of:
 
-- `inherited`: the target omitted an inheritable field and uses `[sync]`.
+- `inherited`: the target omitted the field. External targets resolve it from `[sync]`; non-inheriting target kinds
+  resolve it from their own safe type default. Resolved values retain that source distinction.
 - `explicit_value`: the target supplied a value, including `true` and non-empty strings.
 - `explicit_false`: the target explicitly supplied boolean `false`; it overrides global `true`.
 - `explicit_empty`: the target explicitly supplied an empty string where empty is meaningful; it overrides a non-empty

--- a/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
+++ b/docs/windows-launcher/sync-target-contract.guffawaffle.v1.json
@@ -6,6 +6,11 @@
     "explicit_false",
     "explicit_empty"
   ],
+  "resolutionSources": [
+    "global_default",
+    "target_type_default",
+    "target"
+  ],
   "diagnosticSeverities": [
     "info",
     "warning",

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
@@ -1,0 +1,483 @@
+using System.Collections.ObjectModel;
+using System.Text.RegularExpressions;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public sealed class SyncDesiredTopology
+{
+    public const string LocalSidecarIdentity = "local-sidecar";
+
+    private static readonly Regex TargetNamePattern = new(
+        "^[A-Za-z0-9_-]+$",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+
+    private readonly ReadOnlyDictionary<string, SyncTargetDraft> targets;
+
+    public SyncDesiredTopology(
+        SyncGlobalDefaults globalDefaults,
+        IReadOnlyDictionary<string, SyncTargetDraft>? targets = null)
+    {
+        GlobalDefaults = globalDefaults ?? throw new ArgumentNullException(nameof(globalDefaults));
+        this.targets = new(
+            targets?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal) ??
+            new Dictionary<string, SyncTargetDraft>(StringComparer.Ordinal));
+    }
+
+    public SyncGlobalDefaults GlobalDefaults { get; }
+
+    public IReadOnlyDictionary<string, SyncTargetDraft> Targets => targets;
+
+    public static SyncDesiredTopology Empty { get; } =
+        new(new SyncGlobalDefaults(string.Empty, true, false));
+
+    public SyncDesiredTopology WithGlobalDefaults(SyncGlobalDefaults value) => new(value, targets);
+
+    public SyncTopologyTransitionResult AddTarget(string name, SyncTargetKind kind)
+    {
+        var identity = kind == SyncTargetKind.LocalSidecar ? LocalSidecarIdentity : name;
+        var nameDiagnostic = ValidateIdentity(identity, kind);
+        if (nameDiagnostic is not null)
+        {
+            return Failed(nameDiagnostic);
+        }
+
+        if (targets.ContainsKey(identity))
+        {
+            return Failed(Error("SYNC_TARGET_NAME_DUPLICATE", identity, "identity", "A sync target already uses this name."));
+        }
+
+        var definition = SyncTargetTypeCatalog.Get(kind);
+        if (targets.Values.Count(target => target.Kind == kind) >= definition.MaximumInstances)
+        {
+            return Failed(Error("SYNC_TARGET_CARDINALITY", identity, "kind", "This target kind has reached its instance limit."));
+        }
+
+        var changed = CopyTargets();
+        changed.Add(identity, SyncTargetDraft.Create(identity, kind));
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult AddPreset(string presetId)
+    {
+        var preset = SyncTargetTypeCatalog.GetPreset(presetId);
+        return AddTarget(preset.SuggestedIdentity, preset.TargetKind);
+    }
+
+    public SyncTopologyTransitionResult UpdateTarget(
+        string name,
+        Func<SyncTargetDraft, SyncTargetDraft> update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        if (!targets.TryGetValue(name, out var current))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", name, null, "The sync target no longer exists."));
+        }
+
+        var updated = update(current);
+        if (!string.Equals(updated.Name, current.Name, StringComparison.Ordinal))
+        {
+            return Failed(Error(
+                "SYNC_TARGET_IDENTITY_TRANSITION_REQUIRED",
+                name,
+                "identity",
+                "Use the rename transition to change a target identity."));
+        }
+
+        var changed = CopyTargets();
+        changed[name] = updated;
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult RenameTarget(string currentName, string newName)
+    {
+        if (!targets.TryGetValue(currentName, out var target))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", currentName, null, "The sync target no longer exists."));
+        }
+
+        if (target.Kind == SyncTargetKind.LocalSidecar)
+        {
+            return Failed(Error(
+                "SYNC_SIDECAR_IDENTITY_FIXED",
+                currentName,
+                "identity",
+                "The local Sidecar identity is fixed."));
+        }
+
+        var nameDiagnostic = ValidateIdentity(newName, target.Kind);
+        if (nameDiagnostic is not null)
+        {
+            return Failed(nameDiagnostic);
+        }
+
+        if (targets.ContainsKey(newName))
+        {
+            return Failed(Error("SYNC_TARGET_NAME_DUPLICATE", newName, "identity", "A sync target already uses this name."));
+        }
+
+        var changed = CopyTargets();
+        changed.Remove(currentName);
+        changed.Add(newName, target.WithIdentity(newName));
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult DuplicateTarget(string sourceName, string newName)
+    {
+        if (!targets.TryGetValue(sourceName, out var source))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", sourceName, null, "The sync target no longer exists."));
+        }
+
+        if (source.Kind == SyncTargetKind.LocalSidecar)
+        {
+            return Failed(Error(
+                "SYNC_TARGET_CARDINALITY",
+                sourceName,
+                "kind",
+                "The singleton local Sidecar target cannot be duplicated."));
+        }
+
+        var nameDiagnostic = ValidateIdentity(newName, source.Kind);
+        if (nameDiagnostic is not null)
+        {
+            return Failed(nameDiagnostic);
+        }
+
+        if (targets.ContainsKey(newName))
+        {
+            return Failed(Error("SYNC_TARGET_NAME_DUPLICATE", newName, "identity", "A sync target already uses this name."));
+        }
+
+        var duplicate = source
+            .WithIdentity(newName)
+            .WithEnabled(false)
+            .WithoutSecret();
+        var changed = CopyTargets();
+        changed.Add(newName, duplicate);
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult ChangeTargetKind(string name, SyncTargetKind newKind)
+    {
+        if (!targets.TryGetValue(name, out var target))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", name, null, "The sync target no longer exists."));
+        }
+
+        if (target.Kind == newKind)
+        {
+            return Succeeded(this);
+        }
+
+        if (target.Kind == SyncTargetKind.LocalSidecar || newKind == SyncTargetKind.LocalSidecar)
+        {
+            return Failed(Error(
+                "SYNC_KIND_CHANGE_UNSUPPORTED",
+                name,
+                "kind",
+                "Local Sidecar cannot be converted to or from an external target."));
+        }
+
+        var supported = SyncTargetTypeCatalog.Get(newKind).SupportedDataKinds;
+        var changedTarget = target.WithKind(newKind);
+        foreach (var unsupported in changedTarget.DataOverrides.Keys.Where(kind => !supported.Contains(kind)).ToArray())
+        {
+            changedTarget = changedTarget.WithDataOverride(unsupported, SyncOverride.Inherited<bool>());
+        }
+
+        var changed = CopyTargets();
+        changed[name] = changedTarget;
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncTopologyTransitionResult SetTargetEnabled(string name, bool enabled) =>
+        UpdateTarget(name, target => target.WithEnabled(enabled));
+
+    public SyncTopologyTransitionResult RemoveTarget(string name)
+    {
+        if (!targets.ContainsKey(name))
+        {
+            return Failed(Error("SYNC_TARGET_NOT_FOUND", name, null, "The sync target no longer exists."));
+        }
+
+        var changed = CopyTargets();
+        changed.Remove(name);
+        return Succeeded(new(GlobalDefaults, changed));
+    }
+
+    public SyncResolvedTopology Resolve() => SyncTopologyResolver.Resolve(this);
+
+    internal static SyncTopologyDiagnostic? ValidateIdentity(string name, SyncTargetKind kind)
+    {
+        if (kind == SyncTargetKind.LocalSidecar)
+        {
+            return string.Equals(name, LocalSidecarIdentity, StringComparison.Ordinal)
+                ? null
+                : Error("SYNC_SIDECAR_IDENTITY_FIXED", name, "identity", "The local Sidecar identity is fixed.");
+        }
+
+        if (name.Length is < 1 or > 64 || !TargetNamePattern.IsMatch(name))
+        {
+            return Error(
+                "SYNC_TARGET_NAME_INVALID",
+                name,
+                "identity",
+                "Target names must contain 1-64 ASCII letters, numbers, underscores, or hyphens.");
+        }
+
+        return string.Equals(name, "sidecar", StringComparison.OrdinalIgnoreCase)
+            ? Error(
+                "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID",
+                name,
+                "identity",
+                "External targets cannot use the reserved Sidecar identity.")
+            : null;
+    }
+
+    private Dictionary<string, SyncTargetDraft> CopyTargets() =>
+        targets.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal);
+
+    private SyncTopologyTransitionResult Failed(SyncTopologyDiagnostic diagnostic) => new(false, this, diagnostic);
+
+    private static SyncTopologyTransitionResult Succeeded(SyncDesiredTopology topology) => new(true, topology);
+
+    internal static SyncTopologyDiagnostic Error(string code, string? targetName, string? field, string message) =>
+        new(code, SyncTopologyDiagnosticSeverity.Error, message, targetName, field);
+}
+
+public static class SyncTopologyResolver
+{
+    public static SyncResolvedTopology Resolve(SyncDesiredTopology desired)
+    {
+        ArgumentNullException.ThrowIfNull(desired);
+        var diagnostics = new List<SyncTopologyDiagnostic>();
+        var targets = new List<SyncResolvedTarget>();
+        var invalidCardinality = desired.Targets.Values
+            .GroupBy(target => target.Kind)
+            .Where(group => group.Count() > SyncTargetTypeCatalog.Get(group.Key).MaximumInstances)
+            .Select(group => group.Key)
+            .ToHashSet();
+        foreach (var kind in invalidCardinality)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_TARGET_CARDINALITY",
+                null,
+                "kind",
+                $"Target kind '{kind}' exceeds its instance limit."));
+        }
+
+        foreach (var target in desired.Targets.Values.OrderBy(item => item.Name, StringComparer.Ordinal))
+        {
+            if (invalidCardinality.Contains(target.Kind))
+            {
+                continue;
+            }
+
+            var targetDiagnostics = ValidateTarget(desired.GlobalDefaults, target);
+            diagnostics.AddRange(targetDiagnostics);
+            if (targetDiagnostics.Any(item => item.Severity == SyncTopologyDiagnosticSeverity.Error))
+            {
+                continue;
+            }
+
+            targets.Add(ResolveTarget(desired.GlobalDefaults, target));
+        }
+
+        return new(targets.AsReadOnly(), diagnostics.AsReadOnly());
+    }
+
+    private static List<SyncTopologyDiagnostic> ValidateTarget(
+        SyncGlobalDefaults globals,
+        SyncTargetDraft target)
+    {
+        var diagnostics = new List<SyncTopologyDiagnostic>();
+        var identity = SyncDesiredTopology.ValidateIdentity(target.Name, target.Kind);
+        if (identity is not null)
+        {
+            diagnostics.Add(identity);
+        }
+
+        var definition = SyncTargetTypeCatalog.Get(target.Kind);
+        if (definition.RequiresUrl && !TryValidateEndpoint(target.Url, target.Kind, out var endpointCode, out var endpointMessage))
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(endpointCode, target.Name, "url", endpointMessage));
+        }
+
+        if (definition.RequiresToken && !target.Token.IsConfigured)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_CREDENTIALS_INCOMPLETE",
+                target.Name,
+                "token",
+                "This target requires a configured token."));
+        }
+
+        foreach (var (kind, value) in target.DataOverrides)
+        {
+            if (value.IsExplicit && !definition.SupportedDataKinds.Contains(kind))
+            {
+                diagnostics.Add(SyncDesiredTopology.Error(
+                    "SYNC_CAPABILITY_UNSUPPORTED",
+                    target.Name,
+                    kind.ToString(),
+                    "This data capability is not supported by the selected target kind."));
+            }
+        }
+
+        if (target.BattlelogEnrichment.IsExplicit && !definition.SupportsBattlelogEnrichment)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_CAPABILITY_UNSUPPORTED",
+                target.Name,
+                "battlelog_enrichment",
+                "Battle-log enrichment is supported only by the local Sidecar target."));
+        }
+
+        if (target.FleetRuntimeMode.IsExplicit && !definition.SupportsFleetRuntimeMode)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_CAPABILITY_UNSUPPORTED",
+                target.Name,
+                "fleet_runtime_mode",
+                "Fleet runtime mode is supported only by the local Sidecar target."));
+        }
+        else if (target.FleetRuntimeMode.IsExplicit && !IsFleetRuntimeModeSupported(target.FleetRuntimeMode.Value))
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_FLEET_RUNTIME_MODE_INVALID",
+                target.Name,
+                "fleet_runtime_mode",
+                "Fleet runtime mode must be normal, request_only, snapshot_only, or enqueue_no_transport."));
+        }
+
+        var verifySsl = ResolveVerifySsl(target, definition, globals).Value;
+        var unsafeTls = ResolveUnsafeTls(target, definition, globals).Value;
+        if (!verifySsl && !unsafeTls)
+        {
+            diagnostics.Add(SyncDesiredTopology.Error(
+                "SYNC_UNSAFE_TLS_PAIR_REQUIRED",
+                target.Name,
+                "verify_ssl",
+                "Disabling TLS verification requires the explicit unsafe-TLS acknowledgement."));
+        }
+
+        return diagnostics;
+    }
+
+    private static SyncResolvedTarget ResolveTarget(SyncGlobalDefaults globals, SyncTargetDraft target)
+    {
+        var definition = SyncTargetTypeCatalog.Get(target.Kind);
+        var dataKinds = new ReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>>(
+            definition.SupportedDataKinds.ToDictionary(
+                kind => kind,
+                kind => ResolveDataKind(globals, target, definition, kind)));
+        return new(
+            target.Name,
+            target.Kind,
+            target.Enabled,
+            target.Url,
+            target.Token.IsConfigured,
+            ResolveProxy(globals, target, definition),
+            ResolveVerifySsl(target, definition, globals),
+            ResolveUnsafeTls(target, definition, globals),
+            dataKinds,
+            definition.SupportsBattlelogEnrichment
+                ? target.BattlelogEnrichment.Resolve(false, SyncValueSource.TargetTypeDefault)
+                : null,
+            definition.SupportsFleetRuntimeMode
+                ? target.FleetRuntimeMode.Resolve("normal", SyncValueSource.TargetTypeDefault)
+                : null);
+    }
+
+    private static SyncResolvedValue<string> ResolveProxy(
+        SyncGlobalDefaults globals,
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition) =>
+        definition.InheritsGlobalSync
+            ? target.Proxy.Resolve(globals.Proxy, SyncValueSource.GlobalDefault)
+            : target.Proxy.Resolve(string.Empty, SyncValueSource.TargetTypeDefault);
+
+    private static SyncResolvedValue<bool> ResolveVerifySsl(
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition,
+        SyncGlobalDefaults? globals = null) =>
+        definition.InheritsGlobalSync
+            ? target.VerifySsl.Resolve(globals?.VerifySsl ?? true, SyncValueSource.GlobalDefault)
+            : target.VerifySsl.Resolve(true, SyncValueSource.TargetTypeDefault);
+
+    private static SyncResolvedValue<bool> ResolveUnsafeTls(
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition,
+        SyncGlobalDefaults? globals = null) =>
+        definition.InheritsGlobalSync
+            ? target.AllowUnsafeTlsWithoutCertificateValidation.Resolve(
+                globals?.AllowUnsafeTlsWithoutCertificateValidation ?? false,
+                SyncValueSource.GlobalDefault)
+            : target.AllowUnsafeTlsWithoutCertificateValidation.Resolve(false, SyncValueSource.TargetTypeDefault);
+
+    private static SyncResolvedValue<bool> ResolveDataKind(
+        SyncGlobalDefaults globals,
+        SyncTargetDraft target,
+        SyncTargetTypeDefinition definition,
+        SyncDataKind kind)
+    {
+        var value = target.DataOverrides.TryGetValue(kind, out var configured)
+            ? configured
+            : SyncOverride.Inherited<bool>();
+        return definition.InheritsGlobalSync
+            ? value.Resolve(globals.DataKinds[kind], SyncValueSource.GlobalDefault)
+            : value.Resolve(false, SyncValueSource.TargetTypeDefault);
+    }
+
+    private static bool TryValidateEndpoint(
+        string value,
+        SyncTargetKind kind,
+        out string code,
+        out string message)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || uri.Scheme is not ("http" or "https")
+            || string.IsNullOrEmpty(uri.Host))
+        {
+            code = "SYNC_ENDPOINT_INVALID";
+            message = "The target endpoint must be an absolute HTTP or HTTPS URL.";
+            return false;
+        }
+
+        if (kind == SyncTargetKind.LocalSidecar && !uri.IsLoopback)
+        {
+            code = "SYNC_SIDECAR_ENDPOINT_NOT_LOOPBACK";
+            message = "The local Sidecar endpoint must use a loopback host.";
+            return false;
+        }
+
+        if (kind != SyncTargetKind.LocalSidecar && uri.IsLoopback)
+        {
+            code = "SYNC_LOOPBACK_TARGET_INVALID";
+            message = "Loopback Sidecar endpoints belong to the local Sidecar target.";
+            return false;
+        }
+
+        code = string.Empty;
+        message = string.Empty;
+        return true;
+    }
+
+    private static bool IsFleetRuntimeModeSupported(string value) =>
+        value is "normal" or "request_only" or "snapshot_only" or "enqueue_no_transport";
+}
+
+public sealed record SyncTopologyWorkspace(
+    SyncDesiredTopology Desired,
+    SyncResolvedTopology StartupRuntime)
+{
+    public static SyncTopologyWorkspace Begin(SyncDesiredTopology desired) => new(desired, desired.Resolve());
+
+    public SyncTopologyWorkspace Apply(SyncTopologyTransitionResult transition)
+    {
+        ArgumentNullException.ThrowIfNull(transition);
+        return transition.Succeeded ? new(transition.Topology, StartupRuntime) : this;
+    }
+
+    public SyncResolvedTopology Preview => Desired.Resolve();
+}

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
@@ -1,0 +1,406 @@
+using System.Collections.Frozen;
+using System.Collections.ObjectModel;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public enum SyncTargetKind
+{
+    LocalSidecar,
+    LegacyCommunity,
+    MajelIngest,
+}
+
+public enum SyncDataKind
+{
+    Battlelogs,
+    BattlelogsRealtime,
+    Buffs,
+    Buildings,
+    Inventory,
+    Jobs,
+    Missions,
+    Officer,
+    Research,
+    Resources,
+    Ships,
+    Slots,
+    Tech,
+    Traits,
+    FleetRuntime,
+}
+
+public enum SyncValueProvenance
+{
+    Inherited,
+    ExplicitValue,
+    ExplicitFalse,
+    ExplicitEmpty,
+}
+
+public enum SyncValueSource
+{
+    GlobalDefault,
+    TargetTypeDefault,
+    Target,
+}
+
+public enum SyncTopologyDiagnosticSeverity
+{
+    Info,
+    Warning,
+    Error,
+}
+
+public readonly record struct SyncOverride<T>(bool IsExplicit, T Value)
+{
+    public SyncResolvedValue<T> Resolve(T inheritedValue, SyncValueSource inheritedSource)
+    {
+        if (!IsExplicit)
+        {
+            return new(inheritedValue, SyncValueProvenance.Inherited, inheritedSource);
+        }
+
+        var provenance = Value switch
+        {
+            false => SyncValueProvenance.ExplicitFalse,
+            string { Length: 0 } => SyncValueProvenance.ExplicitEmpty,
+            _ => SyncValueProvenance.ExplicitValue,
+        };
+        return new(Value, provenance, SyncValueSource.Target);
+    }
+}
+
+public static class SyncOverride
+{
+    public static SyncOverride<T> Inherited<T>() => new(false, default!);
+
+    public static SyncOverride<T> Explicit<T>(T value) => new(true, value);
+}
+
+public sealed record SyncResolvedValue<T>(
+    T Value,
+    SyncValueProvenance Provenance,
+    SyncValueSource Source);
+
+public sealed class SyncSecret : IEquatable<SyncSecret>
+{
+    private readonly string value;
+
+    private SyncSecret(string value)
+    {
+        this.value = value;
+    }
+
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(value);
+
+    public static SyncSecret Missing { get; } = new(string.Empty);
+
+    public static SyncSecret FromPlainText(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return new(value);
+    }
+
+    public bool Equals(SyncSecret? other) =>
+        other is not null && string.Equals(value, other.value, StringComparison.Ordinal);
+
+    public override bool Equals(object? obj) => obj is SyncSecret other && Equals(other);
+
+    public override int GetHashCode() => StringComparer.Ordinal.GetHashCode(value);
+
+    public override string ToString() => IsConfigured ? "[configured]" : "[missing]";
+
+    internal string RevealForPersistence() => value;
+}
+
+public sealed record SyncTargetTypeDefinition(
+    SyncTargetKind Kind,
+    string PersistencePattern,
+    string WireContract,
+    int MaximumInstances,
+    bool InheritsGlobalSync,
+    bool RequiresUrl,
+    bool RequiresToken,
+    bool SupportsBattlelogEnrichment,
+    bool SupportsFleetRuntimeMode,
+    IReadOnlySet<SyncDataKind> SupportedDataKinds,
+    string DefaultUrl);
+
+public sealed record SyncTargetPreset(
+    string Id,
+    string DisplayName,
+    SyncTargetKind TargetKind,
+    string SuggestedIdentity);
+
+public static class SyncTargetTypeCatalog
+{
+    private static readonly ReadOnlyDictionary<SyncTargetKind, SyncTargetTypeDefinition> Definitions =
+        new(
+            new Dictionary<SyncTargetKind, SyncTargetTypeDefinition>
+            {
+                [SyncTargetKind.LocalSidecar] = new(
+                    SyncTargetKind.LocalSidecar,
+                    "sidecar.sync",
+                    "sidecar_local_ingest",
+                    1,
+                    false,
+                    true,
+                    true,
+                    true,
+                    true,
+                    new[]
+                    {
+                        SyncDataKind.BattlelogsRealtime,
+                        SyncDataKind.FleetRuntime,
+                    }.ToFrozenSet(),
+                    "http://127.0.0.1:43127/api/sidecar/ingest"),
+                [SyncTargetKind.LegacyCommunity] = External(
+                    SyncTargetKind.LegacyCommunity,
+                    "legacy_sync_json"),
+                [SyncTargetKind.MajelIngest] = External(
+                    SyncTargetKind.MajelIngest,
+                    "majel.ingest.v1"),
+            });
+
+    private static readonly ReadOnlyCollection<SyncTargetPreset> PresetDefinitions =
+        Array.AsReadOnly(
+        new SyncTargetPreset[]
+        {
+            new("spocks_club", "Spocks Club", SyncTargetKind.LegacyCommunity, "spocksclub"),
+            new("next_spocks_club", "Next Spocks Club", SyncTargetKind.LegacyCommunity, "nextspocksclub"),
+        });
+
+    public static IReadOnlyDictionary<SyncTargetKind, SyncTargetTypeDefinition> All => Definitions;
+
+    public static IReadOnlyList<SyncTargetPreset> Presets => PresetDefinitions;
+
+    public static SyncTargetTypeDefinition Get(SyncTargetKind kind) => Definitions[kind];
+
+    public static SyncTargetPreset GetPreset(string id) =>
+        PresetDefinitions.Single(preset => string.Equals(preset.Id, id, StringComparison.Ordinal));
+
+    private static SyncTargetTypeDefinition External(SyncTargetKind kind, string wireContract)
+    {
+        return new(
+            kind,
+            "sync.targets.*",
+            wireContract,
+            int.MaxValue,
+            true,
+            true,
+            true,
+            false,
+            false,
+            Enum.GetValues<SyncDataKind>()
+                .Where(value => value != SyncDataKind.FleetRuntime)
+                .ToFrozenSet(),
+            string.Empty);
+    }
+}
+
+public sealed class SyncGlobalDefaults
+{
+    private readonly ReadOnlyDictionary<SyncDataKind, bool> dataKinds;
+
+    public SyncGlobalDefaults(
+        string proxy,
+        bool verifySsl,
+        bool allowUnsafeTlsWithoutCertificateValidation,
+        IReadOnlyDictionary<SyncDataKind, bool>? dataKinds = null)
+    {
+        Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+        VerifySsl = verifySsl;
+        AllowUnsafeTlsWithoutCertificateValidation = allowUnsafeTlsWithoutCertificateValidation;
+        this.dataKinds = new(
+            Enum.GetValues<SyncDataKind>()
+                .ToDictionary(
+                    kind => kind,
+                    kind => dataKinds is not null && dataKinds.TryGetValue(kind, out var enabled) && enabled));
+    }
+
+    public string Proxy { get; }
+
+    public bool VerifySsl { get; }
+
+    public bool AllowUnsafeTlsWithoutCertificateValidation { get; }
+
+    public IReadOnlyDictionary<SyncDataKind, bool> DataKinds => dataKinds;
+
+    public SyncGlobalDefaults WithProxy(string proxy) =>
+        new(proxy, VerifySsl, AllowUnsafeTlsWithoutCertificateValidation, dataKinds);
+
+    public SyncGlobalDefaults WithVerifySsl(bool value) =>
+        new(Proxy, value, AllowUnsafeTlsWithoutCertificateValidation, dataKinds);
+
+    public SyncGlobalDefaults WithUnsafeTls(bool value) =>
+        new(Proxy, VerifySsl, value, dataKinds);
+
+    public SyncGlobalDefaults WithDataKind(SyncDataKind kind, bool enabled)
+    {
+        var changed = dataKinds.ToDictionary(item => item.Key, item => item.Value);
+        changed[kind] = enabled;
+        return new(Proxy, VerifySsl, AllowUnsafeTlsWithoutCertificateValidation, changed);
+    }
+}
+
+public sealed class SyncTargetDraft
+{
+    private readonly ReadOnlyDictionary<SyncDataKind, SyncOverride<bool>> dataOverrides;
+
+    public SyncTargetDraft(
+        string name,
+        SyncTargetKind kind,
+        bool enabled,
+        string url,
+        SyncSecret token,
+        SyncOverride<string> proxy,
+        SyncOverride<bool> verifySsl,
+        SyncOverride<bool> allowUnsafeTlsWithoutCertificateValidation,
+        IReadOnlyDictionary<SyncDataKind, SyncOverride<bool>>? dataOverrides = null,
+        SyncOverride<bool>? battlelogEnrichment = null,
+        SyncOverride<string>? fleetRuntimeMode = null)
+    {
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+        Kind = kind;
+        Enabled = enabled;
+        Url = url ?? throw new ArgumentNullException(nameof(url));
+        Token = token ?? throw new ArgumentNullException(nameof(token));
+        Proxy = proxy;
+        VerifySsl = verifySsl;
+        AllowUnsafeTlsWithoutCertificateValidation = allowUnsafeTlsWithoutCertificateValidation;
+        this.dataOverrides = new(dataOverrides?.ToDictionary(item => item.Key, item => item.Value) ?? []);
+        BattlelogEnrichment = battlelogEnrichment ?? SyncOverride.Inherited<bool>();
+        FleetRuntimeMode = fleetRuntimeMode ?? SyncOverride.Inherited<string>();
+    }
+
+    public string Name { get; }
+
+    public SyncTargetKind Kind { get; }
+
+    public bool Enabled { get; }
+
+    public string Url { get; }
+
+    public SyncSecret Token { get; }
+
+    public SyncOverride<string> Proxy { get; }
+
+    public SyncOverride<bool> VerifySsl { get; }
+
+    public SyncOverride<bool> AllowUnsafeTlsWithoutCertificateValidation { get; }
+
+    public IReadOnlyDictionary<SyncDataKind, SyncOverride<bool>> DataOverrides => dataOverrides;
+
+    public SyncOverride<bool> BattlelogEnrichment { get; }
+
+    public SyncOverride<string> FleetRuntimeMode { get; }
+
+    public static SyncTargetDraft Create(string name, SyncTargetKind kind)
+    {
+        var definition = SyncTargetTypeCatalog.Get(kind);
+        return new(
+            kind == SyncTargetKind.LocalSidecar ? SyncDesiredTopology.LocalSidecarIdentity : name,
+            kind,
+            false,
+            definition.DefaultUrl,
+            SyncSecret.Missing,
+            SyncOverride.Inherited<string>(),
+            SyncOverride.Inherited<bool>(),
+            SyncOverride.Inherited<bool>());
+    }
+
+    public SyncTargetDraft WithIdentity(string name) => Copy(name: name);
+
+    public SyncTargetDraft WithKind(SyncTargetKind kind) => Copy(kind: kind);
+
+    public SyncTargetDraft WithEnabled(bool enabled) => Copy(enabled: enabled);
+
+    public SyncTargetDraft WithConnection(string url, SyncSecret token) => Copy(url: url, token: token);
+
+    public SyncTargetDraft WithProxy(SyncOverride<string> value) => Copy(proxy: value);
+
+    public SyncTargetDraft WithVerifySsl(SyncOverride<bool> value) => Copy(verifySsl: value);
+
+    public SyncTargetDraft WithUnsafeTls(SyncOverride<bool> value) =>
+        Copy(allowUnsafeTlsWithoutCertificateValidation: value);
+
+    public SyncTargetDraft WithBattlelogEnrichment(SyncOverride<bool> value) =>
+        Copy(battlelogEnrichment: value);
+
+    public SyncTargetDraft WithFleetRuntimeMode(SyncOverride<string> value) =>
+        Copy(fleetRuntimeMode: value);
+
+    public SyncTargetDraft WithDataOverride(SyncDataKind kind, SyncOverride<bool> value)
+    {
+        var changed = dataOverrides.ToDictionary(item => item.Key, item => item.Value);
+        if (value.IsExplicit)
+        {
+            changed[kind] = value;
+        }
+        else
+        {
+            changed.Remove(kind);
+        }
+
+        return Copy(dataOverrides: changed);
+    }
+
+    public SyncTargetDraft WithoutSecret() => Copy(token: SyncSecret.Missing);
+
+    private SyncTargetDraft Copy(
+        string? name = null,
+        SyncTargetKind? kind = null,
+        bool? enabled = null,
+        string? url = null,
+        SyncSecret? token = null,
+        SyncOverride<string>? proxy = null,
+        SyncOverride<bool>? verifySsl = null,
+        SyncOverride<bool>? allowUnsafeTlsWithoutCertificateValidation = null,
+        IReadOnlyDictionary<SyncDataKind, SyncOverride<bool>>? dataOverrides = null,
+        SyncOverride<bool>? battlelogEnrichment = null,
+        SyncOverride<string>? fleetRuntimeMode = null) =>
+        new(
+            name ?? Name,
+            kind ?? Kind,
+            enabled ?? Enabled,
+            url ?? Url,
+            token ?? Token,
+            proxy ?? Proxy,
+            verifySsl ?? VerifySsl,
+            allowUnsafeTlsWithoutCertificateValidation ?? AllowUnsafeTlsWithoutCertificateValidation,
+            dataOverrides ?? this.dataOverrides,
+            battlelogEnrichment ?? BattlelogEnrichment,
+            fleetRuntimeMode ?? FleetRuntimeMode);
+}
+
+public sealed record SyncTopologyDiagnostic(
+    string Code,
+    SyncTopologyDiagnosticSeverity Severity,
+    string Message,
+    string? TargetName = null,
+    string? Field = null);
+
+public sealed record SyncResolvedTarget(
+    string Name,
+    SyncTargetKind Kind,
+    bool Enabled,
+    string Url,
+    bool CredentialsConfigured,
+    SyncResolvedValue<string> Proxy,
+    SyncResolvedValue<bool> VerifySsl,
+    SyncResolvedValue<bool> AllowUnsafeTlsWithoutCertificateValidation,
+    IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> DataKinds,
+    SyncResolvedValue<bool>? BattlelogEnrichment,
+    SyncResolvedValue<string>? FleetRuntimeMode);
+
+public sealed record SyncResolvedTopology(
+    IReadOnlyList<SyncResolvedTarget> Targets,
+    IReadOnlyList<SyncTopologyDiagnostic> Diagnostics)
+{
+    public bool IsCommittable => Diagnostics.All(item => item.Severity != SyncTopologyDiagnosticSeverity.Error);
+}
+
+public sealed record SyncTopologyTransitionResult(
+    bool Succeeded,
+    SyncDesiredTopology Topology,
+    SyncTopologyDiagnostic? Diagnostic = null);

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
@@ -1,0 +1,380 @@
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.Core.Tests;
+
+[TestClass]
+public sealed class SyncDesiredTopologyTests
+{
+    [TestMethod]
+    public void CatalogSeparatesConcreteKindsFromProviderPresets()
+    {
+        Assert.AreEqual(3, SyncTargetTypeCatalog.All.Count);
+        Assert.AreEqual("sidecar.sync", SyncTargetTypeCatalog.Get(SyncTargetKind.LocalSidecar).PersistencePattern);
+        Assert.AreEqual("sidecar_local_ingest", SyncTargetTypeCatalog.Get(SyncTargetKind.LocalSidecar).WireContract);
+        Assert.IsFalse(SyncTargetTypeCatalog.Get(SyncTargetKind.LocalSidecar).InheritsGlobalSync);
+        Assert.AreEqual("sync.targets.*", SyncTargetTypeCatalog.Get(SyncTargetKind.MajelIngest).PersistencePattern);
+        Assert.AreEqual("majel.ingest.v1", SyncTargetTypeCatalog.Get(SyncTargetKind.MajelIngest).WireContract);
+
+        var spocks = SyncTargetTypeCatalog.GetPreset("spocks_club");
+        Assert.AreEqual(SyncTargetKind.LegacyCommunity, spocks.TargetKind);
+        Assert.AreEqual("spocksclub", spocks.SuggestedIdentity);
+    }
+
+    [TestMethod]
+    public void OverridePresenceParticipatesInEqualityAndResolutionProvenance()
+    {
+        var inherited = SyncOverride.Inherited<bool>();
+        var explicitFalse = SyncOverride.Explicit(false);
+
+        Assert.AreNotEqual(inherited, explicitFalse);
+        Assert.AreEqual(
+            new SyncResolvedValue<bool>(false, SyncValueProvenance.Inherited, SyncValueSource.GlobalDefault),
+            inherited.Resolve(false, SyncValueSource.GlobalDefault));
+        Assert.AreEqual(
+            new SyncResolvedValue<bool>(false, SyncValueProvenance.ExplicitFalse, SyncValueSource.Target),
+            explicitFalse.Resolve(true, SyncValueSource.GlobalDefault));
+
+        var explicitEmpty = SyncOverride.Explicit(string.Empty).Resolve(
+            "http://proxy.example.invalid:8080",
+            SyncValueSource.GlobalDefault);
+        Assert.AreEqual(SyncValueProvenance.ExplicitEmpty, explicitEmpty.Provenance);
+        Assert.AreEqual(string.Empty, explicitEmpty.Value);
+    }
+
+    [TestMethod]
+    public void MixedTopologyResolvesCapabilitiesAndProvenance()
+    {
+        var globals = new SyncGlobalDefaults(
+                "http://proxy.example.invalid:8080",
+                true,
+                false)
+            .WithDataKind(SyncDataKind.Battlelogs, true);
+        var topology = new SyncDesiredTopology(globals);
+        topology = AddConfigured(
+            topology,
+            "ignored-for-sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://127.0.0.1:43127/api/sidecar/ingest",
+            target => target
+                .WithProxy(SyncOverride.Explicit(string.Empty))
+                .WithDataOverride(SyncDataKind.BattlelogsRealtime, SyncOverride.Explicit(true))
+                .WithBattlelogEnrichment(SyncOverride.Explicit(true))
+                .WithFleetRuntimeMode(SyncOverride.Explicit("snapshot_only")));
+        topology = AddConfigured(
+            topology,
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync");
+        topology = AddConfigured(
+            topology,
+            "majel",
+            SyncTargetKind.MajelIngest,
+            "https://majel.example.invalid/api/ingest/events",
+            target => target.WithDataOverride(SyncDataKind.Battlelogs, SyncOverride.Explicit(false)));
+
+        var resolved = topology.Resolve();
+
+        Assert.IsTrue(resolved.IsCommittable);
+        Assert.AreEqual(3, resolved.Targets.Count);
+        var sidecar = resolved.Targets.Single(target => target.Kind == SyncTargetKind.LocalSidecar);
+        Assert.AreEqual(string.Empty, sidecar.Proxy.Value);
+        Assert.AreEqual(SyncValueProvenance.ExplicitEmpty, sidecar.Proxy.Provenance);
+        Assert.AreEqual(SyncValueSource.Target, sidecar.Proxy.Source);
+        Assert.AreEqual(
+            SyncValueSource.TargetTypeDefault,
+            sidecar.DataKinds[SyncDataKind.FleetRuntime].Source);
+        Assert.IsTrue(sidecar.BattlelogEnrichment!.Value);
+        Assert.AreEqual("snapshot_only", sidecar.FleetRuntimeMode!.Value);
+
+        var community = resolved.Targets.Single(target => target.Name == "community");
+        Assert.AreEqual(globals.Proxy, community.Proxy.Value);
+        Assert.AreEqual(SyncValueProvenance.Inherited, community.Proxy.Provenance);
+        Assert.AreEqual(SyncValueSource.GlobalDefault, community.Proxy.Source);
+        Assert.IsTrue(community.DataKinds[SyncDataKind.Battlelogs].Value);
+
+        var majel = resolved.Targets.Single(target => target.Name == "majel");
+        Assert.IsFalse(majel.DataKinds[SyncDataKind.Battlelogs].Value);
+        Assert.AreEqual(
+            SyncValueProvenance.ExplicitFalse,
+            majel.DataKinds[SyncDataKind.Battlelogs].Provenance);
+    }
+
+    [TestMethod]
+    public void GlobalChangesFlowOnlyToCompatibleInheritedFields()
+    {
+        var topology = new SyncDesiredTopology(new SyncGlobalDefaults("proxy-one", true, false));
+        topology = AddConfigured(
+            topology,
+            "inherited",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/inherited");
+        topology = AddConfigured(
+            topology,
+            "explicit",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/explicit",
+            target => target.WithProxy(SyncOverride.Explicit("target-proxy")));
+        topology = AddConfigured(
+            topology,
+            "sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://localhost:43127/api/sidecar/ingest");
+
+        topology = topology.WithGlobalDefaults(topology.GlobalDefaults.WithProxy("proxy-two"));
+        var resolved = topology.Resolve();
+
+        Assert.AreEqual("proxy-two", resolved.Targets.Single(target => target.Name == "inherited").Proxy.Value);
+        Assert.AreEqual("target-proxy", resolved.Targets.Single(target => target.Name == "explicit").Proxy.Value);
+        Assert.AreEqual(
+            string.Empty,
+            resolved.Targets.Single(target => target.Kind == SyncTargetKind.LocalSidecar).Proxy.Value);
+    }
+
+    [TestMethod]
+    public void SidecarDoesNotInheritExternalProxyOrUnsafeTlsPolicy()
+    {
+        var topology = new SyncDesiredTopology(
+            new SyncGlobalDefaults("http://external-proxy.example.invalid:8080", false, true));
+        topology = AddConfigured(
+            topology,
+            "sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://127.0.0.1:43127/api/sidecar/ingest");
+        topology = AddConfigured(
+            topology,
+            "external",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync");
+
+        var resolved = topology.Resolve();
+        var sidecar = resolved.Targets.Single(target => target.Kind == SyncTargetKind.LocalSidecar);
+        var external = resolved.Targets.Single(target => target.Kind == SyncTargetKind.LegacyCommunity);
+
+        Assert.AreEqual(string.Empty, sidecar.Proxy.Value);
+        Assert.IsTrue(sidecar.VerifySsl.Value);
+        Assert.IsFalse(sidecar.AllowUnsafeTlsWithoutCertificateValidation.Value);
+        Assert.AreEqual(SyncValueSource.TargetTypeDefault, sidecar.VerifySsl.Source);
+        Assert.AreEqual("http://external-proxy.example.invalid:8080", external.Proxy.Value);
+        Assert.IsFalse(external.VerifySsl.Value);
+        Assert.IsTrue(external.AllowUnsafeTlsWithoutCertificateValidation.Value);
+        Assert.AreEqual(SyncValueSource.GlobalDefault, external.VerifySsl.Source);
+    }
+
+    [TestMethod]
+    public void LifecycleTransitionsAreImmutableAndDuplicateClearsCredentials()
+    {
+        var topology = SyncDesiredTopology.Empty;
+        var added = topology.AddPreset("spocks_club");
+        Assert.IsTrue(added.Succeeded);
+        Assert.AreEqual(0, topology.Targets.Count);
+        topology = added.Topology;
+        topology = RequireSuccess(
+            topology.UpdateTarget(
+                "spocksclub",
+                target => target
+                    .WithConnection(
+                        "https://community.example.invalid/sync",
+                        SyncSecret.FromPlainText("secret-one"))
+                    .WithEnabled(true)));
+
+        topology = RequireSuccess(topology.RenameTarget("spocksclub", "primary"));
+        topology = RequireSuccess(topology.DuplicateTarget("primary", "backup"));
+        var duplicate = topology.Targets["backup"];
+        Assert.IsFalse(duplicate.Enabled);
+        Assert.IsFalse(duplicate.Token.IsConfigured);
+        Assert.AreEqual(topology.Targets["primary"].Url, duplicate.Url);
+
+        topology = RequireSuccess(topology.ChangeTargetKind("backup", SyncTargetKind.MajelIngest));
+        Assert.AreEqual(SyncTargetKind.MajelIngest, topology.Targets["backup"].Kind);
+        topology = RequireSuccess(topology.SetTargetEnabled("backup", true));
+        Assert.IsTrue(topology.Targets["backup"].Enabled);
+        topology = RequireSuccess(topology.RemoveTarget("backup"));
+        Assert.IsFalse(topology.Targets.ContainsKey("backup"));
+    }
+
+    [TestMethod]
+    public void SidecarCardinalityIdentityAndDuplicationAreGuarded()
+    {
+        var topology = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("anything", SyncTargetKind.LocalSidecar));
+
+        Assert.AreEqual(SyncDesiredTopology.LocalSidecarIdentity, topology.Targets.Keys.Single());
+        Assert.IsFalse(topology.AddTarget("second", SyncTargetKind.LocalSidecar).Succeeded);
+        Assert.IsFalse(topology.RenameTarget(SyncDesiredTopology.LocalSidecarIdentity, "other").Succeeded);
+        Assert.IsFalse(topology.DuplicateTarget(SyncDesiredTopology.LocalSidecarIdentity, "other").Succeeded);
+        Assert.IsFalse(
+            topology.ChangeTargetKind(
+                SyncDesiredTopology.LocalSidecarIdentity,
+                SyncTargetKind.LegacyCommunity).Succeeded);
+    }
+
+    [TestMethod]
+    public void ResolverRejectsCardinalityViolationsFromUntrustedConstruction()
+    {
+        var sidecar = SyncTargetDraft.Create("ignored", SyncTargetKind.LocalSidecar)
+            .WithConnection(
+                "http://127.0.0.1:43127/api/sidecar/ingest",
+                SyncSecret.FromPlainText("fixture-sidecar"));
+        var topology = new SyncDesiredTopology(
+            new SyncGlobalDefaults(string.Empty, true, false),
+            new Dictionary<string, SyncTargetDraft>
+            {
+                ["first"] = sidecar,
+                ["second"] = sidecar,
+            });
+
+        var resolved = topology.Resolve();
+
+        Assert.IsFalse(resolved.IsCommittable);
+        Assert.AreEqual(0, resolved.Targets.Count);
+        Assert.IsTrue(resolved.Diagnostics.Any(item => item.Code == "SYNC_TARGET_CARDINALITY"));
+    }
+
+    [TestMethod]
+    public void InvalidNamesCredentialsAndEndpointOwnershipBlockCommit()
+    {
+        Assert.IsFalse(SyncDesiredTopology.Empty.AddTarget("bad.target", SyncTargetKind.LegacyCommunity).Succeeded);
+        Assert.IsFalse(SyncDesiredTopology.Empty.AddTarget("sidecar", SyncTargetKind.LegacyCommunity).Succeeded);
+
+        var external = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("external", SyncTargetKind.LegacyCommunity));
+        external = RequireSuccess(
+            external.UpdateTarget(
+                "external",
+                target => target.WithConnection(
+                    "http://127.0.0.1:43127/api/sidecar/ingest",
+                    SyncSecret.FromPlainText("hidden-value"))));
+        var externalResolved = external.Resolve();
+        Assert.IsFalse(externalResolved.IsCommittable);
+        Assert.IsTrue(externalResolved.Diagnostics.Any(item => item.Code == "SYNC_LOOPBACK_TARGET_INVALID"));
+
+        var missing = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("missing", SyncTargetKind.MajelIngest));
+        missing = RequireSuccess(
+            missing.UpdateTarget(
+                "missing",
+                target => target.WithConnection(
+                    "https://majel.example.invalid/api/ingest/events",
+                    SyncSecret.Missing)));
+        Assert.IsTrue(missing.Resolve().Diagnostics.Any(item => item.Code == "SYNC_CREDENTIALS_INCOMPLETE"));
+
+        var sidecar = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("sidecar", SyncTargetKind.LocalSidecar));
+        sidecar = RequireSuccess(
+            sidecar.UpdateTarget(
+                SyncDesiredTopology.LocalSidecarIdentity,
+                target => target.WithConnection(
+                    "https://sidecar.example.invalid/ingest",
+                    SyncSecret.FromPlainText("hidden-value"))));
+        Assert.IsTrue(sidecar.Resolve().Diagnostics.Any(item => item.Code == "SYNC_SIDECAR_ENDPOINT_NOT_LOOPBACK"));
+    }
+
+    [TestMethod]
+    public void UnsupportedCapabilitiesAndUnsafeTlsCannotEnterACommittableSet()
+    {
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "external",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync",
+            target => target
+                .WithDataOverride(SyncDataKind.FleetRuntime, SyncOverride.Explicit(true))
+                .WithBattlelogEnrichment(SyncOverride.Explicit(true))
+                .WithVerifySsl(SyncOverride.Explicit(false)));
+
+        var blocked = topology.Resolve();
+        Assert.IsFalse(blocked.IsCommittable);
+        Assert.IsTrue(blocked.Diagnostics.Any(item => item.Code == "SYNC_CAPABILITY_UNSUPPORTED"));
+        Assert.IsTrue(blocked.Diagnostics.Any(item => item.Code == "SYNC_UNSAFE_TLS_PAIR_REQUIRED"));
+
+        topology = RequireSuccess(
+            topology.UpdateTarget(
+                "external",
+                target => target
+                    .WithDataOverride(SyncDataKind.FleetRuntime, SyncOverride.Inherited<bool>())
+                    .WithBattlelogEnrichment(SyncOverride.Inherited<bool>())
+                    .WithUnsafeTls(SyncOverride.Explicit(true))));
+        Assert.IsTrue(topology.Resolve().IsCommittable);
+    }
+
+    [TestMethod]
+    public void InvalidSidecarRuntimeModeBlocksCommit()
+    {
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "sidecar",
+            SyncTargetKind.LocalSidecar,
+            "http://127.0.0.1:43127/api/sidecar/ingest",
+            target => target.WithFleetRuntimeMode(SyncOverride.Explicit("surprise")));
+
+        var resolved = topology.Resolve();
+
+        Assert.IsFalse(resolved.IsCommittable);
+        Assert.IsTrue(resolved.Diagnostics.Any(item => item.Code == "SYNC_FLEET_RUNTIME_MODE_INVALID"));
+    }
+
+    [TestMethod]
+    public void SecretsRemainOpaqueInDisplayAndDiagnostics()
+    {
+        const string secretValue = "do-not-display-this-token";
+        var secret = SyncSecret.FromPlainText(secretValue);
+        Assert.AreEqual("[configured]", secret.ToString());
+        Assert.AreEqual(secret, SyncSecret.FromPlainText(secretValue));
+
+        var topology = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("external", SyncTargetKind.LegacyCommunity));
+        topology = RequireSuccess(
+            topology.UpdateTarget(
+                "external",
+                target => target.WithConnection("not-a-url", secret)));
+
+        var diagnostics = topology.Resolve().Diagnostics;
+        Assert.IsTrue(diagnostics.Count > 0);
+        Assert.IsFalse(diagnostics.Any(item => item.Message.Contains(secretValue, StringComparison.Ordinal)));
+        Assert.IsFalse(diagnostics.Any(item => item.ToString().Contains(secretValue, StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void StartupRuntimeTopologyDoesNotChangeWithDesiredEdits()
+    {
+        var desired = AddConfigured(
+            new SyncDesiredTopology(new SyncGlobalDefaults("proxy-one", true, false)),
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync");
+        var workspace = SyncTopologyWorkspace.Begin(desired);
+        var startup = workspace.StartupRuntime;
+
+        var changedDesired = desired.WithGlobalDefaults(desired.GlobalDefaults.WithProxy("proxy-two"));
+        workspace = workspace.Apply(new(true, changedDesired));
+
+        Assert.AreSame(startup, workspace.StartupRuntime);
+        Assert.AreEqual("proxy-one", workspace.StartupRuntime.Targets.Single().Proxy.Value);
+        Assert.AreEqual("proxy-two", workspace.Preview.Targets.Single().Proxy.Value);
+    }
+
+    private static SyncDesiredTopology AddConfigured(
+        SyncDesiredTopology topology,
+        string name,
+        SyncTargetKind kind,
+        string url,
+        Func<SyncTargetDraft, SyncTargetDraft>? configure = null)
+    {
+        topology = RequireSuccess(topology.AddTarget(name, kind));
+        var identity = kind == SyncTargetKind.LocalSidecar
+            ? SyncDesiredTopology.LocalSidecarIdentity
+            : name;
+        return RequireSuccess(
+            topology.UpdateTarget(
+                identity,
+                target => (configure?.Invoke(target) ?? target)
+                    .WithConnection(url, SyncSecret.FromPlainText($"fixture-{identity}"))
+                    .WithEnabled(true)));
+    }
+
+    private static SyncDesiredTopology RequireSuccess(SyncTopologyTransitionResult result)
+    {
+        Assert.IsTrue(result.Succeeded, result.Diagnostic?.Message);
+        return result.Topology;
+    }
+}

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTargetContractCorpusTests.cs
@@ -32,6 +32,13 @@ public sealed class SyncTargetContractCorpusTests
 
     private static readonly string[] LocalSidecarKindOnly = ["local_sidecar"];
 
+    private static readonly string[] LockedResolutionSources =
+    [
+        "global_default",
+        "target_type_default",
+        "target",
+    ];
+
     [TestMethod]
     public void CorpusCoversLockedCompatibilityCasesAndPreservesEveryFixtureByte()
     {
@@ -91,6 +98,9 @@ public sealed class SyncTargetContractCorpusTests
         CollectionAssert.AreEquivalent(
             LockedProvenanceStates,
             root.GetProperty("provenanceStates").EnumerateArray().Select(item => item.GetString()).ToArray());
+        CollectionAssert.AreEquivalent(
+            LockedResolutionSources,
+            root.GetProperty("resolutionSources").EnumerateArray().Select(item => item.GetString()).ToArray());
 
         var kinds = root.GetProperty("targetKinds");
         Assert.IsFalse(kinds.GetProperty("local_sidecar").GetProperty("inheritsGlobalSync").GetBoolean());


### PR DESCRIPTION
## Summary

- add a dependency-free catalog for local Sidecar, legacy/community, and Majel ingest target kinds
- model provider presets separately from transport kinds
- add typed inherited/explicit overrides with value provenance and resolution source
- add immutable global defaults, target drafts, desired topology transitions, and startup runtime snapshots
- implement add, preset, rename, duplicate, kind-change, enable/disable, update, and remove transitions
- validate identity, cardinality, endpoint ownership, credentials, unsupported capabilities, Sidecar runtime mode, and unsafe TLS policy
- keep target tokens opaque in display, diagnostics, and resolved summaries
- extend the locked contract with explicit resolution-source vocabulary

## Why

The launcher needs a stable domain between raw TOML and WPF. Without it, inheritance, Sidecar ownership, credentials, and target lifecycle behavior would become UI or persistence side effects. This slice implements issue #224 without referencing WPF or the TOML parser.

## Impact

Global changes flow only to compatible inherited external fields. Explicit values—including false and empty proxy—remain stable. Sidecar uses its own safe defaults and cannot inherit an external proxy or unsafe TLS policy. Invalid and unsupported combinations may exist as drafts but cannot produce a committable resolved topology. Desired edits never mutate the startup runtime snapshot.

Duplicate targets are disabled and have credentials cleared by default.

## Validation

- `dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release --no-restore` — 239 core + 3 WPF tests
- `dotnet build windows-launcher/src/STFCCommunityMod.Launcher/STFCCommunityMod.Launcher.csproj -c Release --no-restore`
- `dotnet format windows-launcher/STFCCommunityMod.Launcher.sln --verify-no-changes --no-restore`
- `node --test scripts/test_config_schema.mjs` — 21 tests
- `node scripts/generate_config_schema.mjs --check`
- `git diff --check`

Closes #224
Parent campaign: #221
Umbrella PR: #227
Depends on merged child PR #228