### PR TITLE
Persist launcher sync topology safely

### DIFF
--- a/docs/windows-launcher/SYNC_TARGET_PERSISTENCE.md
+++ b/docs/windows-launcher/SYNC_TARGET_PERSISTENCE.md
@@ -1,0 +1,74 @@
+# Windows Launcher Sync Target Persistence
+
+This document records the LS-004 persistence boundary for the launcher sync campaign. The implementation maps the
+dependency-free desired topology to sparse TOML operations and delegates the only filesystem replacement to the
+existing `AtomicTomlStore`.
+
+## Pipeline
+
+1. `SyncTopologyTomlAdapter` reads conservative TOML assignments into the desired domain without modifying bytes.
+2. `SyncTopologyPersistencePlanner` compares the baseline and desired topology and produces bounded semantic
+   mutations. Mutation display text contains paths and secret-state markers, never rendered token values.
+3. `SyncTopologyPersistencePlan.Apply` re-loads the sparse document before every mutation and fails closed on the first
+   unsupported or conflicting construct.
+4. `SyncTopologyPersistenceWorkspace` submits the transformed bytes and exact baseline bytes to `AtomicTomlStore`.
+5. The atomic store rechecks the destination, writes durably to a sibling temporary file, creates a backup, and replaces
+   the destination. A stale or disappearing destination is a conflict and preserves the external file.
+
+No sync change bypasses this boundary or writes one field at a time to the live file.
+
+## Mapping
+
+- Global values persist under `[sync]`.
+- External targets persist under `[sync.targets.<name>]` and newly added or kind-changed targets receive explicit
+  `mode = "legacy"` or `mode = "majel"`.
+- Local Sidecar persists only under `[sidecar.sync]`.
+- An inherited target override removes the target-local assignment.
+- Explicit false and explicit empty proxy remain assignments.
+- Unchanged tokens produce no mutation. Replacement and clearing are secret-bearing internal mutations whose display
+  form is redacted.
+- External targets cannot be persisted as disabled because the native schema has no canonical enabled field. The user
+  must keep the target enabled or remove it.
+
+## Structural operations
+
+The sparse editor supports whole-table removal and rename for bare-key tables. Rename includes descendant tables and
+preserves body bytes, comments, whitespace, line endings, BOM, ordering, and unknown fields. Removal deletes the owned
+table and its descendants while retaining unrelated tables.
+
+Both operations reject:
+
+- a destination table or dotted-assignment collision;
+- a source represented only through dotted assignments;
+- duplicate tables or malformed source documents;
+- unsupported quoted table paths and array-of-table syntax.
+
+Declared target tables are inventoried independently of their assignments. An empty target table is therefore surfaced
+as an invalid, incomplete target instead of disappearing from the launcher model.
+
+## Kind changes and migration
+
+Changing an external target kind requires one explicit policy:
+
+- `PreserveCompatibleOverrides` keeps compatible target-local overrides.
+- `ResetOverrides` requires the desired target to have no explicit overrides and persists their removal.
+
+Legacy root `[sync].url` and `[sync].token` load as a virtual `default` target. An unchanged virtual target never rewrites
+the source. Editing or renaming it is blocked until migration is explicitly confirmed; confirmed migration clears the
+legacy root credentials and creates `[sync.targets.default]` atomically.
+
+## Security and display
+
+- `SyncSecret`, `SyncOverride<T>`, `SyncResolvedValue<T>`, and `SyncResolvedTarget` have redacted display forms.
+- Resolved summaries expose only whether credentials are configured.
+- Proxy values remain available to the editor but are absent from domain and plan `ToString()` output.
+- Endpoint URLs containing embedded user information are rejected; credentials belong in the opaque token field.
+- Invalid-value diagnostics name the canonical path and line, never the rendered value.
+- Mutation factories accepting rendered values are assembly-internal.
+
+## Workspace behavior
+
+Staging changes does not touch disk or the startup runtime snapshot, and a semantic no-op does not create pending work.
+Discard restores the baseline topology. Successful commit advances the baseline only after atomic replacement. Conflict
+leaves the desired draft pending, marks the workspace stale, and preserves the external file without creating a backup;
+staging or discarding cannot falsely clear that stale state.

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlDocument.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlDocument.cs
@@ -79,8 +79,14 @@ public sealed partial class SparseTomlDocument
                 text[assignment.ValueStart..assignment.ValueEnd],
                 assignment.Line.Number),
             StringComparer.Ordinal);
+        var tables = analysis.Sections
+            .Select(section => new SparseTomlTable(
+                string.Join('.', section.Path),
+                section.HeaderLine.Number))
+            .ToArray();
         return SparseTomlReadResult.Success(
-            new ReadOnlyDictionary<string, SparseTomlOverride>(overrides));
+            new ReadOnlyDictionary<string, SparseTomlOverride>(overrides),
+            Array.AsReadOnly(tables));
     }
 
     public SparseTomlEditResult SetOverride(string canonicalPath, string renderedTomlValue)
@@ -215,6 +221,140 @@ public sealed partial class SparseTomlDocument
         var line = analysis.TargetAssignments[0].Line;
         var updatedText = text.Remove(line.Start, line.End - line.Start);
         return BuildResult(updatedText);
+    }
+
+    public SparseTomlEditResult RemoveTable(string canonicalTablePath)
+    {
+        var pathResult = ParseCanonicalPath(canonicalTablePath);
+        if (pathResult.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(pathResult.Error);
+        }
+
+        var path = pathResult.Segments!;
+        var analysis = Analyze(targetPath: null);
+        if (analysis.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(analysis.Error);
+        }
+
+        var matchingSections = analysis.Sections
+            .Where(section => HasPathPrefix(section.Path, path))
+            .OrderByDescending(section => section.HeaderLine.Start)
+            .ToArray();
+        if (matchingSections.Length == 0)
+        {
+            return analysis.AllAssignments.Any(assignment => HasPathPrefix(assignment.Path, path))
+                ? SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{canonicalTablePath}]' is represented by dotted assignments and cannot be removed safely."))
+                : SparseTomlEditResult.Unchanged([.. originalContents]);
+        }
+
+        var updatedText = text;
+        foreach (var section in matchingSections)
+        {
+            updatedText = updatedText.Remove(
+                section.HeaderLine.Start,
+                section.End - section.HeaderLine.Start);
+        }
+
+        return BuildValidatedResult(updatedText);
+    }
+
+    public SparseTomlEditResult RenameTable(string canonicalTablePath, string newCanonicalTablePath)
+    {
+        var sourceResult = ParseCanonicalPath(canonicalTablePath);
+        if (sourceResult.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(sourceResult.Error);
+        }
+
+        var destinationResult = ParseCanonicalPath(newCanonicalTablePath);
+        if (destinationResult.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(destinationResult.Error);
+        }
+
+        var source = sourceResult.Segments!;
+        var destination = destinationResult.Segments!;
+        if (source.SequenceEqual(destination, StringComparer.Ordinal))
+        {
+            return SparseTomlEditResult.Unchanged([.. originalContents]);
+        }
+
+        var analysis = Analyze(targetPath: null);
+        if (analysis.Error is not null)
+        {
+            return SparseTomlEditResult.Invalid(analysis.Error);
+        }
+
+        var matchingSections = analysis.Sections
+            .Where(section => HasPathPrefix(section.Path, source))
+            .ToArray();
+        if (matchingSections.Length == 0)
+        {
+            return analysis.AllAssignments.Any(assignment => HasPathPrefix(assignment.Path, source))
+                ? SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{canonicalTablePath}]' is represented by dotted assignments and cannot be renamed safely."))
+                : SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{canonicalTablePath}]' does not exist."));
+        }
+
+        var selected = matchingSections.ToHashSet();
+        foreach (var section in matchingSections)
+        {
+            var mappedPath = destination.Concat(section.Path[source.Length..]).ToArray();
+            if (analysis.Sections.Any(other =>
+                    !selected.Contains(other)
+                    && other.Path.SequenceEqual(mappedPath, StringComparer.Ordinal)))
+            {
+                return SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.DuplicateTarget,
+                        $"Table '[{string.Join('.', mappedPath)}]' already exists.",
+                        section.HeaderLine.Number));
+            }
+
+            if (analysis.AllAssignments.Any(assignment =>
+                    !HasPathPrefix(assignment.Path, source)
+                    && HasPathPrefix(assignment.Path, mappedPath)))
+            {
+                return SparseTomlEditResult.Invalid(
+                    new(
+                        SparseTomlErrorCode.UnsupportedTarget,
+                        $"Table '[{string.Join('.', mappedPath)}]' collides with an existing dotted assignment.",
+                        section.HeaderLine.Number));
+            }
+        }
+
+        var replacements = matchingSections
+            .Select(section =>
+            {
+                var match = SimpleTableHeaderRegex().Match(section.HeaderLine.Content);
+                var pathGroup = match.Groups["path"];
+                var suffix = section.Path[source.Length..];
+                return new TableHeaderReplacement(
+                    section.HeaderLine.Start + pathGroup.Index,
+                    pathGroup.Length,
+                    string.Join('.', destination.Concat(suffix)));
+            })
+            .OrderByDescending(replacement => replacement.Start)
+            .ToArray();
+
+        var updatedText = text;
+        foreach (var replacement in replacements)
+        {
+            updatedText = updatedText.Remove(replacement.Start, replacement.Length)
+                .Insert(replacement.Start, replacement.Value);
+        }
+
+        return BuildValidatedResult(updatedText);
     }
 
     private Analysis Analyze(string[]? targetPath)
@@ -566,6 +706,28 @@ public sealed partial class SparseTomlDocument
             ? SparseTomlEditResult.Unchanged(updatedContents)
             : SparseTomlEditResult.Updated(updatedContents);
     }
+
+    private SparseTomlEditResult BuildValidatedResult(string updatedText)
+    {
+        var result = BuildResult(updatedText);
+        if (!result.IsValid || !result.Changed || result.Contents is null)
+        {
+            return result;
+        }
+
+        var load = Load(result.Contents, out var updatedDocument);
+        if (!load.IsValid || updatedDocument is null)
+        {
+            return load;
+        }
+
+        var validation = updatedDocument.ValidateForMutation();
+        return validation.IsValid ? result : validation;
+    }
+
+    private static bool HasPathPrefix(string[] path, string[] prefix) =>
+        path.Length >= prefix.Length
+        && path.AsSpan(0, prefix.Length).SequenceEqual(prefix);
 
     private static PathParseResult ParseCanonicalPath(string canonicalPath)
     {
@@ -919,6 +1081,11 @@ public sealed partial class SparseTomlDocument
         PhysicalLine Line,
         int ValueStart,
         int ValueEnd);
+
+    private sealed record TableHeaderReplacement(
+        int Start,
+        int Length,
+        string Value);
 
     private sealed class Section(string[] path, PhysicalLine headerLine, int end)
     {

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlResult.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SparseTomlResult.cs
@@ -36,15 +36,21 @@ public sealed record SparseTomlOverride(
     string RenderedValue,
     int LineNumber);
 
+public sealed record SparseTomlTable(
+    string CanonicalPath,
+    int LineNumber);
+
 public sealed record SparseTomlReadResult(
     bool IsValid,
     IReadOnlyDictionary<string, SparseTomlOverride>? Overrides,
+    IReadOnlyList<SparseTomlTable>? Tables,
     SparseTomlError? Error)
 {
     public static SparseTomlReadResult Success(
-        IReadOnlyDictionary<string, SparseTomlOverride> overrides) =>
-        new(true, overrides, null);
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        IReadOnlyList<SparseTomlTable> tables) =>
+        new(true, overrides, tables, null);
 
     public static SparseTomlReadResult Invalid(SparseTomlError error) =>
-        new(false, null, error);
+        new(false, null, null, error);
 }

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncDesiredTopology.cs
@@ -157,7 +157,10 @@ public sealed class SyncDesiredTopology
         return Succeeded(new(GlobalDefaults, changed));
     }
 
-    public SyncTopologyTransitionResult ChangeTargetKind(string name, SyncTargetKind newKind)
+    public SyncTopologyTransitionResult ChangeTargetKind(
+        string name,
+        SyncTargetKind newKind,
+        SyncTargetKindChangePolicy policy = SyncTargetKindChangePolicy.PreserveCompatibleOverrides)
     {
         if (!targets.TryGetValue(name, out var target))
         {
@@ -180,6 +183,11 @@ public sealed class SyncDesiredTopology
 
         var supported = SyncTargetTypeCatalog.Get(newKind).SupportedDataKinds;
         var changedTarget = target.WithKind(newKind);
+        if (policy == SyncTargetKindChangePolicy.ResetOverrides)
+        {
+            changedTarget = changedTarget.WithoutOverrides();
+        }
+
         foreach (var unsupported in changedTarget.DataOverrides.Keys.Where(kind => !supported.Contains(kind)).ToArray())
         {
             changedTarget = changedTarget.WithDataOverride(unsupported, SyncOverride.Inherited<bool>());
@@ -298,12 +306,14 @@ public static class SyncTopologyResolver
         }
 
         var definition = SyncTargetTypeCatalog.Get(target.Kind);
-        if (definition.RequiresUrl && !TryValidateEndpoint(target.Url, target.Kind, out var endpointCode, out var endpointMessage))
+        if (target.Enabled
+            && definition.RequiresUrl
+            && !TryValidateEndpoint(target.Url, target.Kind, out var endpointCode, out var endpointMessage))
         {
             diagnostics.Add(SyncDesiredTopology.Error(endpointCode, target.Name, "url", endpointMessage));
         }
 
-        if (definition.RequiresToken && !target.Token.IsConfigured)
+        if (target.Enabled && definition.RequiresToken && !target.Token.IsConfigured)
         {
             diagnostics.Add(SyncDesiredTopology.Error(
                 "SYNC_CREDENTIALS_INCOMPLETE",
@@ -441,6 +451,13 @@ public static class SyncTopologyResolver
         {
             code = "SYNC_ENDPOINT_INVALID";
             message = "The target endpoint must be an absolute HTTP or HTTPS URL.";
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            code = "SYNC_ENDPOINT_EMBEDDED_CREDENTIALS";
+            message = "The target endpoint cannot contain embedded credentials; use the token field.";
             return false;
         }
 

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyContracts.cs
@@ -51,6 +51,12 @@ public enum SyncTopologyDiagnosticSeverity
     Error,
 }
 
+public enum SyncTargetKindChangePolicy
+{
+    PreserveCompatibleOverrides,
+    ResetOverrides,
+}
+
 public readonly record struct SyncOverride<T>(bool IsExplicit, T Value)
 {
     public SyncResolvedValue<T> Resolve(T inheritedValue, SyncValueSource inheritedSource)
@@ -68,6 +74,8 @@ public readonly record struct SyncOverride<T>(bool IsExplicit, T Value)
         };
         return new(Value, provenance, SyncValueSource.Target);
     }
+
+    public override string ToString() => IsExplicit ? "[explicit]" : "[inherited]";
 }
 
 public static class SyncOverride
@@ -80,7 +88,10 @@ public static class SyncOverride
 public sealed record SyncResolvedValue<T>(
     T Value,
     SyncValueProvenance Provenance,
-    SyncValueSource Source);
+    SyncValueSource Source)
+{
+    public override string ToString() => $"[{Provenance} from {Source}]";
+}
 
 public sealed class SyncSecret : IEquatable<SyncSecret>
 {
@@ -347,6 +358,15 @@ public sealed class SyncTargetDraft
 
     public SyncTargetDraft WithoutSecret() => Copy(token: SyncSecret.Missing);
 
+    public SyncTargetDraft WithoutOverrides() =>
+        Copy(
+            proxy: SyncOverride.Inherited<string>(),
+            verifySsl: SyncOverride.Inherited<bool>(),
+            allowUnsafeTlsWithoutCertificateValidation: SyncOverride.Inherited<bool>(),
+            dataOverrides: new Dictionary<SyncDataKind, SyncOverride<bool>>(),
+            battlelogEnrichment: SyncOverride.Inherited<bool>(),
+            fleetRuntimeMode: SyncOverride.Inherited<string>());
+
     private SyncTargetDraft Copy(
         string? name = null,
         SyncTargetKind? kind = null,
@@ -380,18 +400,45 @@ public sealed record SyncTopologyDiagnostic(
     string? TargetName = null,
     string? Field = null);
 
-public sealed record SyncResolvedTarget(
-    string Name,
-    SyncTargetKind Kind,
-    bool Enabled,
-    string Url,
-    bool CredentialsConfigured,
-    SyncResolvedValue<string> Proxy,
-    SyncResolvedValue<bool> VerifySsl,
-    SyncResolvedValue<bool> AllowUnsafeTlsWithoutCertificateValidation,
-    IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> DataKinds,
-    SyncResolvedValue<bool>? BattlelogEnrichment,
-    SyncResolvedValue<string>? FleetRuntimeMode);
+public sealed class SyncResolvedTarget(
+    string name,
+    SyncTargetKind kind,
+    bool enabled,
+    string url,
+    bool credentialsConfigured,
+    SyncResolvedValue<string> proxy,
+    SyncResolvedValue<bool> verifySsl,
+    SyncResolvedValue<bool> allowUnsafeTlsWithoutCertificateValidation,
+    IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> dataKinds,
+    SyncResolvedValue<bool>? battlelogEnrichment,
+    SyncResolvedValue<string>? fleetRuntimeMode)
+{
+    public string Name { get; } = name;
+
+    public SyncTargetKind Kind { get; } = kind;
+
+    public bool Enabled { get; } = enabled;
+
+    public string Url { get; } = url;
+
+    public bool CredentialsConfigured { get; } = credentialsConfigured;
+
+    public SyncResolvedValue<string> Proxy { get; } = proxy;
+
+    public SyncResolvedValue<bool> VerifySsl { get; } = verifySsl;
+
+    public SyncResolvedValue<bool> AllowUnsafeTlsWithoutCertificateValidation { get; } =
+        allowUnsafeTlsWithoutCertificateValidation;
+
+    public IReadOnlyDictionary<SyncDataKind, SyncResolvedValue<bool>> DataKinds { get; } = dataKinds;
+
+    public SyncResolvedValue<bool>? BattlelogEnrichment { get; } = battlelogEnrichment;
+
+    public SyncResolvedValue<string>? FleetRuntimeMode { get; } = fleetRuntimeMode;
+
+    public override string ToString() =>
+        $"{Name} ({Kind}, {(Enabled ? "enabled" : "disabled")}, credentials {(CredentialsConfigured ? "configured" : "missing")})";
+}
 
 public sealed record SyncResolvedTopology(
     IReadOnlyList<SyncResolvedTarget> Targets,

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
@@ -1,0 +1,606 @@
+using System.Collections.ObjectModel;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public enum SyncTomlMutationKind
+{
+    SetOverride,
+    ClearOverride,
+    RenameTable,
+    RemoveTable,
+}
+
+public sealed class SyncTomlMutation
+{
+    private SyncTomlMutation(
+        SyncTomlMutationKind kind,
+        string path,
+        string? renderedValue,
+        string? destinationPath,
+        bool containsSecret)
+    {
+        Kind = kind;
+        Path = path;
+        RenderedValue = renderedValue;
+        DestinationPath = destinationPath;
+        ContainsSecret = containsSecret;
+    }
+
+    public SyncTomlMutationKind Kind { get; }
+
+    public string Path { get; }
+
+    public string? DestinationPath { get; }
+
+    public bool ContainsSecret { get; }
+
+    internal string? RenderedValue { get; }
+
+    internal static SyncTomlMutation Set(string path, string renderedValue, bool containsSecret = false) =>
+        new(SyncTomlMutationKind.SetOverride, path, renderedValue, null, containsSecret);
+
+    internal static SyncTomlMutation Clear(string path) =>
+        new(SyncTomlMutationKind.ClearOverride, path, null, null, false);
+
+    internal static SyncTomlMutation Rename(string path, string destinationPath) =>
+        new(SyncTomlMutationKind.RenameTable, path, null, destinationPath, false);
+
+    internal static SyncTomlMutation Remove(string path) =>
+        new(SyncTomlMutationKind.RemoveTable, path, null, null, false);
+
+    public override string ToString() =>
+        Kind switch
+        {
+            SyncTomlMutationKind.RenameTable => $"{Kind}: {Path} -> {DestinationPath}",
+            SyncTomlMutationKind.SetOverride when ContainsSecret => $"{Kind}: {Path} [secret]",
+            _ => $"{Kind}: {Path}",
+        };
+}
+
+public sealed record SyncTopologyPersistencePlan(
+    bool IsValid,
+    IReadOnlyList<SyncTomlMutation> Mutations,
+    IReadOnlyList<SyncTopologyDiagnostic> Diagnostics)
+{
+    public SparseTomlEditResult Apply(byte[] baselineContents)
+    {
+        ArgumentNullException.ThrowIfNull(baselineContents);
+        if (!IsValid)
+        {
+            return SparseTomlEditResult.Invalid(
+                new(
+                    SparseTomlErrorCode.InvalidValue,
+                    "The sync topology contains persistence errors and was not applied."));
+        }
+
+        byte[] contents = [.. baselineContents];
+        var changed = false;
+        foreach (var mutation in Mutations)
+        {
+            var load = SparseTomlDocument.Load(contents, out var document);
+            if (!load.IsValid || document is null)
+            {
+                return load;
+            }
+
+            var edit = mutation.Kind switch
+            {
+                SyncTomlMutationKind.SetOverride when mutation.RenderedValue is not null =>
+                    document.SetOverride(mutation.Path, mutation.RenderedValue),
+                SyncTomlMutationKind.ClearOverride => document.RemoveOverride(mutation.Path),
+                SyncTomlMutationKind.RenameTable when mutation.DestinationPath is not null =>
+                    document.RenameTable(mutation.Path, mutation.DestinationPath),
+                SyncTomlMutationKind.RemoveTable => document.RemoveTable(mutation.Path),
+                _ => SparseTomlEditResult.Invalid(
+                    new(SparseTomlErrorCode.InvalidValue, $"Mutation '{mutation.Kind}' is incomplete.")),
+            };
+            if (!edit.IsValid || edit.Contents is null)
+            {
+                return edit;
+            }
+
+            contents = edit.Contents;
+            changed |= edit.Changed;
+        }
+
+        return changed
+            ? SparseTomlEditResult.Updated(contents)
+            : SparseTomlEditResult.Unchanged(contents);
+    }
+}
+
+public static class SyncTopologyPersistencePlanner
+{
+    public static SyncTopologyPersistencePlan Build(
+        SyncTopologyTomlLoadResult baseline,
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string>? renames = null,
+        IReadOnlyDictionary<string, SyncTargetKindChangePolicy>? kindChangeDecisions = null,
+        bool migrateLegacyRoot = false)
+    {
+        ArgumentNullException.ThrowIfNull(baseline);
+        ArgumentNullException.ThrowIfNull(desired);
+        if (!baseline.IsValid || baseline.Topology is null)
+        {
+            return Invalid("SYNC_BASELINE_INVALID", "The baseline sync topology is invalid.");
+        }
+
+        var diagnostics = baseline.Diagnostics.Concat(desired.Resolve().Diagnostics).ToList();
+        foreach (var target in desired.Targets.Values.Where(target =>
+                     target.Kind != SyncTargetKind.LocalSidecar && !target.Enabled))
+        {
+            diagnostics.Add(Error(
+                "SYNC_EXTERNAL_DISABLED_PERSISTENCE_REQUIRED",
+                target.Name,
+                "enabled",
+                "External targets cannot be persisted as disabled; remove the target or keep it enabled."));
+        }
+
+        var renameMap = renames?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        var kindDecisions = kindChangeDecisions?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal);
+        ValidateRenames(baseline.Topology, desired, renameMap, diagnostics);
+        ValidateKindChanges(baseline.Topology, desired, renameMap, kindDecisions, diagnostics);
+        if (diagnostics.Any(item => item.Severity == SyncTopologyDiagnosticSeverity.Error))
+        {
+            return new(false, [], diagnostics.AsReadOnly());
+        }
+
+        var mutations = new List<SyncTomlMutation>();
+        AddGlobalChanges(mutations, baseline.Topology.GlobalDefaults, desired.GlobalDefaults);
+
+        var baselineTargets = baseline.Topology.Targets;
+        var consumedDesired = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (baselineName, baselineTarget) in baselineTargets)
+        {
+            var desiredName = renameMap.GetValueOrDefault(baselineName, baselineName);
+            var hasDesired = desired.Targets.TryGetValue(desiredName, out var desiredTarget);
+            var isLegacyVirtual = baseline.HasLegacyRootTarget
+                && string.Equals(baselineName, "default", StringComparison.Ordinal);
+
+            if (!hasDesired)
+            {
+                if (isLegacyVirtual)
+                {
+                    mutations.Add(SyncTomlMutation.Clear("sync.url"));
+                    mutations.Add(SyncTomlMutation.Clear("sync.token"));
+                }
+                else
+                {
+                    mutations.Add(SyncTomlMutation.Remove(TargetRoot(baselineTarget)));
+                }
+
+                continue;
+            }
+
+            consumedDesired.Add(desiredName);
+            if (isLegacyVirtual)
+            {
+                var changed = !TargetsEquivalent(baselineTarget, desiredTarget!);
+                var renamed = !string.Equals(baselineName, desiredName, StringComparison.Ordinal);
+                if ((changed || renamed) && !migrateLegacyRoot)
+                {
+                    diagnostics.Add(Error(
+                        "SYNC_LEGACY_MIGRATION_REQUIRED",
+                        desiredName,
+                        null,
+                        "Editing or renaming the virtual legacy target requires explicit migration confirmation."));
+                    continue;
+                }
+
+                if (changed || renamed)
+                {
+                    mutations.Add(SyncTomlMutation.Clear("sync.url"));
+                    mutations.Add(SyncTomlMutation.Clear("sync.token"));
+                    AddTarget(mutations, desiredTarget!);
+                }
+
+                continue;
+            }
+
+            if (!string.Equals(baselineName, desiredName, StringComparison.Ordinal))
+            {
+                mutations.Add(SyncTomlMutation.Rename(TargetRoot(baselineTarget), TargetRoot(desiredTarget!)));
+            }
+
+            AddTargetChanges(mutations, baselineTarget, desiredTarget!);
+        }
+
+        foreach (var (name, target) in desired.Targets)
+        {
+            if (!consumedDesired.Contains(name))
+            {
+                AddTarget(mutations, target);
+            }
+        }
+
+        var valid = diagnostics.All(item => item.Severity != SyncTopologyDiagnosticSeverity.Error);
+        return new(valid, valid ? mutations.AsReadOnly() : [], diagnostics.AsReadOnly());
+    }
+
+    private static void AddGlobalChanges(
+        List<SyncTomlMutation> mutations,
+        SyncGlobalDefaults baseline,
+        SyncGlobalDefaults desired)
+    {
+        AddChanged(mutations, "sync.proxy", baseline.Proxy, desired.Proxy);
+        AddChanged(mutations, "sync.verify_ssl", baseline.VerifySsl, desired.VerifySsl);
+        AddChanged(
+            mutations,
+            "sync.allow_unsafe_tls_without_certificate_validation",
+            baseline.AllowUnsafeTlsWithoutCertificateValidation,
+            desired.AllowUnsafeTlsWithoutCertificateValidation);
+        foreach (var (kind, key) in SyncTopologyTomlAdapter.DataKeys)
+        {
+            AddChanged(mutations, $"sync.{key}", baseline.DataKinds[kind], desired.DataKinds[kind]);
+        }
+    }
+
+    private static void AddTarget(List<SyncTomlMutation> mutations, SyncTargetDraft target)
+    {
+        var root = TargetRoot(target);
+        if (target.Kind == SyncTargetKind.LocalSidecar)
+        {
+            mutations.Add(SyncTomlMutation.Set(root + ".enabled", Render(target.Enabled)));
+        }
+        else
+        {
+            mutations.Add(SyncTomlMutation.Set(root + ".mode", LauncherTomlValue.RenderString(Mode(target.Kind))));
+        }
+
+        mutations.Add(SyncTomlMutation.Set(root + ".url", LauncherTomlValue.RenderString(target.Url)));
+        mutations.Add(SyncTomlMutation.Set(
+            root + ".token",
+            LauncherTomlValue.RenderString(target.Token.RevealForPersistence()),
+            containsSecret: true));
+        AddOverride(mutations, root + ".proxy", target.Proxy, LauncherTomlValue.RenderString);
+        AddOverride(mutations, root + ".verify_ssl", target.VerifySsl, Render);
+        AddOverride(
+            mutations,
+            root + ".allow_unsafe_tls_without_certificate_validation",
+            target.AllowUnsafeTlsWithoutCertificateValidation,
+            Render);
+        foreach (var (kind, value) in target.DataOverrides)
+        {
+            AddOverride(mutations, $"{root}.{SyncTopologyTomlAdapter.DataKey(kind)}", value, Render);
+        }
+
+        if (target.Kind == SyncTargetKind.LocalSidecar)
+        {
+            AddOverride(mutations, root + ".battlelog_enrichment", target.BattlelogEnrichment, Render);
+            AddOverride(mutations, root + ".fleet_runtime_mode", target.FleetRuntimeMode, LauncherTomlValue.RenderString);
+        }
+    }
+
+    private static void AddTargetChanges(
+        List<SyncTomlMutation> mutations,
+        SyncTargetDraft baseline,
+        SyncTargetDraft desired)
+    {
+        var root = TargetRoot(desired);
+        if (baseline.Kind != desired.Kind)
+        {
+            mutations.Add(SyncTomlMutation.Set(root + ".mode", LauncherTomlValue.RenderString(Mode(desired.Kind))));
+        }
+
+        if (desired.Kind == SyncTargetKind.LocalSidecar)
+        {
+            AddChanged(mutations, root + ".enabled", baseline.Enabled, desired.Enabled);
+        }
+
+        AddChanged(mutations, root + ".url", baseline.Url, desired.Url);
+        if (!baseline.Token.Equals(desired.Token))
+        {
+            mutations.Add(SyncTomlMutation.Set(
+                root + ".token",
+                LauncherTomlValue.RenderString(desired.Token.RevealForPersistence()),
+                containsSecret: true));
+        }
+
+        AddOverrideChange(mutations, root + ".proxy", baseline.Proxy, desired.Proxy, LauncherTomlValue.RenderString);
+        AddOverrideChange(mutations, root + ".verify_ssl", baseline.VerifySsl, desired.VerifySsl, Render);
+        AddOverrideChange(
+            mutations,
+            root + ".allow_unsafe_tls_without_certificate_validation",
+            baseline.AllowUnsafeTlsWithoutCertificateValidation,
+            desired.AllowUnsafeTlsWithoutCertificateValidation,
+            Render);
+        foreach (var kind in baseline.DataOverrides.Keys.Union(desired.DataOverrides.Keys))
+        {
+            AddOverrideChange(
+                mutations,
+                $"{root}.{SyncTopologyTomlAdapter.DataKey(kind)}",
+                baseline.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>()),
+                desired.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>()),
+                Render);
+        }
+
+        AddOverrideChange(
+            mutations,
+            root + ".battlelog_enrichment",
+            baseline.BattlelogEnrichment,
+            desired.BattlelogEnrichment,
+            Render);
+        AddOverrideChange(
+            mutations,
+            root + ".fleet_runtime_mode",
+            baseline.FleetRuntimeMode,
+            desired.FleetRuntimeMode,
+            LauncherTomlValue.RenderString);
+    }
+
+    private static void AddChanged(List<SyncTomlMutation> mutations, string path, string baseline, string desired)
+    {
+        if (!string.Equals(baseline, desired, StringComparison.Ordinal))
+        {
+            mutations.Add(SyncTomlMutation.Set(path, LauncherTomlValue.RenderString(desired)));
+        }
+    }
+
+    private static void AddChanged(List<SyncTomlMutation> mutations, string path, bool baseline, bool desired)
+    {
+        if (baseline != desired)
+        {
+            mutations.Add(SyncTomlMutation.Set(path, Render(desired)));
+        }
+    }
+
+    private static void AddOverride<T>(
+        List<SyncTomlMutation> mutations,
+        string path,
+        SyncOverride<T> value,
+        Func<T, string> render)
+    {
+        if (value.IsExplicit)
+        {
+            mutations.Add(SyncTomlMutation.Set(path, render(value.Value)));
+        }
+    }
+
+    private static void AddOverrideChange<T>(
+        List<SyncTomlMutation> mutations,
+        string path,
+        SyncOverride<T> baseline,
+        SyncOverride<T> desired,
+        Func<T, string> render)
+    {
+        if (baseline.Equals(desired))
+        {
+            return;
+        }
+
+        mutations.Add(desired.IsExplicit
+            ? SyncTomlMutation.Set(path, render(desired.Value))
+            : SyncTomlMutation.Clear(path));
+    }
+
+    private static void ValidateRenames(
+        SyncDesiredTopology baseline,
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string> renames,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var destinations = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (source, destination) in renames)
+        {
+            if (!baseline.Targets.ContainsKey(source)
+                || !desired.Targets.ContainsKey(destination)
+                || !destinations.Add(destination))
+            {
+                diagnostics.Add(Error(
+                    "SYNC_RENAME_INVALID",
+                    source,
+                    "identity",
+                    "The target rename does not match the baseline and desired topology."));
+            }
+        }
+    }
+
+    private static void ValidateKindChanges(
+        SyncDesiredTopology baseline,
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string> renames,
+        Dictionary<string, SyncTargetKindChangePolicy> decisions,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        foreach (var (baselineName, baselineTarget) in baseline.Targets)
+        {
+            var desiredName = renames.GetValueOrDefault(baselineName, baselineName);
+            if (!desired.Targets.TryGetValue(desiredName, out var desiredTarget)
+                || baselineTarget.Kind == desiredTarget.Kind)
+            {
+                continue;
+            }
+
+            if (!decisions.TryGetValue(desiredName, out var decision))
+            {
+                diagnostics.Add(Error(
+                    "SYNC_KIND_CHANGE_DECISION_REQUIRED",
+                    desiredName,
+                    "kind",
+                    "Changing target kind requires an explicit preserve-or-reset decision."));
+                continue;
+            }
+
+            if (decision == SyncTargetKindChangePolicy.ResetOverrides && HasExplicitOverrides(desiredTarget))
+            {
+                diagnostics.Add(Error(
+                    "SYNC_KIND_CHANGE_RESET_MISMATCH",
+                    desiredName,
+                    "kind",
+                    "The reset decision requires all target overrides to use inherited values."));
+            }
+        }
+    }
+
+    private static bool HasExplicitOverrides(SyncTargetDraft target) =>
+        target.Proxy.IsExplicit
+        || target.VerifySsl.IsExplicit
+        || target.AllowUnsafeTlsWithoutCertificateValidation.IsExplicit
+        || target.BattlelogEnrichment.IsExplicit
+        || target.FleetRuntimeMode.IsExplicit
+        || target.DataOverrides.Values.Any(value => value.IsExplicit);
+
+    private static bool TargetsEquivalent(SyncTargetDraft left, SyncTargetDraft right) =>
+        left.Kind == right.Kind
+        && left.Enabled == right.Enabled
+        && string.Equals(left.Url, right.Url, StringComparison.Ordinal)
+        && left.Token.Equals(right.Token)
+        && left.Proxy.Equals(right.Proxy)
+        && left.VerifySsl.Equals(right.VerifySsl)
+        && left.AllowUnsafeTlsWithoutCertificateValidation.Equals(right.AllowUnsafeTlsWithoutCertificateValidation)
+        && left.BattlelogEnrichment.Equals(right.BattlelogEnrichment)
+        && left.FleetRuntimeMode.Equals(right.FleetRuntimeMode)
+        && left.DataOverrides.Count == right.DataOverrides.Count
+        && left.DataOverrides.All(item => right.DataOverrides.TryGetValue(item.Key, out var value) && value.Equals(item.Value));
+
+    private static string TargetRoot(SyncTargetDraft target) =>
+        target.Kind == SyncTargetKind.LocalSidecar
+            ? "sidecar.sync"
+            : $"sync.targets.{target.Name}";
+
+    private static string Mode(SyncTargetKind kind) =>
+        kind == SyncTargetKind.MajelIngest ? "majel" : "legacy";
+
+    private static string Render(bool value) => value ? "true" : "false";
+
+    private static SyncTopologyPersistencePlan Invalid(string code, string message) =>
+        new(false, [], [Error(code, null, null, message)]);
+
+    private static SyncTopologyDiagnostic Error(string code, string? targetName, string? field, string message) =>
+        new(code, SyncTopologyDiagnosticSeverity.Error, message, targetName, field);
+}
+
+public sealed record SyncTopologyPersistenceCommitResult(
+    AtomicTomlWriteState State,
+    ConfigurationDocumentSnapshot? Snapshot = null,
+    SyncTopologyPersistencePlan? Plan = null,
+    string? BackupPath = null,
+    SparseTomlError? ValidationError = null,
+    string? Error = null);
+
+public sealed class SyncTopologyPersistenceWorkspace
+{
+    private readonly AtomicTomlStore store;
+    private SyncTopologyTomlLoadResult baseline;
+    private ConfigurationDocumentSnapshot snapshot;
+    private IReadOnlyDictionary<string, string> renames = new ReadOnlyDictionary<string, string>(
+        new Dictionary<string, string>(StringComparer.Ordinal));
+    private IReadOnlyDictionary<string, SyncTargetKindChangePolicy> kindChangeDecisions =
+        new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+
+    private SyncTopologyPersistenceWorkspace(
+        ConfigurationDocumentSnapshot snapshot,
+        SyncTopologyTomlLoadResult baseline,
+        AtomicTomlStore store)
+    {
+        this.snapshot = snapshot;
+        this.baseline = baseline;
+        this.store = store;
+        Desired = baseline.Topology!;
+    }
+
+    public SyncDesiredTopology Desired { get; private set; }
+
+    public bool HasPendingChanges { get; private set; }
+
+    public bool IsStale { get; private set; }
+
+    public ConfigurationDocumentRevision BaselineRevision => snapshot.Revision;
+
+    public static SyncTopologyTomlLoadResult Load(
+        ConfigurationDocumentSnapshot snapshot,
+        out SyncTopologyPersistenceWorkspace? workspace,
+        AtomicTomlStore? store = null)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        var load = SyncTopologyTomlAdapter.Load(snapshot.Contents);
+        workspace = load.IsValid && load.Topology is not null
+            ? new(snapshot, load, store ?? new AtomicTomlStore())
+            : null;
+        return load;
+    }
+
+    public void Stage(
+        SyncDesiredTopology desired,
+        IReadOnlyDictionary<string, string>? targetRenames = null,
+        IReadOnlyDictionary<string, SyncTargetKindChangePolicy>? targetKindChangeDecisions = null)
+    {
+        Desired = desired ?? throw new ArgumentNullException(nameof(desired));
+        renames = new ReadOnlyDictionary<string, string>(
+            targetRenames?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, string>(StringComparer.Ordinal));
+        kindChangeDecisions = new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            targetKindChangeDecisions?.ToDictionary(item => item.Key, item => item.Value, StringComparer.Ordinal)
+            ?? new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+        var plan = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            Desired,
+            renames,
+            kindChangeDecisions);
+        HasPendingChanges = !plan.IsValid || plan.Mutations.Count > 0;
+    }
+
+    public void Discard()
+    {
+        Desired = baseline.Topology!;
+        renames = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.Ordinal));
+        kindChangeDecisions = new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+        HasPendingChanges = false;
+    }
+
+    public async Task<SyncTopologyPersistenceCommitResult> CommitAsync(
+        bool migrateLegacyRoot = false,
+        CancellationToken cancellationToken = default)
+    {
+        var plan = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            Desired,
+            renames,
+            kindChangeDecisions,
+            migrateLegacyRoot);
+        if (!plan.IsValid)
+        {
+            return new(AtomicTomlWriteState.Invalid, Plan: plan);
+        }
+
+        var edit = plan.Apply(snapshot.Contents);
+        if (!edit.IsValid || edit.Contents is null)
+        {
+            return new(AtomicTomlWriteState.Invalid, Plan: plan, ValidationError: edit.Error);
+        }
+
+        var write = await store.SaveDocumentAsync(
+            snapshot.Path,
+            snapshot.Contents,
+            edit.Contents,
+            cancellationToken).ConfigureAwait(false);
+        if (!write.IsSuccess)
+        {
+            if (write.State == AtomicTomlWriteState.Conflict)
+            {
+                IsStale = true;
+            }
+
+            return new(
+                write.State,
+                Plan: plan,
+                BackupPath: write.BackupPath,
+                ValidationError: write.ValidationError,
+                Error: write.Error);
+        }
+
+        snapshot = new ConfigurationDocumentSnapshot(snapshot.Path, edit.Contents);
+        baseline = SyncTopologyTomlAdapter.Load(edit.Contents);
+        Desired = baseline.Topology!;
+        renames = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(StringComparer.Ordinal));
+        kindChangeDecisions = new ReadOnlyDictionary<string, SyncTargetKindChangePolicy>(
+            new Dictionary<string, SyncTargetKindChangePolicy>(StringComparer.Ordinal));
+        HasPendingChanges = false;
+        IsStale = false;
+        return new(write.State, snapshot, plan, write.BackupPath);
+    }
+}

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyTomlAdapter.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyTomlAdapter.cs
@@ -1,0 +1,370 @@
+using System.Collections.ObjectModel;
+
+namespace STFCCommunityMod.Launcher.Core;
+
+public sealed record SyncTopologyTomlLoadResult(
+    bool IsValid,
+    SyncDesiredTopology? Topology,
+    IReadOnlyList<SyncTopologyDiagnostic> Diagnostics,
+    bool HasLegacyRootTarget,
+    SparseTomlError? Error = null);
+
+public static class SyncTopologyTomlAdapter
+{
+    private static readonly ReadOnlyDictionary<SyncDataKind, string> DataKindKeys =
+        new(
+            new Dictionary<SyncDataKind, string>
+            {
+                [SyncDataKind.Battlelogs] = "battlelogs",
+                [SyncDataKind.BattlelogsRealtime] = "battlelogs_realtime",
+                [SyncDataKind.Buffs] = "buffs",
+                [SyncDataKind.Buildings] = "buildings",
+                [SyncDataKind.Inventory] = "inventory",
+                [SyncDataKind.Jobs] = "jobs",
+                [SyncDataKind.Missions] = "missions",
+                [SyncDataKind.Officer] = "officer",
+                [SyncDataKind.Research] = "research",
+                [SyncDataKind.Resources] = "resources",
+                [SyncDataKind.Ships] = "ships",
+                [SyncDataKind.Slots] = "slots",
+                [SyncDataKind.Tech] = "tech",
+                [SyncDataKind.Traits] = "traits",
+                [SyncDataKind.FleetRuntime] = "fleet_runtime",
+            });
+
+    public static SyncGlobalDefaults NativeGlobalDefaults { get; } =
+        new SyncGlobalDefaults(
+            string.Empty,
+            true,
+            false,
+            new Dictionary<SyncDataKind, bool>
+            {
+                [SyncDataKind.Battlelogs] = true,
+                [SyncDataKind.BattlelogsRealtime] = false,
+                [SyncDataKind.Buffs] = true,
+                [SyncDataKind.Buildings] = true,
+                [SyncDataKind.FleetRuntime] = false,
+                [SyncDataKind.Inventory] = true,
+                [SyncDataKind.Jobs] = true,
+                [SyncDataKind.Missions] = true,
+                [SyncDataKind.Officer] = true,
+                [SyncDataKind.Research] = true,
+                [SyncDataKind.Resources] = true,
+                [SyncDataKind.Ships] = true,
+                [SyncDataKind.Slots] = true,
+                [SyncDataKind.Tech] = true,
+                [SyncDataKind.Traits] = true,
+            });
+
+    public static IReadOnlyDictionary<SyncDataKind, string> DataKeys => DataKindKeys;
+
+    public static SyncTopologyTomlLoadResult Load(
+        byte[] contents,
+        SyncGlobalDefaults? nativeDefaults = null)
+    {
+        ArgumentNullException.ThrowIfNull(contents);
+        var load = SparseTomlDocument.Load(contents, out var document);
+        if (!load.IsValid || document is null)
+        {
+            return Invalid(load.Error);
+        }
+
+        var read = document.ReadOverrides();
+        if (!read.IsValid || read.Overrides is null)
+        {
+            return Invalid(read.Error);
+        }
+
+        var diagnostics = new List<SyncTopologyDiagnostic>();
+        var overrides = read.Overrides;
+        var globals = ReadGlobals(overrides, nativeDefaults ?? NativeGlobalDefaults, diagnostics);
+        var targets = new Dictionary<string, SyncTargetDraft>(StringComparer.Ordinal);
+
+        ReadSidecar(overrides, targets, diagnostics);
+        ReadExternalTargets(overrides, read.Tables ?? [], targets, diagnostics);
+        var hasLegacyRootTarget = ReadLegacyRootTarget(overrides, targets, diagnostics);
+
+        return new(
+            true,
+            new SyncDesiredTopology(globals, targets),
+            diagnostics.AsReadOnly(),
+            hasLegacyRootTarget);
+    }
+
+    internal static string DataKey(SyncDataKind kind) => DataKindKeys[kind];
+
+    private static SyncGlobalDefaults ReadGlobals(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        SyncGlobalDefaults defaults,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var proxy = ReadString(overrides, "sync.proxy", defaults.Proxy, diagnostics, null);
+        var verifySsl = ReadBoolean(overrides, "sync.verify_ssl", defaults.VerifySsl, diagnostics, null);
+        var unsafeTls = ReadBoolean(
+            overrides,
+            "sync.allow_unsafe_tls_without_certificate_validation",
+            defaults.AllowUnsafeTlsWithoutCertificateValidation,
+            diagnostics,
+            null);
+        var dataKinds = defaults.DataKinds.ToDictionary(item => item.Key, item => item.Value);
+        foreach (var (kind, key) in DataKindKeys)
+        {
+            dataKinds[kind] = ReadBoolean(overrides, $"sync.{key}", dataKinds[kind], diagnostics, null);
+        }
+
+        return new(proxy, verifySsl, unsafeTls, dataKinds);
+    }
+
+    private static void ReadSidecar(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        Dictionary<string, SyncTargetDraft> targets,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        const string prefix = "sidecar.sync.";
+        if (!overrides.Keys.Any(path => path.StartsWith(prefix, StringComparison.Ordinal)))
+        {
+            return;
+        }
+
+        var target = SyncTargetDraft.Create(
+            SyncDesiredTopology.LocalSidecarIdentity,
+            SyncTargetKind.LocalSidecar);
+        var url = ReadString(overrides, prefix + "url", target.Url, diagnostics, target.Name);
+        var token = ReadSecret(overrides, prefix + "token", diagnostics, target.Name);
+        target = target
+            .WithEnabled(ReadBoolean(overrides, prefix + "enabled", false, diagnostics, target.Name))
+            .WithConnection(url, token)
+            .WithProxy(ReadStringOverride(overrides, prefix + "proxy", diagnostics, target.Name))
+            .WithVerifySsl(ReadBooleanOverride(overrides, prefix + "verify_ssl", diagnostics, target.Name))
+            .WithUnsafeTls(ReadBooleanOverride(
+                overrides,
+                prefix + "allow_unsafe_tls_without_certificate_validation",
+                diagnostics,
+                target.Name))
+            .WithDataOverride(
+                SyncDataKind.BattlelogsRealtime,
+                ReadBooleanOverride(overrides, prefix + "battlelogs_realtime", diagnostics, target.Name))
+            .WithDataOverride(
+                SyncDataKind.FleetRuntime,
+                ReadBooleanOverride(overrides, prefix + "fleet_runtime", diagnostics, target.Name))
+            .WithBattlelogEnrichment(
+                ReadBooleanOverride(overrides, prefix + "battlelog_enrichment", diagnostics, target.Name))
+            .WithFleetRuntimeMode(
+                ReadStringOverride(overrides, prefix + "fleet_runtime_mode", diagnostics, target.Name));
+        targets.Add(target.Name, target);
+    }
+
+    private static void ReadExternalTargets(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        IReadOnlyList<SparseTomlTable> tables,
+        Dictionary<string, SyncTargetDraft> targets,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var names = overrides.Keys
+            .Where(path => path.StartsWith("sync.targets.", StringComparison.Ordinal))
+            .Select(path => path.Split('.'))
+            .Where(parts => parts.Length >= 4)
+            .Select(parts => parts[2])
+            .Concat(
+                tables
+                    .Select(table => table.CanonicalPath.Split('.'))
+                    .Where(parts => parts.Length >= 3
+                        && parts[0] == "sync"
+                        && parts[1] == "targets")
+                    .Select(parts => parts[2]))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal);
+        foreach (var name in names)
+        {
+            var prefix = $"sync.targets.{name}.";
+            var mode = ReadString(overrides, prefix + "mode", "legacy", diagnostics, name);
+            var kind = mode switch
+            {
+                "majel" => SyncTargetKind.MajelIngest,
+                "legacy" or "" => SyncTargetKind.LegacyCommunity,
+                _ => SyncTargetKind.LegacyCommunity,
+            };
+            if (mode == "sidecar_broker")
+            {
+                diagnostics.Add(new(
+                    "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID",
+                    SyncTopologyDiagnosticSeverity.Error,
+                    "Sidecar broker mode is invalid under external sync targets; use the local Sidecar target.",
+                    name,
+                    "mode"));
+            }
+            else if (mode is not ("legacy" or "majel" or ""))
+            {
+                diagnostics.Add(new(
+                    "SYNC_TARGET_MODE_INVALID",
+                    SyncTopologyDiagnosticSeverity.Warning,
+                    "The target mode is unknown and resolves as legacy until explicitly corrected.",
+                    name,
+                    "mode"));
+            }
+
+            var target = SyncTargetDraft.Create(name, kind)
+                .WithEnabled(true)
+                .WithConnection(
+                    ReadString(overrides, prefix + "url", string.Empty, diagnostics, name),
+                    ReadSecret(overrides, prefix + "token", diagnostics, name))
+                .WithProxy(ReadStringOverride(overrides, prefix + "proxy", diagnostics, name))
+                .WithVerifySsl(ReadBooleanOverride(overrides, prefix + "verify_ssl", diagnostics, name))
+                .WithUnsafeTls(ReadBooleanOverride(
+                    overrides,
+                    prefix + "allow_unsafe_tls_without_certificate_validation",
+                    diagnostics,
+                    name));
+            foreach (var (dataKind, key) in DataKindKeys)
+            {
+                target = target.WithDataOverride(
+                    dataKind,
+                    ReadBooleanOverride(overrides, prefix + key, diagnostics, name));
+            }
+
+            targets[name] = target;
+        }
+    }
+
+    private static bool ReadLegacyRootTarget(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        Dictionary<string, SyncTargetDraft> targets,
+        List<SyncTopologyDiagnostic> diagnostics)
+    {
+        var hasUrl = TryReadString(overrides, "sync.url", out var url, diagnostics, null);
+        var hasToken = TryReadString(overrides, "sync.token", out var token, diagnostics, null);
+        if (!hasUrl && !hasToken)
+        {
+            return false;
+        }
+
+        if (!hasUrl || !hasToken || string.IsNullOrEmpty(url) || string.IsNullOrEmpty(token))
+        {
+            diagnostics.Add(new(
+                "SYNC_LEGACY_ROOT_INCOMPLETE",
+                SyncTopologyDiagnosticSeverity.Warning,
+                "Legacy root sync credentials are incomplete and do not create a target."));
+            return false;
+        }
+
+        if (targets.ContainsKey("default"))
+        {
+            diagnostics.Add(new(
+                "SYNC_LEGACY_ROOT_CONFLICT",
+                SyncTopologyDiagnosticSeverity.Error,
+                "Legacy root credentials conflict with the named default target.",
+                "default"));
+            return false;
+        }
+
+        var target = SyncTargetDraft.Create("default", SyncTargetKind.LegacyCommunity)
+            .WithEnabled(true)
+            .WithConnection(url, SyncSecret.FromPlainText(token));
+        targets.Add(target.Name, target);
+        diagnostics.Add(new(
+            "SYNC_LEGACY_ROOT_CONVERTED",
+            SyncTopologyDiagnosticSeverity.Info,
+            "Legacy root credentials are represented as a virtual default target without changing the source.",
+            "default"));
+        return true;
+    }
+
+    private static SyncOverride<string> ReadStringOverride(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadString(overrides, path, out var value, diagnostics, targetName)
+            ? SyncOverride.Explicit(value)
+            : SyncOverride.Inherited<string>();
+
+    private static SyncOverride<bool> ReadBooleanOverride(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadBoolean(overrides, path, out var value, diagnostics, targetName)
+            ? SyncOverride.Explicit(value)
+            : SyncOverride.Inherited<bool>();
+
+    private static SyncSecret ReadSecret(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string targetName) =>
+        TryReadString(overrides, path, out var value, diagnostics, targetName)
+            ? SyncSecret.FromPlainText(value)
+            : SyncSecret.Missing;
+
+    private static string ReadString(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        string fallback,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadString(overrides, path, out var value, diagnostics, targetName) ? value : fallback;
+
+    private static bool ReadBoolean(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        bool fallback,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName) =>
+        TryReadBoolean(overrides, path, out var value, diagnostics, targetName) ? value : fallback;
+
+    private static bool TryReadString(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        out string value,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName)
+    {
+        value = string.Empty;
+        if (!overrides.TryGetValue(path, out var configured))
+        {
+            return false;
+        }
+
+        if (LauncherTomlValue.TryReadString(configured.RenderedValue, out value))
+        {
+            return true;
+        }
+
+        diagnostics.Add(InvalidValue(path, configured.LineNumber, targetName));
+        return false;
+    }
+
+    private static bool TryReadBoolean(
+        IReadOnlyDictionary<string, SparseTomlOverride> overrides,
+        string path,
+        out bool value,
+        List<SyncTopologyDiagnostic> diagnostics,
+        string? targetName)
+    {
+        value = false;
+        if (!overrides.TryGetValue(path, out var configured))
+        {
+            return false;
+        }
+
+        if (configured.RenderedValue is "true" or "false")
+        {
+            value = configured.RenderedValue == "true";
+            return true;
+        }
+
+        diagnostics.Add(InvalidValue(path, configured.LineNumber, targetName));
+        return false;
+    }
+
+    private static SyncTopologyDiagnostic InvalidValue(string path, int lineNumber, string? targetName) =>
+        new(
+            "SYNC_TOML_VALUE_INVALID",
+            SyncTopologyDiagnosticSeverity.Error,
+            $"'{path}' has an invalid value at line {lineNumber}.",
+            targetName,
+            path[(path.LastIndexOf('.') + 1)..]);
+
+    private static SyncTopologyTomlLoadResult Invalid(SparseTomlError? error) =>
+        new(false, null, [], false, error);
+}

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SparseTomlDocumentTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SparseTomlDocumentTests.cs
@@ -231,6 +231,9 @@ public sealed class SparseTomlDocumentTests
             """{ system = true, audio = true, sound = "alarm" }""",
             result.Overrides["notifications.incoming_attack_player"].RenderedValue);
         Assert.AreEqual(4, result.Overrides["notifications.incoming_attack_player"].LineNumber);
+        Assert.AreEqual(1, result.Tables?.Count);
+        Assert.AreEqual("notifications", result.Tables![0].CanonicalPath);
+        Assert.AreEqual(3, result.Tables[0].LineNumber);
     }
 
     [TestMethod]
@@ -248,6 +251,108 @@ public sealed class SparseTomlDocumentTests
         Assert.AreEqual(2, result.Overrides?.Count);
         Assert.AreEqual("1", result.Overrides!["FutureKey"].RenderedValue);
         Assert.AreEqual("2", result.Overrides["futurekey"].RenderedValue);
+    }
+
+    [TestMethod]
+    public void RenameTablePreservesBodyUnknownFieldsCommentsAndChildTables()
+    {
+        const string source = """
+            # target heading stays outside the table body
+            [sync.targets.old] # provider note
+            url = "https://example.invalid/sync"
+            future = "keep"
+
+            [sync.targets.old.metadata]
+            label = "keep child"
+
+            [unrelated]
+            value = true
+            """;
+        var document = Load(source);
+
+        var result = document.RenameTable("sync.targets.old", "sync.targets.renamed");
+
+        Assert.IsTrue(result.IsValid, result.Error?.Message);
+        Assert.IsTrue(result.Changed);
+        Assert.AreEqual(
+            source
+                .Replace("[sync.targets.old]", "[sync.targets.renamed]", StringComparison.Ordinal)
+                .Replace("[sync.targets.old.metadata]", "[sync.targets.renamed.metadata]", StringComparison.Ordinal),
+            Decode(result.Contents!));
+    }
+
+    [TestMethod]
+    public void RenameTableRejectsDestinationAndDottedAssignmentCollisions()
+    {
+        var destination = Load(
+            """
+            [sync.targets.old]
+            value = true
+            [sync.targets.new]
+            value = false
+            """);
+        var destinationResult = destination.RenameTable("sync.targets.old", "sync.targets.new");
+        Assert.IsFalse(destinationResult.IsValid);
+        Assert.AreEqual(SparseTomlErrorCode.DuplicateTarget, destinationResult.Error?.Code);
+        Assert.IsNull(destinationResult.Contents);
+
+        var dotted = Load(
+            """
+            sync.targets.new.value = false
+            [sync.targets.old]
+            value = true
+            """);
+        var dottedResult = dotted.RenameTable("sync.targets.old", "sync.targets.new");
+        Assert.IsFalse(dottedResult.IsValid);
+        Assert.AreEqual(SparseTomlErrorCode.UnsupportedTarget, dottedResult.Error?.Code);
+        Assert.IsNull(dottedResult.Contents);
+    }
+
+    [TestMethod]
+    public void RemoveTableRemovesItsDescendantsAndPreservesUnrelatedTables()
+    {
+        const string source = """
+            [sync.targets.remove]
+            url = "https://example.invalid/sync"
+            unknown = "remove with owner"
+
+            [unrelated]
+            value = true
+
+            [sync.targets.remove.metadata]
+            label = "also remove"
+
+            [sync.targets.keep]
+            url = "https://keep.example.invalid/sync"
+            """;
+        var document = Load(source);
+
+        var result = document.RemoveTable("sync.targets.remove");
+
+        Assert.IsTrue(result.IsValid, result.Error?.Message);
+        var updated = Decode(result.Contents!);
+        Assert.IsFalse(updated.Contains("sync.targets.remove", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("unknown", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "[unrelated]");
+        StringAssert.Contains(updated, "[sync.targets.keep]");
+    }
+
+    [TestMethod]
+    public void TableOperationsPreserveBomAndCrLf()
+    {
+        const string source = "[sync.targets.old]\r\nurl = \"https://example.invalid\"\r\n";
+        var contents = new byte[] { 0xef, 0xbb, 0xbf }
+            .Concat(Encoding.UTF8.GetBytes(source))
+            .ToArray();
+        var document = Load(contents);
+
+        var result = document.RenameTable("sync.targets.old", "sync.targets.new");
+
+        CollectionAssert.AreEqual(
+            new byte[] { 0xef, 0xbb, 0xbf }
+                .Concat(Encoding.UTF8.GetBytes(source.Replace("old", "new", StringComparison.Ordinal)))
+                .ToArray(),
+            result.Contents!);
     }
 
     private static SparseTomlDocument Load(string source) =>

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncDesiredTopologyTests.cs
@@ -193,6 +193,33 @@ public sealed class SyncDesiredTopologyTests
     }
 
     [TestMethod]
+    public void KindChangeResetPolicyClearsTargetOverridesButKeepsConnection()
+    {
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync",
+            target => target
+                .WithProxy(SyncOverride.Explicit("target-proxy"))
+                .WithDataOverride(SyncDataKind.Jobs, SyncOverride.Explicit(false)));
+        var original = topology.Targets["community"];
+
+        topology = RequireSuccess(
+            topology.ChangeTargetKind(
+                "community",
+                SyncTargetKind.MajelIngest,
+                SyncTargetKindChangePolicy.ResetOverrides));
+        var changed = topology.Targets["community"];
+
+        Assert.AreEqual(SyncTargetKind.MajelIngest, changed.Kind);
+        Assert.AreEqual(original.Url, changed.Url);
+        Assert.AreEqual(original.Token, changed.Token);
+        Assert.IsFalse(changed.Proxy.IsExplicit);
+        Assert.AreEqual(0, changed.DataOverrides.Count);
+    }
+
+    [TestMethod]
     public void SidecarCardinalityIdentityAndDuplicationAreGuarded()
     {
         var topology = RequireSuccess(
@@ -243,10 +270,22 @@ public sealed class SyncDesiredTopologyTests
                 "external",
                 target => target.WithConnection(
                     "http://127.0.0.1:43127/api/sidecar/ingest",
-                    SyncSecret.FromPlainText("hidden-value"))));
+                    SyncSecret.FromPlainText("hidden-value")).WithEnabled(true)));
         var externalResolved = external.Resolve();
         Assert.IsFalse(externalResolved.IsCommittable);
         Assert.IsTrue(externalResolved.Diagnostics.Any(item => item.Code == "SYNC_LOOPBACK_TARGET_INVALID"));
+
+        var embeddedCredentials = RequireSuccess(
+            SyncDesiredTopology.Empty.AddTarget("embedded", SyncTargetKind.LegacyCommunity));
+        embeddedCredentials = RequireSuccess(
+            embeddedCredentials.UpdateTarget(
+                "embedded",
+                target => target.WithConnection(
+                    "https://username:password@community.example.invalid/sync",
+                    SyncSecret.FromPlainText("hidden-value")).WithEnabled(true)));
+        Assert.IsTrue(
+            embeddedCredentials.Resolve().Diagnostics.Any(
+                item => item.Code == "SYNC_ENDPOINT_EMBEDDED_CREDENTIALS"));
 
         var missing = RequireSuccess(
             SyncDesiredTopology.Empty.AddTarget("missing", SyncTargetKind.MajelIngest));
@@ -255,7 +294,7 @@ public sealed class SyncDesiredTopologyTests
                 "missing",
                 target => target.WithConnection(
                     "https://majel.example.invalid/api/ingest/events",
-                    SyncSecret.Missing)));
+                    SyncSecret.Missing).WithEnabled(true)));
         Assert.IsTrue(missing.Resolve().Diagnostics.Any(item => item.Code == "SYNC_CREDENTIALS_INCOMPLETE"));
 
         var sidecar = RequireSuccess(
@@ -265,7 +304,7 @@ public sealed class SyncDesiredTopologyTests
                 SyncDesiredTopology.LocalSidecarIdentity,
                 target => target.WithConnection(
                     "https://sidecar.example.invalid/ingest",
-                    SyncSecret.FromPlainText("hidden-value"))));
+                    SyncSecret.FromPlainText("hidden-value")).WithEnabled(true)));
         Assert.IsTrue(sidecar.Resolve().Diagnostics.Any(item => item.Code == "SYNC_SIDECAR_ENDPOINT_NOT_LOOPBACK"));
     }
 
@@ -326,12 +365,30 @@ public sealed class SyncDesiredTopologyTests
         topology = RequireSuccess(
             topology.UpdateTarget(
                 "external",
-                target => target.WithConnection("not-a-url", secret)));
+                target => target.WithConnection("not-a-url", secret).WithEnabled(true)));
 
         var diagnostics = topology.Resolve().Diagnostics;
         Assert.IsTrue(diagnostics.Count > 0);
         Assert.IsFalse(diagnostics.Any(item => item.Message.Contains(secretValue, StringComparison.Ordinal)));
         Assert.IsFalse(diagnostics.Any(item => item.ToString().Contains(secretValue, StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void ProxyUserInfoDoesNotAppearInDomainDisplayStrings()
+    {
+        const string proxy = "http://proxy-user:proxy-password@example.invalid:8080";
+        var topology = AddConfigured(
+            SyncDesiredTopology.Empty,
+            "community",
+            SyncTargetKind.LegacyCommunity,
+            "https://community.example.invalid/sync",
+            target => target.WithProxy(SyncOverride.Explicit(proxy)));
+        var draft = topology.Targets["community"];
+        var resolved = topology.Resolve().Targets.Single();
+
+        Assert.IsFalse(draft.Proxy.ToString().Contains("proxy-password", StringComparison.Ordinal));
+        Assert.IsFalse(resolved.Proxy.ToString().Contains("proxy-password", StringComparison.Ordinal));
+        Assert.IsFalse(resolved.ToString().Contains("proxy-password", StringComparison.Ordinal));
     }
 
     [TestMethod]

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTopologyPersistenceTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Core.Tests/SyncTopologyPersistenceTests.cs
@@ -1,0 +1,536 @@
+using System.Text;
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.Core.Tests;
+
+[TestClass]
+public sealed class SyncTopologyPersistenceTests
+{
+    [TestMethod]
+    public void LockedCorpusLoadsWithoutChangingAnySourceBytes()
+    {
+        var corpusDirectory = Path.GetDirectoryName(
+            FindRepositoryFile("docs", "windows-launcher", "sync-target-corpus", "cases.json"))!;
+        foreach (var path in Directory.GetFiles(corpusDirectory, "*.toml"))
+        {
+            var contents = File.ReadAllBytes(path);
+
+            var load = SyncTopologyTomlAdapter.Load(contents);
+            var sparseLoad = SparseTomlDocument.Load(contents, out var document);
+            var validation = document!.ValidateForMutation();
+
+            Assert.IsTrue(load.IsValid, Path.GetFileName(path));
+            Assert.IsNotNull(load.Topology, Path.GetFileName(path));
+            Assert.IsTrue(sparseLoad.IsValid, Path.GetFileName(path));
+            Assert.IsFalse(validation.Changed, Path.GetFileName(path));
+            CollectionAssert.AreEqual(contents, validation.Contents, Path.GetFileName(path));
+        }
+    }
+
+    [TestMethod]
+    public void AdapterNativeDefaultsMatchTheGeneratedRuntimeSchema()
+    {
+        var catalog = LauncherConfigurationSchemaLoader.LoadFile(
+            FindRepositoryFile("docs", "windows-launcher", "config-schema.guffawaffle.v1.json"));
+        var defaults = SyncTopologyTomlAdapter.NativeGlobalDefaults;
+
+        Assert.AreEqual(
+            defaults.Proxy,
+            catalog.Settings.Single(item => item.Path == "sync.proxy").DefaultValue.GetString());
+        Assert.AreEqual(
+            defaults.VerifySsl,
+            catalog.Settings.Single(item => item.Path == "sync.verify_ssl").DefaultValue.GetBoolean());
+        Assert.AreEqual(
+            defaults.AllowUnsafeTlsWithoutCertificateValidation,
+            catalog.Settings.Single(
+                item => item.Path == "sync.allow_unsafe_tls_without_certificate_validation").DefaultValue.GetBoolean());
+        foreach (var (kind, key) in SyncTopologyTomlAdapter.DataKeys)
+        {
+            Assert.AreEqual(
+                defaults.DataKinds[kind],
+                catalog.Settings.Single(item => item.Path == $"sync.{key}").DefaultValue.GetBoolean(),
+                key);
+        }
+    }
+
+    [TestMethod]
+    public void AdapterPreservesExplicitFalseEmptyAndInheritedResolution()
+    {
+        var load = Load(
+            """
+            [sync]
+            proxy = "http://proxy.example.invalid:8080"
+            battlelogs = true
+
+            [sync.targets.direct]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            proxy = ""
+            battlelogs = false
+            """);
+
+        var target = load.Topology!.Targets["direct"];
+        Assert.AreEqual(SyncOverride.Explicit(string.Empty), target.Proxy);
+        Assert.AreEqual(SyncOverride.Explicit(false), target.DataOverrides[SyncDataKind.Battlelogs]);
+        var resolved = load.Topology.Resolve().Targets.Single();
+        Assert.AreEqual(SyncValueProvenance.ExplicitEmpty, resolved.Proxy.Provenance);
+        Assert.AreEqual(SyncValueProvenance.ExplicitFalse, resolved.DataKinds[SyncDataKind.Battlelogs].Provenance);
+    }
+
+    [TestMethod]
+    public void SidecarBrokerModeIsABlockingExternalTargetDiagnostic()
+    {
+        var load = Load(
+            """
+            [sync.targets.external]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "sidecar_broker"
+            """);
+
+        var plan = SyncTopologyPersistencePlanner.Build(load, load.Topology!);
+
+        Assert.IsFalse(plan.IsValid);
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_TARGET_SIDECAR_NAMESPACE_INVALID"));
+    }
+
+    [TestMethod]
+    public void EmptyTargetTableIsDiscoveredAndRejectedAsMalformed()
+    {
+        var load = Load(
+            """
+            [sync.targets.empty]
+            # An explicitly declared target cannot disappear merely because it has no assignments.
+            """);
+
+        Assert.IsTrue(load.Topology!.Targets.ContainsKey("empty"));
+        var plan = SyncTopologyPersistencePlanner.Build(load, load.Topology);
+        Assert.IsFalse(plan.IsValid);
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_ENDPOINT_INVALID"));
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_CREDENTIALS_INCOMPLETE"));
+    }
+
+    [TestMethod]
+    public void ClearingOverridesRemovesOnlyOwnedAssignments()
+    {
+        const string source = """
+            [sync]
+            proxy = "http://proxy.example.invalid:8080"
+            battlelogs = true
+
+            [sync.targets.direct]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            proxy = ""
+            battlelogs = false
+            future = "preserve" # unknown ownership
+            """;
+        var baseline = Load(source);
+        var desired = RequireSuccess(
+            baseline.Topology!.UpdateTarget(
+                "direct",
+                target => target
+                    .WithProxy(SyncOverride.Inherited<string>())
+                    .WithDataOverride(SyncDataKind.Battlelogs, SyncOverride.Inherited<bool>())));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var edit = plan.Apply(Encoding.UTF8.GetBytes(source));
+        var updated = Encoding.UTF8.GetString(edit.Contents!);
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.IsTrue(edit.IsValid, edit.Error?.Message);
+        Assert.IsFalse(updated.Contains("proxy = \"\"", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("battlelogs = false", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "proxy = \"http://proxy.example.invalid:8080\"");
+        StringAssert.Contains(updated, "battlelogs = true");
+        StringAssert.Contains(updated, "future = \"preserve\" # unknown ownership");
+    }
+
+    [TestMethod]
+    public void AddingTargetWritesExplicitModeAndKeepsSecretsOutOfPlanDisplay()
+    {
+        const string secret = "never-show-this-token";
+        var baseline = Load("# empty sync topology\n");
+        var desired = RequireSuccess(
+            baseline.Topology!.AddTarget("majel", SyncTargetKind.MajelIngest));
+        desired = RequireSuccess(
+            desired.UpdateTarget(
+                "majel",
+                target => target
+                    .WithConnection(
+                        "https://majel.example.invalid/api/ingest/events",
+                        SyncSecret.FromPlainText(secret))
+                    .WithEnabled(true)
+                    .WithDataOverride(SyncDataKind.BattlelogsRealtime, SyncOverride.Explicit(true))));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var display = string.Join('\n', plan.Mutations.Select(mutation => mutation.ToString()));
+        var edit = plan.Apply(Encoding.UTF8.GetBytes("# empty sync topology\n"));
+        var updated = Encoding.UTF8.GetString(edit.Contents!);
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.IsFalse(display.Contains(secret, StringComparison.Ordinal));
+        StringAssert.Contains(display, "[secret]");
+        StringAssert.Contains(updated, "[sync.targets.majel]");
+        StringAssert.Contains(updated, "mode = \"majel\"");
+        StringAssert.Contains(updated, "battlelogs_realtime = true");
+        StringAssert.Contains(updated, $"token = \"{secret}\"");
+    }
+
+    [TestMethod]
+    public void UnchangedSecretProducesNoSecretMutation()
+    {
+        var baseline = Load(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            """);
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, baseline.Topology!);
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.AreEqual(0, plan.Mutations.Count);
+    }
+
+    [TestMethod]
+    public void RenamePreservesUnknownTargetBodyAndComments()
+    {
+        const string source = """
+            # provider target
+            [sync.targets.old]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            future = "preserve" # exact comment
+            """;
+        var baseline = Load(source);
+        var desired = RequireSuccess(baseline.Topology!.RenameTarget("old", "renamed"));
+
+        var plan = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            desired,
+            new Dictionary<string, string> { ["old"] = "renamed" });
+        var edit = plan.Apply(Encoding.UTF8.GetBytes(source));
+        var updated = Encoding.UTF8.GetString(edit.Contents!);
+
+        Assert.IsTrue(plan.IsValid);
+        StringAssert.Contains(updated, "[sync.targets.renamed]");
+        Assert.IsFalse(updated.Contains("[sync.targets.old]", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "future = \"preserve\" # exact comment");
+    }
+
+    [TestMethod]
+    public void RemovingTargetRemovesWholeOwnedTableOnly()
+    {
+        const string source = """
+            [sync.targets.remove]
+            url = "https://remove.example.invalid/sync"
+            token = "fixture-remove"
+            unknown = "remove too"
+
+            [sync.targets.keep]
+            url = "https://keep.example.invalid/sync"
+            token = "fixture-keep"
+            unknown = "keep"
+            """;
+        var baseline = Load(source);
+        var desired = RequireSuccess(baseline.Topology!.RemoveTarget("remove"));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var updated = Encoding.UTF8.GetString(plan.Apply(Encoding.UTF8.GetBytes(source)).Contents!);
+
+        Assert.IsFalse(updated.Contains("sync.targets.remove", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("remove too", StringComparison.Ordinal));
+        StringAssert.Contains(updated, "[sync.targets.keep]");
+        StringAssert.Contains(updated, "unknown = \"keep\"");
+    }
+
+    [TestMethod]
+    public void LegacyRootIsVirtualUntilMigrationIsExplicitlyConfirmed()
+    {
+        const string source = """
+            [sync]
+            url = "https://legacy.example.invalid/sync"
+            token = "fixture-legacy"
+            battlelogs = true
+            """;
+        var baseline = Load(source);
+        Assert.IsTrue(baseline.HasLegacyRootTarget);
+        var desired = RequireSuccess(
+            baseline.Topology!.UpdateTarget(
+                "default",
+                target => target.WithDataOverride(SyncDataKind.Battlelogs, SyncOverride.Explicit(false))));
+
+        var blocked = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var migration = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            desired,
+            migrateLegacyRoot: true);
+        var updated = Encoding.UTF8.GetString(migration.Apply(Encoding.UTF8.GetBytes(source)).Contents!);
+
+        Assert.IsFalse(blocked.IsValid);
+        Assert.IsTrue(blocked.Diagnostics.Any(item => item.Code == "SYNC_LEGACY_MIGRATION_REQUIRED"));
+        Assert.IsTrue(migration.IsValid);
+        StringAssert.Contains(updated, "[sync.targets.default]");
+        StringAssert.Contains(updated, "battlelogs = false");
+        var migrated = Load(updated);
+        var sparseLoad = SparseTomlDocument.Load(Encoding.UTF8.GetBytes(updated), out var document);
+        var overrides = document!.ReadOverrides();
+        Assert.IsTrue(sparseLoad.IsValid);
+        Assert.IsFalse(overrides.Overrides!.ContainsKey("sync.url"));
+        Assert.IsFalse(overrides.Overrides.ContainsKey("sync.token"));
+        Assert.IsTrue(overrides.Overrides.ContainsKey("sync.targets.default.url"));
+        Assert.IsFalse(migrated.HasLegacyRootTarget);
+    }
+
+    [TestMethod]
+    public void ExternalDisabledDraftRequiresAnExplicitPersistenceChoice()
+    {
+        var baseline = Load(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var desired = RequireSuccess(baseline.Topology!.SetTargetEnabled("community", false));
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+
+        Assert.IsFalse(plan.IsValid);
+        Assert.IsTrue(plan.Diagnostics.Any(item => item.Code == "SYNC_EXTERNAL_DISABLED_PERSISTENCE_REQUIRED"));
+    }
+
+    [TestMethod]
+    public void KindChangeRequiresExplicitCompatibleOrResetDecision()
+    {
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            proxy = "target-proxy"
+            jobs = false
+            """;
+        var baseline = Load(source);
+        var preserved = RequireSuccess(
+            baseline.Topology!.ChangeTargetKind("community", SyncTargetKind.MajelIngest));
+        var reset = RequireSuccess(
+            baseline.Topology.ChangeTargetKind(
+                "community",
+                SyncTargetKind.MajelIngest,
+                SyncTargetKindChangePolicy.ResetOverrides));
+
+        var missingDecision = SyncTopologyPersistencePlanner.Build(baseline, preserved);
+        var mismatchedReset = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            preserved,
+            kindChangeDecisions: new Dictionary<string, SyncTargetKindChangePolicy>
+            {
+                ["community"] = SyncTargetKindChangePolicy.ResetOverrides,
+            });
+        var validReset = SyncTopologyPersistencePlanner.Build(
+            baseline,
+            reset,
+            kindChangeDecisions: new Dictionary<string, SyncTargetKindChangePolicy>
+            {
+                ["community"] = SyncTargetKindChangePolicy.ResetOverrides,
+            });
+        var updated = Encoding.UTF8.GetString(validReset.Apply(Encoding.UTF8.GetBytes(source)).Contents!);
+
+        Assert.IsFalse(missingDecision.IsValid);
+        Assert.IsTrue(missingDecision.Diagnostics.Any(item => item.Code == "SYNC_KIND_CHANGE_DECISION_REQUIRED"));
+        Assert.IsFalse(mismatchedReset.IsValid);
+        Assert.IsTrue(mismatchedReset.Diagnostics.Any(item => item.Code == "SYNC_KIND_CHANGE_RESET_MISMATCH"));
+        Assert.IsTrue(validReset.IsValid);
+        StringAssert.Contains(updated, "mode = \"majel\"");
+        Assert.IsFalse(updated.Contains("proxy =", StringComparison.Ordinal));
+        Assert.IsFalse(updated.Contains("jobs = false", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void PersistedEffectiveValuesMatchTheLauncherPreviewAfterReload()
+    {
+        const string source = """
+            [sync]
+            proxy = "global-proxy"
+            jobs = true
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            """;
+        var baseline = Load(source);
+        var desired = baseline.Topology!.WithGlobalDefaults(
+            baseline.Topology.GlobalDefaults.WithDataKind(SyncDataKind.Jobs, false));
+        desired = RequireSuccess(
+            desired.UpdateTarget(
+                "community",
+                target => target
+                    .WithProxy(SyncOverride.Explicit(string.Empty))
+                    .WithVerifySsl(SyncOverride.Explicit(false))
+                    .WithUnsafeTls(SyncOverride.Explicit(true))));
+        var preview = desired.Resolve().Targets.Single();
+
+        var plan = SyncTopologyPersistencePlanner.Build(baseline, desired);
+        var edit = plan.Apply(Encoding.UTF8.GetBytes(source));
+        var reloaded = SyncTopologyTomlAdapter.Load(edit.Contents!).Topology!.Resolve().Targets.Single();
+
+        Assert.IsTrue(plan.IsValid);
+        Assert.AreEqual(preview.Kind, reloaded.Kind);
+        Assert.AreEqual(preview.Url, reloaded.Url);
+        Assert.AreEqual(preview.CredentialsConfigured, reloaded.CredentialsConfigured);
+        Assert.AreEqual(preview.Proxy, reloaded.Proxy);
+        Assert.AreEqual(preview.VerifySsl, reloaded.VerifySsl);
+        Assert.AreEqual(
+            preview.AllowUnsafeTlsWithoutCertificateValidation,
+            reloaded.AllowUnsafeTlsWithoutCertificateValidation);
+        Assert.AreEqual(preview.DataKinds[SyncDataKind.Jobs], reloaded.DataKinds[SyncDataKind.Jobs]);
+    }
+
+    [TestMethod]
+    public async Task WorkspaceCommitUsesAtomicBackupAndDiscardRestoresBaseline()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var path = Path.Combine(temporaryDirectory.Path, "settings.toml");
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            mode = "legacy"
+            """;
+        await File.WriteAllTextAsync(path, source);
+        var snapshot = new ConfigurationDocumentSnapshot(path, Encoding.UTF8.GetBytes(source));
+        var load = SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+        Assert.IsTrue(load.IsValid, load.Error?.Message);
+
+        var staged = RequireSuccess(
+            workspace!.Desired.UpdateTarget(
+                "community",
+                target => target.WithProxy(SyncOverride.Explicit(string.Empty))));
+        workspace.Stage(staged);
+        Assert.IsTrue(workspace.HasPendingChanges);
+        workspace.Discard();
+        Assert.IsFalse(workspace.HasPendingChanges);
+        Assert.IsFalse(workspace.Desired.Targets["community"].Proxy.IsExplicit);
+
+        workspace.Stage(staged);
+        var result = await workspace.CommitAsync();
+
+        Assert.AreEqual(AtomicTomlWriteState.Succeeded, result.State, result.Error);
+        Assert.IsFalse(workspace.HasPendingChanges);
+        StringAssert.Contains(await File.ReadAllTextAsync(path), "proxy = \"\"");
+        Assert.AreEqual(source, await File.ReadAllTextAsync(path + ".bak"));
+    }
+
+    [TestMethod]
+    public async Task WorkspaceConflictPreservesExternalFileAndPendingDraft()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var path = Path.Combine(temporaryDirectory.Path, "settings.toml");
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """;
+        await File.WriteAllTextAsync(path, source);
+        var snapshot = new ConfigurationDocumentSnapshot(path, Encoding.UTF8.GetBytes(source));
+        SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+        var staged = RequireSuccess(
+            workspace!.Desired.UpdateTarget(
+                "community",
+                target => target.WithDataOverride(SyncDataKind.Jobs, SyncOverride.Explicit(false))));
+        workspace.Stage(staged);
+        const string external = "# external change\n" + source;
+        await File.WriteAllTextAsync(path, external);
+
+        var result = await workspace.CommitAsync();
+
+        Assert.AreEqual(AtomicTomlWriteState.Conflict, result.State);
+        Assert.IsTrue(workspace.IsStale);
+        Assert.IsTrue(workspace.HasPendingChanges);
+        Assert.AreEqual(external, await File.ReadAllTextAsync(path));
+        Assert.IsFalse(File.Exists(path + ".bak"));
+    }
+
+    [TestMethod]
+    public void WorkspaceSemanticNoOpDoesNotCreatePendingChanges()
+    {
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """;
+        var snapshot = new ConfigurationDocumentSnapshot(
+            "settings.toml",
+            Encoding.UTF8.GetBytes(source));
+        SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+
+        workspace!.Stage(workspace.Desired);
+
+        Assert.IsFalse(workspace.HasPendingChanges);
+    }
+
+    [TestMethod]
+    public async Task WorkspaceConflictRemainsStaleAcrossStageAndDiscard()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var path = Path.Combine(temporaryDirectory.Path, "settings.toml");
+        const string source = """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """;
+        await File.WriteAllTextAsync(path, source);
+        var snapshot = new ConfigurationDocumentSnapshot(path, Encoding.UTF8.GetBytes(source));
+        SyncTopologyPersistenceWorkspace.Load(snapshot, out var workspace);
+        var staged = RequireSuccess(
+            workspace!.Desired.UpdateTarget(
+                "community",
+                target => target.WithDataOverride(SyncDataKind.Jobs, SyncOverride.Explicit(false))));
+        workspace.Stage(staged);
+        await File.WriteAllTextAsync(path, "# external change\n" + source);
+        Assert.AreEqual(AtomicTomlWriteState.Conflict, (await workspace.CommitAsync()).State);
+
+        workspace.Stage(staged);
+        Assert.IsTrue(workspace.IsStale);
+        workspace.Discard();
+
+        Assert.IsTrue(workspace.IsStale);
+        Assert.IsFalse(workspace.HasPendingChanges);
+    }
+
+    private static SyncTopologyTomlLoadResult Load(string source)
+    {
+        var load = SyncTopologyTomlAdapter.Load(Encoding.UTF8.GetBytes(source));
+        Assert.IsTrue(load.IsValid, load.Error?.Message);
+        Assert.IsNotNull(load.Topology);
+        return load;
+    }
+
+    private static SyncDesiredTopology RequireSuccess(SyncTopologyTransitionResult result)
+    {
+        Assert.IsTrue(result.Succeeded, result.Diagnostic?.Message);
+        return result.Topology;
+    }
+
+    private static string FindRepositoryFile(params string[] relativeParts)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine([directory.FullName, .. relativeParts]);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail($"Could not find repository file '{Path.Combine(relativeParts)}'.");
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
Closes #225
Part of #221

## Summary
- load the locked sync-target TOML corpus into the desired topology without source mutation
- plan sparse global, target, Sidecar, rename, removal, kind-change, and explicitly gated legacy-migration operations
- preserve unknown TOML, formatting, line endings, BOM, explicit false/empty overrides, and unchanged secrets
- commit through the existing atomic store with exact-baseline conflict detection and stale-state behavior
- fail closed on malformed/empty targets, unsafe syntax, invalid target modes, embedded URL credentials, and ambiguous kind changes
- document the persistence and security boundary

## Validation
- `dotnet test windows-launcher/STFCCommunityMod.Launcher.sln -c Release --no-restore` — 266 passed
- `node scripts/test_config_schema.mjs` — 21 passed
- `node scripts/generate_config_schema.mjs --check` — current (333 settings)
- `dotnet format windows-launcher/STFCCommunityMod.Launcher.sln --verify-no-changes --no-restore`
- `git diff --check`
- Windows native release build passed during this slice; final changes after it are launcher-only C#/docs