### PR TITLE
Build and dogfood typed launcher Sync workspace

### DIFF
--- a/docs/windows-launcher/SYNC_WORKSPACE.md
+++ b/docs/windows-launcher/SYNC_WORKSPACE.md
@@ -1,0 +1,57 @@
+# Windows Launcher Sync Workspace
+
+This document records the LS-005 player surface and dogfood boundary for typed multi-target sync setup.
+
+## Player model
+
+The existing **Data Sync** settings destination now opens a dedicated workspace. It deliberately separates:
+
+- global proxy, TLS, and feed defaults;
+- concrete target instances and their wire contracts;
+- target-local inherited, explicit-on/value, explicit-off, and explicit-clear states;
+- Sidecar-only controls from external provider controls.
+
+The add surface supports the singleton local Sidecar, Majel, the Spocks Club preset, and custom community/legacy
+instances. External targets are enabled while present because the native contract has no canonical disabled field;
+removal is the explicit disable operation. Sidecar retains its native enabled switch.
+
+Each target card shows its stable identity, player-facing type, wire contract, validation state, effective enabled feeds,
+endpoint, opaque token state, proxy provenance, TLS overrides, and supported feed overrides. Sidecar cards additionally
+show battle-log enrichment and fleet-runtime mode. Unsupported controls are not rendered.
+
+## Secret intent
+
+Saved tokens are never placed in a text property or displayed. The password control begins empty and reports only
+whether a saved token exists. Typing alone does not alter the desired topology; **Replace** explicitly adopts the new
+secret, while **Clear** explicitly removes it. Persistence plan display remains redacted.
+
+## Document coordination
+
+Typed sync and ordinary settings use the same selected TOML and atomic store but keep separate typed edit sessions.
+Only one session may save while the other owns a pending draft. A successful save refreshes the sibling baseline,
+preventing two optimistic revisions from racing. Open and navigation never write the document, and successful sync save
+does not mutate the startup runtime snapshot; restart is required.
+
+Legacy root `sync.url` / `sync.token` loads as a virtual default target. Editing it remains blocked until the player
+checks the explicit migration confirmation, after which the move into `sync.targets.default` occurs in the same atomic
+save.
+
+## Accessibility and scale
+
+- Navigation, add actions, global controls, target actions, secret intent, override selectors, Save, and Discard have
+  keyboard-focusable native controls and automation names/help.
+- The target collection uses a recycling `VirtualizingStackPanel`.
+- Long identities use trimming while their containing target card retains the complete automation name.
+- Validation and operation status use polite live regions.
+- Layout uses the launcher's dynamic theme brushes and scales with WPF DPI behavior.
+
+## Automated evidence
+
+- View-model tests cover byte-preserving open, mixed typed targets, Sidecar cardinality, inherited/effective feed state,
+  secret replacement intent, proxy/TLS tri-state overrides, Sidecar-only controls, legacy migration confirmation,
+  cross-workspace save exclusion, and atomic save/reload.
+- Packaged UI Automation enters Data Sync, finds the typed workspace, global defaults, and virtualized target collection,
+  then verifies both the active manual TOML and an isolated mixed-target fixture remain unchanged. The fixture run restores
+  the real launcher selection byte-for-byte in `finally`.
+- Packaging asserts the public setup directory contains exactly one `STFCCommunityMod.Launcher.Setup.exe`; the internal
+  ZIP remains only the embedded installer/self-update payload, not a second public install artifact.

--- a/windows-launcher/scripts/smoke-settings.ps1
+++ b/windows-launcher/scripts/smoke-settings.ps1
@@ -4,7 +4,9 @@ param(
   [string]$LauncherPath,
 
   [ValidateRange(5, 120)]
-  [int]$TimeoutSeconds = 30
+  [int]$TimeoutSeconds = 30,
+
+  [switch]$UseDisposableSyncFixture
 )
 
 $ErrorActionPreference = "Stop"
@@ -222,6 +224,33 @@ function Stop-OwnedProcess {
   }
 }
 
+function Restore-DisposableFixture {
+  param(
+    [bool]$SelectionExisted,
+    [AllowNull()][byte[]]$SelectionBytes,
+    [string]$SelectionPath,
+    [AllowNull()][string]$DisposableGameDirectory
+  )
+
+  if ($SelectionExisted) {
+    [System.IO.File]::WriteAllBytes($SelectionPath, $SelectionBytes)
+  }
+  elseif (Test-Path -LiteralPath $SelectionPath -PathType Leaf) {
+    [System.IO.File]::Delete($SelectionPath)
+  }
+
+  if ($null -ne $DisposableGameDirectory -and
+      $DisposableGameDirectory.StartsWith(
+        [System.IO.Path]::GetTempPath(),
+        [StringComparison]::OrdinalIgnoreCase) -and
+      (Split-Path -Leaf $DisposableGameDirectory).StartsWith(
+        "stfc-launcher-sync-smoke-",
+        [StringComparison]::Ordinal) -and
+      (Test-Path -LiteralPath $DisposableGameDirectory -PathType Container)) {
+    [System.IO.Directory]::Delete($DisposableGameDirectory, $true)
+  }
+}
+
 $resolvedLauncherPath = (Resolve-Path -LiteralPath $LauncherPath).Path
 if (-not (Test-Path -LiteralPath $resolvedLauncherPath -PathType Leaf) -or
     [System.IO.Path]::GetExtension($resolvedLauncherPath) -ne ".exe") {
@@ -253,16 +282,73 @@ if ([string]::IsNullOrWhiteSpace($originalWindir)) {
   Write-Verbose "Restored process WINDIR from SystemRoot for the launcher smoke."
 }
 
-$configurationPath = Get-ActiveConfigurationPath
-$configurationHashBefore = $null
-if ($null -ne $configurationPath) {
-  $configurationHashBefore = (
-    Get-FileHash -LiteralPath $configurationPath -Algorithm SHA256
-  ).Hash
-  Write-Host "Guarding active TOML: $configurationPath"
+$selectionPath = Join-Path `
+  ([Environment]::GetFolderPath([Environment+SpecialFolder]::LocalApplicationData)) `
+  "STFC Community Mod Launcher\install-selection.json"
+$selectionExisted = Test-Path -LiteralPath $selectionPath -PathType Leaf
+$selectionBytes = if ($selectionExisted) {
+  [System.IO.File]::ReadAllBytes($selectionPath)
+} else {
+  $null
 }
-else {
-  Write-Host "No active game TOML was discoverable; continuing with read-only UI checks."
+$disposableGameDirectory = $null
+try {
+  if ($UseDisposableSyncFixture) {
+    $disposableGameDirectory = Join-Path `
+      ([System.IO.Path]::GetTempPath()) `
+      "stfc-launcher-sync-smoke-$([Guid]::NewGuid().ToString('N'))"
+    [void](New-Item -ItemType Directory -Path $disposableGameDirectory)
+    [System.IO.File]::WriteAllBytes(
+      (Join-Path $disposableGameDirectory "prime.exe"),
+      [byte[]]::new(0))
+    [System.IO.File]::WriteAllText(
+      (Join-Path $disposableGameDirectory "community_patch_settings.toml"),
+      @"
+[sync]
+jobs = true
+
+[sidecar.sync]
+enabled = false
+
+[sync.targets.community]
+url = "https://community.example.invalid/sync"
+token = "disposable-smoke-secret"
+"@,
+      [System.Text.UTF8Encoding]::new($false))
+    [void](New-Item -ItemType Directory -Path (Split-Path -Parent $selectionPath) -Force)
+    $selectionDocument = [ordered]@{
+      schemaVersion = 1
+      gameDirectory = $disposableGameDirectory
+      confirmedAtUtc = [DateTimeOffset]::UtcNow
+    }
+    [System.IO.File]::WriteAllText(
+      $selectionPath,
+      ($selectionDocument | ConvertTo-Json),
+      [System.Text.UTF8Encoding]::new($false))
+    Write-Host "Using disposable Sync fixture: $disposableGameDirectory"
+  }
+
+  $configurationPath = Get-ActiveConfigurationPath
+  $configurationHashBefore = $null
+  if ($null -ne $configurationPath) {
+    $configurationHashBefore = (
+      Get-FileHash -LiteralPath $configurationPath -Algorithm SHA256
+    ).Hash
+    Write-Host "Guarding active TOML: $configurationPath"
+  }
+  else {
+    Write-Host "No active game TOML was discoverable; continuing with read-only UI checks."
+  }
+}
+catch {
+  if ($UseDisposableSyncFixture) {
+    Restore-DisposableFixture `
+      -SelectionExisted $selectionExisted `
+      -SelectionBytes $selectionBytes `
+      -SelectionPath $selectionPath `
+      -DisposableGameDirectory $disposableGameDirectory
+  }
+  throw
 }
 
 $launcherProcess = $null
@@ -412,6 +498,11 @@ try {
     -Name "Hotkey settings" `
     -ControlType ([System.Windows.Automation.ControlType]::Button) `
     -Deadline $settingsDeadline
+  $syncNavigation = Find-AutomationElement `
+    -Root $root `
+    -Name "Data Sync settings" `
+    -ControlType ([System.Windows.Automation.ControlType]::Button) `
+    -Deadline $settingsDeadline
 
   Invoke-AutomationElement -Element $notificationsNavigation
   [void](Find-AutomationElement `
@@ -436,6 +527,22 @@ try {
     -ControlType ([System.Windows.Automation.ControlType]::Button) `
     -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
 
+  Invoke-AutomationElement -Element $syncNavigation
+  [void](Find-AutomationElement `
+    -Root $root `
+    -Name "Sync setup workspace" `
+    -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
+  [void](Find-AutomationElement `
+    -Root $root `
+    -Name "Global defaults" `
+    -ControlType ([System.Windows.Automation.ControlType]::Text) `
+    -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
+  [void](Find-AutomationElement `
+    -Root $root `
+    -Name "Configured sync targets" `
+    -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
+  Write-Host "PASS: typed Sync setup, global defaults, and virtualized target collection are UI Automation accessible."
+
   $aboutNavigation = Find-AutomationElement `
     -Root $root `
     -Name "About launcher settings" `
@@ -455,7 +562,7 @@ try {
       -Deadline ([DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)))
   }
 
-  Write-Host "PASS: launcher chrome, grouped Hotkeys actions, overflow binding actions, appearance selection, and startup activation diagnostics are UI Automation accessible."
+  Write-Host "PASS: launcher chrome, typed Sync setup, grouped Hotkeys actions, overflow binding actions, appearance selection, and startup activation diagnostics are UI Automation accessible."
 }
 catch {
   $smokeFailure = $_
@@ -482,6 +589,14 @@ finally {
 
   if ($windirWasRestored) {
     [Environment]::SetEnvironmentVariable("WINDIR", $null, "Process")
+  }
+
+  if ($UseDisposableSyncFixture) {
+    Restore-DisposableFixture `
+      -SelectionExisted $selectionExisted `
+      -SelectionBytes $selectionBytes `
+      -SelectionPath $selectionPath `
+      -DisposableGameDirectory $disposableGameDirectory
   }
 }
 

--- a/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher.Core/SyncTopologyPersistence.cs
@@ -510,6 +510,16 @@ public sealed class SyncTopologyPersistenceWorkspace
 
     public ConfigurationDocumentRevision BaselineRevision => snapshot.Revision;
 
+    public bool HasLegacyRootTarget => baseline.HasLegacyRootTarget;
+
+    public SyncTopologyPersistencePlan PreparePlan(bool migrateLegacyRoot = false) =>
+        SyncTopologyPersistencePlanner.Build(
+            baseline,
+            Desired,
+            renames,
+            kindChangeDecisions,
+            migrateLegacyRoot);
+
     public static SyncTopologyTomlLoadResult Load(
         ConfigurationDocumentSnapshot snapshot,
         out SyncTopologyPersistenceWorkspace? workspace,
@@ -556,12 +566,7 @@ public sealed class SyncTopologyPersistenceWorkspace
         bool migrateLegacyRoot = false,
         CancellationToken cancellationToken = default)
     {
-        var plan = SyncTopologyPersistencePlanner.Build(
-            baseline,
-            Desired,
-            renames,
-            kindChangeDecisions,
-            migrateLegacyRoot);
+        var plan = PreparePlan(migrateLegacyRoot);
         if (!plan.IsValid)
         {
             return new(AtomicTomlWriteState.Invalid, Plan: plan);

--- a/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SettingsViewModel.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SettingsViewModel.cs
@@ -66,6 +66,10 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         discardCommand = new SettingsActionCommand(Discard, () => HasPendingChanges);
         saveCommand = new AsyncSettingsActionCommand(SaveAsync, () => CanSave);
 
+        SyncWorkspace = new(configurationPathProvider, this.repository, () => HasPendingChanges);
+        SyncWorkspace.StateChanged += SyncWorkspace_StateChanged;
+        SyncWorkspace.Committed += SyncWorkspace_Committed;
+
         TryLoadConfiguration();
         projectionQuery = new(catalog, layoutProvider);
         RefreshKeybindingConflicts();
@@ -95,6 +99,8 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
     public ICommand SaveCommand => saveCommand;
 
     public ICommand SearchToggleCommand { get; }
+
+    public SyncWorkspaceViewModel SyncWorkspace { get; }
 
     public string SearchText
     {
@@ -154,7 +160,12 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
     public bool IsGeneralSelected =>
         !IsSearchActive && selectedSection == LauncherSettingsSection.General;
 
-    public bool IsSettingsListVisible => !IsAboutSelected;
+    public bool IsDataSyncSelected =>
+        !IsSearchActive && selectedSection == LauncherSettingsSection.DataSync;
+
+    public bool IsSettingsListVisible => !IsAboutSelected && !IsDataSyncSelected;
+
+    public bool IsSettingsFooterVisible => HasPendingChanges && !IsDataSyncSelected;
 
     public int VisibleSettingCount =>
         projectedItems.OfType<SettingsRowViewModel>().Count();
@@ -228,10 +239,13 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         IsConfigurationReady
         && HasPendingChanges
         && !HasInvalidInput
+        && !SyncWorkspace.HasPendingChanges
         && ConfigurationPathMatchesLoadedSession();
 
     public string SaveAvailability =>
-        HasInvalidInput
+        SyncWorkspace.HasPendingChanges
+            ? "Save or discard the pending sync setup before saving other settings."
+            : HasInvalidInput
             ? "Fix the highlighted setting before saving."
             : CanSave
                 ? "Save all staged configuration changes."
@@ -268,6 +282,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
 
         ClearEditorDrafts();
         TryLoadConfiguration();
+        SyncWorkspace.Reload();
         RefreshAllStates();
         NotifySessionChanged();
     }
@@ -327,7 +342,13 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(VisibleItemsSummary));
         OnPropertyChanged(nameof(IsAboutSelected));
         OnPropertyChanged(nameof(IsGeneralSelected));
+        OnPropertyChanged(nameof(IsDataSyncSelected));
         OnPropertyChanged(nameof(IsSettingsListVisible));
+        OnPropertyChanged(nameof(IsSettingsFooterVisible));
+        if (section == LauncherSettingsSection.DataSync)
+        {
+            SyncWorkspace.Reload();
+        }
         RebuildProjection();
     }
 
@@ -519,6 +540,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         if (selectedConfigurationChanged)
         {
             TryLoadConfiguration();
+            SyncWorkspace.Reload();
         }
 
         ClearEditorDrafts();
@@ -526,6 +548,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
             ? "Unsaved changes discarded and the selected configuration reloaded."
             : "Unsaved changes discarded.";
         RefreshAllStates();
+        SyncWorkspace.Reload();
         NotifySessionChanged();
     }
 
@@ -560,6 +583,10 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         };
 
         RefreshAllStates();
+        if (result.IsSuccess)
+        {
+            SyncWorkspace.Reload();
+        }
         NotifySessionChanged();
     }
 
@@ -670,6 +697,7 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         OnPropertyChanged(nameof(ConfigurationStatus));
         OnPropertyChanged(nameof(PendingChangeCount));
         OnPropertyChanged(nameof(HasPendingChanges));
+        OnPropertyChanged(nameof(IsSettingsFooterVisible));
         OnPropertyChanged(nameof(PendingChangesText));
         OnPropertyChanged(nameof(PendingApplyTimingText));
         OnPropertyChanged(nameof(HasInvalidInput));
@@ -702,6 +730,26 @@ public sealed class SettingsViewModel : INotifyPropertyChanged
         {
             return false;
         }
+    }
+
+    private void SyncWorkspace_StateChanged(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        NotifySessionChanged();
+    }
+
+    private void SyncWorkspace_Committed(object? sender, EventArgs e)
+    {
+        _ = sender;
+        _ = e;
+        if (!HasPendingChanges)
+        {
+            TryLoadConfiguration();
+            RefreshAllStates();
+        }
+
+        NotifySessionChanged();
     }
 
     private void RebuildProjection()

--- a/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SyncWorkspaceViewModel.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/ViewModels/SyncWorkspaceViewModel.cs
@@ -1,0 +1,621 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using STFCCommunityMod.Launcher.Core;
+
+namespace STFCCommunityMod.Launcher.ViewModels;
+
+public enum SyncBooleanOverrideChoice
+{
+    UseGlobal,
+    Enabled,
+    Disabled,
+}
+
+public sealed record SyncOverrideChoice(SyncBooleanOverrideChoice Value, string Label);
+
+public sealed record SyncFleetRuntimeModeOption(string Value, string Label);
+
+public sealed class SyncWorkspaceViewModel : INotifyPropertyChanged
+{
+    private static readonly IReadOnlyList<SyncOverrideChoice> OverrideChoices =
+    [
+        new(SyncBooleanOverrideChoice.UseGlobal, "Use inherited"),
+        new(SyncBooleanOverrideChoice.Enabled, "On"),
+        new(SyncBooleanOverrideChoice.Disabled, "Off"),
+    ];
+
+    private readonly Func<string?> configurationPathProvider;
+    private readonly Func<bool> hasSiblingPendingChanges;
+    private readonly IConfigurationRepository repository;
+    private readonly SettingsActionCommand discardCommand;
+    private readonly AsyncSettingsActionCommand saveCommand;
+    private SyncTopologyPersistenceWorkspace? workspace;
+    private string operationStatus = string.Empty;
+    private string newTargetName = string.Empty;
+    private bool migrateLegacyRoot;
+
+    public SyncWorkspaceViewModel(
+        Func<string?> configurationPathProvider,
+        IConfigurationRepository repository,
+        Func<bool>? hasSiblingPendingChanges = null)
+    {
+        this.configurationPathProvider =
+            configurationPathProvider ?? throw new ArgumentNullException(nameof(configurationPathProvider));
+        this.repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        this.hasSiblingPendingChanges = hasSiblingPendingChanges ?? (() => false);
+        discardCommand = new(Discard, () => HasPendingChanges);
+        saveCommand = new(SaveAsync, () => CanSave);
+        AddSidecarCommand = new SettingsActionCommand(AddSidecar, () => CanAddSidecar);
+        AddMajelCommand = new SettingsActionCommand(() => AddExternal(SyncTargetKind.MajelIngest));
+        AddLegacyCommand = new SettingsActionCommand(() => AddExternal(SyncTargetKind.LegacyCommunity));
+        AddSpocksClubCommand = new SettingsActionCommand(() => AddPreset("spocks_club"));
+        Reload();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public event EventHandler? StateChanged;
+
+    public event EventHandler? Committed;
+
+    public ObservableCollection<SyncTargetCardViewModel> Targets { get; } = [];
+
+    public ObservableCollection<SyncGlobalFeedViewModel> GlobalFeeds { get; } = [];
+
+    internal static IReadOnlyList<SyncOverrideChoice> BooleanOverrideChoices => OverrideChoices;
+
+    public ICommand AddSidecarCommand { get; }
+
+    public ICommand AddMajelCommand { get; }
+
+    public ICommand AddLegacyCommand { get; }
+
+    public ICommand AddSpocksClubCommand { get; }
+
+    public ICommand DiscardCommand => discardCommand;
+
+    public ICommand SaveCommand => saveCommand;
+
+    public bool IsConfigurationReady => workspace is not null;
+
+    public bool HasPendingChanges => workspace?.HasPendingChanges ?? false;
+
+    public bool IsStale => workspace?.IsStale ?? false;
+
+    public bool IsCommittable =>
+        workspace is not null
+        && workspace.Desired.Resolve().IsCommittable
+        && workspace.PreparePlan(MigrateLegacyRoot).IsValid;
+
+    public bool HasLegacyRootTarget => workspace?.HasLegacyRootTarget ?? false;
+
+    public bool MigrateLegacyRoot
+    {
+        get => migrateLegacyRoot;
+        set
+        {
+            if (SetField(ref migrateLegacyRoot, value))
+            {
+                Rebuild();
+            }
+        }
+    }
+
+    public bool CanSave =>
+        IsConfigurationReady
+        && HasPendingChanges
+        && IsCommittable
+        && !IsStale
+        && !hasSiblingPendingChanges();
+
+    public bool CanAddSidecar =>
+        workspace is not null
+        && !workspace.Desired.Targets.Values.Any(target => target.Kind == SyncTargetKind.LocalSidecar);
+
+    public string ConfigurationStatus => IsConfigurationReady
+        ? "Changes are staged until Save. The running game keeps its startup topology until restart."
+        : "Select a game folder with a supported configuration to set up sync.";
+
+    public string PendingChangesText => HasPendingChanges ? "Unsaved sync changes" : "No unsaved sync changes";
+
+    public string SaveAvailability => IsStale
+        ? "The TOML changed outside the launcher. Reload before saving."
+        : hasSiblingPendingChanges()
+            ? "Save or discard the pending non-sync settings before saving sync setup."
+        : !IsCommittable
+            ? "Fix the target validation errors before saving."
+            : CanSave
+                ? "Save all staged sync changes atomically."
+                : "Stage a valid sync change before saving.";
+
+    public string OperationStatus
+    {
+        get => operationStatus;
+        private set => SetField(ref operationStatus, value);
+    }
+
+    public string NewTargetName
+    {
+        get => newTargetName;
+        set => SetField(ref newTargetName, value?.Trim() ?? string.Empty);
+    }
+
+    public string GlobalProxy
+    {
+        get => workspace?.Desired.GlobalDefaults.Proxy ?? string.Empty;
+        set
+        {
+            if (workspace is null || value == GlobalProxy)
+            {
+                return;
+            }
+
+            Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithProxy(value ?? string.Empty)));
+        }
+    }
+
+    public bool GlobalVerifySsl
+    {
+        get => workspace?.Desired.GlobalDefaults.VerifySsl ?? true;
+        set
+        {
+            if (workspace is null || value == GlobalVerifySsl)
+            {
+                return;
+            }
+
+            Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithVerifySsl(value)));
+        }
+    }
+
+    public bool GlobalUnsafeTls
+    {
+        get => workspace?.Desired.GlobalDefaults.AllowUnsafeTlsWithoutCertificateValidation ?? false;
+        set
+        {
+            if (workspace is null || value == GlobalUnsafeTls)
+            {
+                return;
+            }
+
+            Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithUnsafeTls(value)));
+        }
+    }
+
+    public void Reload()
+    {
+        if (HasPendingChanges)
+        {
+            return;
+        }
+
+        workspace = null;
+        var read = repository.Read(configurationPathProvider());
+        if (!read.IsSuccess || read.Snapshot is null)
+        {
+            OperationStatus = read.State == ConfigurationRepositoryReadState.Invalid
+                ? $"Sync setup is unavailable because the TOML is unsafe to edit: {read.ValidationError?.Message}"
+                : read.State == ConfigurationRepositoryReadState.IoFailure
+                    ? $"Sync setup is unavailable: {read.Error}"
+                    : string.Empty;
+            Rebuild();
+            return;
+        }
+
+        var load = SyncTopologyPersistenceWorkspace.Load(read.Snapshot, out workspace);
+        if (!load.IsValid || workspace is null)
+        {
+            OperationStatus = $"Sync setup is unavailable because the topology could not be loaded: {load.Error?.Message}";
+        }
+        else
+        {
+            OperationStatus = load.Diagnostics.FirstOrDefault(item => item.Severity == SyncTopologyDiagnosticSeverity.Error)?.Message
+                ?? string.Empty;
+        }
+
+        Rebuild();
+    }
+
+    internal SyncTargetDraft? GetTarget(string name) =>
+        workspace?.Desired.Targets.GetValueOrDefault(name);
+
+    internal SyncResolvedTarget? GetResolvedTarget(string name) =>
+        workspace?.Desired.Resolve().Targets.FirstOrDefault(target => target.Name == name);
+
+    internal bool GetGlobalFeed(SyncDataKind kind) =>
+        workspace?.Desired.GlobalDefaults.DataKinds.GetValueOrDefault(kind) ?? false;
+
+    internal string GetGlobalProxy() => workspace?.Desired.GlobalDefaults.Proxy ?? string.Empty;
+
+    internal bool GetGlobalVerifySsl() => workspace?.Desired.GlobalDefaults.VerifySsl ?? true;
+
+    internal bool GetGlobalUnsafeTls() =>
+        workspace?.Desired.GlobalDefaults.AllowUnsafeTlsWithoutCertificateValidation ?? false;
+
+    internal IReadOnlyList<SyncTopologyDiagnostic> GetDiagnostics(string name) =>
+        workspace?.Desired.Resolve().Diagnostics.Where(item => item.TargetName == name).ToArray() ?? [];
+
+    internal void UpdateTarget(string name, Func<SyncTargetDraft, SyncTargetDraft> update)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        Apply(workspace.Desired.UpdateTarget(name, update));
+    }
+
+    internal void RemoveTarget(string name)
+    {
+        if (workspace is not null)
+        {
+            Apply(workspace.Desired.RemoveTarget(name));
+        }
+    }
+
+    internal void SetGlobalFeed(SyncDataKind kind, bool enabled)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        Stage(workspace.Desired.WithGlobalDefaults(workspace.Desired.GlobalDefaults.WithDataKind(kind, enabled)));
+    }
+
+    private void AddSidecar()
+    {
+        if (workspace is not null)
+        {
+            Apply(workspace.Desired.AddTarget(SyncDesiredTopology.LocalSidecarIdentity, SyncTargetKind.LocalSidecar));
+        }
+    }
+
+    private void AddPreset(string preset)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        Apply(workspace.Desired.AddPreset(preset), enableExternal: true);
+    }
+
+    private void AddExternal(SyncTargetKind kind)
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        var name = string.IsNullOrWhiteSpace(NewTargetName)
+            ? kind == SyncTargetKind.MajelIngest ? "majel" : "community"
+            : NewTargetName;
+        Apply(workspace.Desired.AddTarget(name, kind), enableExternal: true);
+    }
+
+    private void Apply(SyncTopologyTransitionResult transition, bool enableExternal = false)
+    {
+        if (!transition.Succeeded)
+        {
+            OperationStatus = transition.Diagnostic?.Message ?? "The sync change could not be staged.";
+            return;
+        }
+
+        var desired = transition.Topology;
+        if (enableExternal)
+        {
+            var added = desired.Targets.Values.ExceptBy(workspace!.Desired.Targets.Keys, target => target.Name).Single();
+            desired = desired.SetTargetEnabled(added.Name, true).Topology;
+            NewTargetName = string.Empty;
+        }
+
+        Stage(desired);
+    }
+
+    private void Stage(SyncDesiredTopology desired)
+    {
+        workspace!.Stage(desired);
+        OperationStatus = string.Empty;
+        Rebuild();
+    }
+
+    private void Discard()
+    {
+        workspace?.Discard();
+        OperationStatus = "Unsaved sync changes discarded.";
+        Rebuild();
+    }
+
+    private async Task SaveAsync()
+    {
+        if (workspace is null)
+        {
+            return;
+        }
+
+        OperationStatus = "Saving sync setup…";
+        var result = await workspace.CommitAsync(MigrateLegacyRoot);
+        OperationStatus = result.State switch
+        {
+            AtomicTomlWriteState.Succeeded => "Sync setup saved. Restart the game to activate the new topology.",
+            AtomicTomlWriteState.NoChange => "No sync changes were needed.",
+            AtomicTomlWriteState.Conflict => "The TOML changed outside the launcher. External edits were preserved; reload before saving.",
+            AtomicTomlWriteState.Invalid => $"Nothing was written: {result.ValidationError?.Message ?? FirstPlanDiagnostic(result)}",
+            _ => $"Sync setup could not be saved: {result.Error}",
+        };
+        if (result.State is AtomicTomlWriteState.Succeeded or AtomicTomlWriteState.NoChange)
+        {
+            migrateLegacyRoot = false;
+            Committed?.Invoke(this, EventArgs.Empty);
+        }
+        Rebuild();
+    }
+
+    private void Rebuild()
+    {
+        Targets.Clear();
+        GlobalFeeds.Clear();
+        if (workspace is not null)
+        {
+            foreach (var kind in Enum.GetValues<SyncDataKind>().Where(kind => kind != SyncDataKind.FleetRuntime))
+            {
+                GlobalFeeds.Add(new(this, kind));
+            }
+
+            foreach (var target in workspace.Desired.Targets.Values.OrderBy(target => target.Name, StringComparer.Ordinal))
+            {
+                Targets.Add(new(this, target.Name));
+            }
+        }
+
+        OnPropertyChanged(string.Empty);
+        discardCommand.RaiseCanExecuteChanged();
+        saveCommand.RaiseCanExecuteChanged();
+        (AddSidecarCommand as SettingsActionCommand)?.RaiseCanExecuteChanged();
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private static string? FirstPlanDiagnostic(SyncTopologyPersistenceCommitResult result) =>
+        result.Plan is { Diagnostics.Count: > 0 } plan ? plan.Diagnostics[0].Message : null;
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value))
+        {
+            return false;
+        }
+
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new(propertyName));
+}
+
+public sealed class SyncGlobalFeedViewModel(SyncWorkspaceViewModel owner, SyncDataKind kind) : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public string Label => SyncPresentation.FeedLabel(kind);
+    public bool IsEnabled
+    {
+        get => owner.IsConfigurationReady && owner.GetGlobalFeed(kind);
+        set
+        {
+            owner.SetGlobalFeed(kind, value);
+            PropertyChanged?.Invoke(this, new(nameof(IsEnabled)));
+        }
+    }
+}
+
+public sealed class SyncTargetCardViewModel : INotifyPropertyChanged
+{
+    private static readonly IReadOnlyList<SyncFleetRuntimeModeOption> FleetRuntimeModes =
+    [
+        new(string.Empty, "Use target default (Normal)"),
+        new("normal", "Normal"),
+        new("request_only", "Requests only"),
+        new("snapshot_only", "Snapshots only"),
+        new("enqueue_no_transport", "Queue without transport"),
+    ];
+
+    private readonly SyncWorkspaceViewModel owner;
+    private readonly string name;
+    private string replacementToken = string.Empty;
+
+    internal SyncTargetCardViewModel(SyncWorkspaceViewModel owner, string name)
+    {
+        this.owner = owner;
+        this.name = name;
+        RemoveCommand = new SettingsActionCommand(() => owner.RemoveTarget(name));
+        UseInheritedProxyCommand = new SettingsActionCommand(
+            () => owner.UpdateTarget(name, target => target.WithProxy(SyncOverride.Inherited<string>())));
+        ClearTokenCommand = new SettingsActionCommand(ClearToken);
+        ReplaceTokenCommand = new SettingsActionCommand(ReplaceToken, () => !string.IsNullOrWhiteSpace(replacementToken));
+        Feeds = SyncTargetTypeCatalog.Get(Draft.Kind).SupportedDataKinds
+            .OrderBy(SyncPresentation.FeedLabel, StringComparer.Ordinal)
+            .Select(kind => new SyncTargetFeedViewModel(owner, name, kind))
+            .ToArray();
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private SyncTargetDraft Draft => owner.GetTarget(name)!;
+    public string Name => name;
+    public string KindLabel => SyncPresentation.KindLabel(Draft.Kind);
+    public string WireContract => SyncTargetTypeCatalog.Get(Draft.Kind).WireContract;
+    public bool CanDisable => Draft.Kind == SyncTargetKind.LocalSidecar;
+    public bool ShowSidecarControls => Draft.Kind == SyncTargetKind.LocalSidecar;
+    public bool IsEnabled
+    {
+        get => Draft.Enabled;
+        set { owner.UpdateTarget(name, target => target.WithEnabled(value)); NotifyAll(); }
+    }
+    public string Url
+    {
+        get => Draft.Url;
+        set { owner.UpdateTarget(name, target => target.WithConnection(value ?? string.Empty, target.Token)); NotifyAll(); }
+    }
+    public string TokenStatus => Draft.Token.IsConfigured ? "Saved token configured" : "No token configured";
+    public string ProxyText
+    {
+        get => Draft.Proxy.IsExplicit ? Draft.Proxy.Value : string.Empty;
+        set { owner.UpdateTarget(name, target => target.WithProxy(SyncOverride.Explicit(value ?? string.Empty))); NotifyAll(); }
+    }
+    public string ProxySummary
+    {
+        get
+        {
+            if (!Draft.Proxy.IsExplicit)
+            {
+                var inherited = SyncTargetTypeCatalog.Get(Draft.Kind).InheritsGlobalSync ? owner.GetGlobalProxy() : string.Empty;
+                return $"Inherited: {(string.IsNullOrEmpty(inherited) ? "no proxy" : inherited)}";
+            }
+
+            return string.IsNullOrEmpty(Draft.Proxy.Value) ? "Explicitly cleared" : "Target override";
+        }
+    }
+    public SyncBooleanOverrideChoice VerifySslChoice
+    {
+        get => ToChoice(Draft.VerifySsl);
+        set { owner.UpdateTarget(name, target => target.WithVerifySsl(FromChoice(value))); NotifyAll(); }
+    }
+    public SyncBooleanOverrideChoice UnsafeTlsChoice
+    {
+        get => ToChoice(Draft.AllowUnsafeTlsWithoutCertificateValidation);
+        set { owner.UpdateTarget(name, target => target.WithUnsafeTls(FromChoice(value))); NotifyAll(); }
+    }
+    public SyncBooleanOverrideChoice BattlelogEnrichmentChoice
+    {
+        get => ToChoice(Draft.BattlelogEnrichment);
+        set { owner.UpdateTarget(name, target => target.WithBattlelogEnrichment(FromChoice(value))); NotifyAll(); }
+    }
+    public string FleetRuntimeModeChoice
+    {
+        get => Draft.FleetRuntimeMode.IsExplicit ? Draft.FleetRuntimeMode.Value : string.Empty;
+        set
+        {
+            owner.UpdateTarget(
+                name,
+                target => target.WithFleetRuntimeMode(
+                    string.IsNullOrEmpty(value) ? SyncOverride.Inherited<string>() : SyncOverride.Explicit(value)));
+            NotifyAll();
+        }
+    }
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "WPF binds this property through each target card instance.")]
+    public IReadOnlyList<SyncOverrideChoice> BooleanChoices => SyncWorkspaceViewModel.BooleanOverrideChoices;
+
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "WPF binds this property through each target card instance.")]
+    public IReadOnlyList<SyncFleetRuntimeModeOption> FleetRuntimeModeChoices => FleetRuntimeModes;
+    public string ValidationSummary
+    {
+        get
+        {
+            var errors = owner.GetDiagnostics(name).Where(item => item.Severity == SyncTopologyDiagnosticSeverity.Error).ToArray();
+            return errors.Length == 0 ? "Ready" : string.Join(" ", errors.Select(item => item.Message));
+        }
+    }
+    public bool HasValidationError => owner.GetDiagnostics(name).Any(item => item.Severity == SyncTopologyDiagnosticSeverity.Error);
+    public string EffectiveFeeds => string.Join(", ", Feeds.Where(feed => feed.EffectiveEnabled).Select(feed => feed.Label).DefaultIfEmpty("None"));
+    public IReadOnlyList<SyncTargetFeedViewModel> Feeds { get; }
+    public ICommand RemoveCommand { get; }
+    public ICommand UseInheritedProxyCommand { get; }
+    public ICommand ClearTokenCommand { get; }
+    public ICommand ReplaceTokenCommand { get; }
+
+    public void SetReplacementToken(string value)
+    {
+        replacementToken = value ?? string.Empty;
+        (ReplaceTokenCommand as SettingsActionCommand)?.RaiseCanExecuteChanged();
+    }
+
+    private void ReplaceToken()
+    {
+        owner.UpdateTarget(name, target => target.WithConnection(target.Url, SyncSecret.FromPlainText(replacementToken)));
+        replacementToken = string.Empty;
+        NotifyAll();
+    }
+
+    private void ClearToken()
+    {
+        owner.UpdateTarget(name, target => target.WithConnection(target.Url, SyncSecret.Missing));
+        replacementToken = string.Empty;
+        NotifyAll();
+    }
+
+    private void NotifyAll() => PropertyChanged?.Invoke(this, new(string.Empty));
+
+    private static SyncBooleanOverrideChoice ToChoice(SyncOverride<bool> value) =>
+        !value.IsExplicit
+            ? SyncBooleanOverrideChoice.UseGlobal
+            : value.Value ? SyncBooleanOverrideChoice.Enabled : SyncBooleanOverrideChoice.Disabled;
+
+    private static SyncOverride<bool> FromChoice(SyncBooleanOverrideChoice value) => value switch
+    {
+        SyncBooleanOverrideChoice.Enabled => SyncOverride.Explicit(true),
+        SyncBooleanOverrideChoice.Disabled => SyncOverride.Explicit(false),
+        _ => SyncOverride.Inherited<bool>(),
+    };
+}
+
+public sealed class SyncTargetFeedViewModel(
+    SyncWorkspaceViewModel owner,
+    string targetName,
+    SyncDataKind kind) : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public string Label => SyncPresentation.FeedLabel(kind);
+    [SuppressMessage("Performance", "CA1822:Mark members as static", Justification = "WPF binds this property through each feed row instance.")]
+    public IReadOnlyList<SyncOverrideChoice> Choices => SyncWorkspaceViewModel.BooleanOverrideChoices;
+    public SyncBooleanOverrideChoice Choice
+    {
+        get
+        {
+            var target = owner.GetTarget(targetName)!;
+            var configured = target.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>());
+            return !configured.IsExplicit
+                ? SyncBooleanOverrideChoice.UseGlobal
+                : configured.Value ? SyncBooleanOverrideChoice.Enabled : SyncBooleanOverrideChoice.Disabled;
+        }
+        set
+        {
+            var configured = value switch
+            {
+                SyncBooleanOverrideChoice.Enabled => SyncOverride.Explicit(true),
+                SyncBooleanOverrideChoice.Disabled => SyncOverride.Explicit(false),
+                _ => SyncOverride.Inherited<bool>(),
+            };
+            owner.UpdateTarget(targetName, target => target.WithDataOverride(kind, configured));
+            PropertyChanged?.Invoke(this, new(string.Empty));
+        }
+    }
+    public bool EffectiveEnabled
+    {
+        get
+        {
+            var target = owner.GetTarget(targetName)!;
+            var configured = target.DataOverrides.GetValueOrDefault(kind, SyncOverride.Inherited<bool>());
+            var inherited = SyncTargetTypeCatalog.Get(target.Kind).InheritsGlobalSync
+                && owner.GetGlobalFeed(kind);
+            return configured.IsExplicit ? configured.Value : inherited;
+        }
+    }
+    public string EffectiveSummary => $"Effective: {(EffectiveEnabled ? "On" : "Off")} · {(Choice == SyncBooleanOverrideChoice.UseGlobal ? "inherited" : "target override")}";
+}
+
+internal static class SyncPresentation
+{
+    public static string KindLabel(SyncTargetKind kind) => kind switch
+    {
+        SyncTargetKind.LocalSidecar => "Local Sidecar",
+        SyncTargetKind.MajelIngest => "Majel",
+        _ => "Community / legacy",
+    };
+
+    public static string FeedLabel(SyncDataKind kind) => string.Concat(
+        kind.ToString().SelectMany((character, index) => index > 0 && char.IsUpper(character) ? new[] { ' ', character } : new[] { character }));
+}

--- a/windows-launcher/src/STFCCommunityMod.Launcher/Views/SettingsView.xaml
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/Views/SettingsView.xaml
@@ -6,6 +6,7 @@
              xmlns:controls="clr-namespace:STFCCommunityMod.Launcher.Controls"
              xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework"
              xmlns:viewModels="clr-namespace:STFCCommunityMod.Launcher.ViewModels"
+             xmlns:views="clr-namespace:STFCCommunityMod.Launcher.Views"
              MinWidth="760"
              Background="{DynamicResource WindowBackgroundBrush}"
              Foreground="{DynamicResource TextPrimaryBrush}"
@@ -1138,13 +1139,18 @@
       </Grid>
     </Grid>
 
+    <views:SyncView Grid.Row="0"
+                    Grid.Column="1"
+                    DataContext="{Binding SyncWorkspace}"
+                    Visibility="{Binding IsDataSyncSelected, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
     <Border Grid.Row="1"
             Grid.Column="1"
             Padding="20,8,24,8"
             Background="{DynamicResource SurfaceBrush}"
             BorderBrush="{DynamicResource BorderBrush}"
             BorderThickness="0,1,0,0"
-            Visibility="{Binding HasPendingChanges, Converter={StaticResource BooleanToVisibilityConverter}}"
+            Visibility="{Binding IsSettingsFooterVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
             automation:AutomationProperties.Name="{Binding PendingChangesText}">
       <Grid>
         <Grid.ColumnDefinitions>

--- a/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml
@@ -1,0 +1,281 @@
+<UserControl x:Class="STFCCommunityMod.Launcher.Views.SyncView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:automation="clr-namespace:System.Windows.Automation;assembly=PresentationCore"
+             xmlns:viewModels="clr-namespace:STFCCommunityMod.Launcher.ViewModels"
+             Background="{DynamicResource WindowBackgroundBrush}"
+             Foreground="{DynamicResource TextPrimaryBrush}"
+             automation:AutomationProperties.Name="Sync setup workspace">
+  <UserControl.Resources>
+    <Style x:Key="SyncTextBox" TargetType="TextBox">
+      <Setter Property="MinHeight" Value="34" />
+      <Setter Property="Padding" Value="9,6" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+      <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}" />
+    </Style>
+    <Style x:Key="SyncComboBox" TargetType="ComboBox">
+      <Setter Property="MinHeight" Value="34" />
+      <Setter Property="Padding" Value="8,4" />
+      <Setter Property="Background" Value="{DynamicResource ControlBackgroundBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource TextPrimaryBrush}" />
+    </Style>
+  </UserControl.Resources>
+
+  <Grid Margin="24,10,24,0">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <Grid>
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
+      <StackPanel>
+        <TextBlock FontSize="22" FontWeight="SemiBold" Text="Sync setup" />
+        <TextBlock Margin="0,4,0,0"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="Set shared defaults, then connect one or more typed destinations."
+                   TextWrapping="Wrap" />
+        <TextBlock Margin="0,4,0,0"
+                   FontSize="12"
+                   Foreground="{DynamicResource TextSecondaryBrush}"
+                   Text="{Binding ConfigurationStatus}"
+                   automation:AutomationProperties.LiveSetting="Polite" />
+        <CheckBox Margin="0,7,0,0"
+                  Content="Migrate legacy root sync credentials to a named default target when saving"
+                  IsChecked="{Binding MigrateLegacyRoot}"
+                  Visibility="{Binding HasLegacyRootTarget, Converter={StaticResource BooleanToVisibilityConverter}}"
+                  automation:AutomationProperties.Name="Confirm legacy sync target migration"
+                  automation:AutomationProperties.HelpText="This moves sync.url and sync.token into sync.targets.default in the same atomic save." />
+      </StackPanel>
+      <StackPanel Grid.Column="1" Margin="20,0,0,0" HorizontalAlignment="Right">
+        <TextBlock HorizontalAlignment="Right" FontSize="11"
+                   Foreground="{DynamicResource TextSecondaryBrush}" Text="Add destination" />
+        <StackPanel Margin="0,5,0,0" Orientation="Horizontal">
+          <TextBox Width="145" Style="{StaticResource SyncTextBox}"
+                   Text="{Binding NewTargetName, UpdateSourceTrigger=PropertyChanged}"
+                   ToolTip="Optional custom target name"
+                   automation:AutomationProperties.Name="New sync target name" />
+          <Button Margin="6,0,0,0" Command="{Binding AddLegacyCommand}" Content="Community"
+                  automation:AutomationProperties.Name="Add community sync target" />
+          <Button Margin="6,0,0,0" Command="{Binding AddMajelCommand}" Content="Majel"
+                  automation:AutomationProperties.Name="Add Majel sync target" />
+          <Button Margin="6,0,0,0" Command="{Binding AddSpocksClubCommand}" Content="Spocks Club"
+                  automation:AutomationProperties.Name="Add Spocks Club preset" />
+          <Button Margin="6,0,0,0" Command="{Binding AddSidecarCommand}" Content="Sidecar"
+                  automation:AutomationProperties.Name="Add local Sidecar target" />
+        </StackPanel>
+      </StackPanel>
+    </Grid>
+
+    <Border Grid.Row="1" Margin="0,12,0,10" Padding="14"
+            Background="{DynamicResource SurfaceBrush}"
+            BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="8"
+            automation:AutomationProperties.Name="Global sync defaults">
+      <Grid>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="Auto" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock FontSize="17" FontWeight="SemiBold" Text="Global defaults" />
+        <Grid Grid.Row="1" Margin="0,9,0,0">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="80" />
+            <ColumnDefinition Width="260" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+          </Grid.ColumnDefinitions>
+          <TextBlock VerticalAlignment="Center" Text="Proxy" />
+          <TextBox Grid.Column="1" Style="{StaticResource SyncTextBox}"
+                   Text="{Binding GlobalProxy, UpdateSourceTrigger=LostFocus}"
+                   automation:AutomationProperties.Name="Global sync proxy" />
+          <CheckBox Grid.Column="2" Margin="18,0,0,0" VerticalAlignment="Center"
+                    Content="Verify TLS" IsChecked="{Binding GlobalVerifySsl}"
+                    automation:AutomationProperties.Name="Verify TLS by default" />
+          <CheckBox Grid.Column="3" Margin="18,0,0,0" VerticalAlignment="Center"
+                    Content="Acknowledge unsafe TLS" IsChecked="{Binding GlobalUnsafeTls}"
+                    automation:AutomationProperties.Name="Acknowledge unsafe TLS without certificate validation" />
+        </Grid>
+        <ItemsControl Grid.Row="2" Margin="0,10,0,0" ItemsSource="{Binding GlobalFeeds}">
+          <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate DataType="{x:Type viewModels:SyncGlobalFeedViewModel}">
+              <CheckBox MinWidth="120" Margin="0,3,14,3" Content="{Binding Label}"
+                        IsChecked="{Binding IsEnabled}"
+                        automation:AutomationProperties.Name="{Binding Label, StringFormat='Global {0} feed'}" />
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </Grid>
+    </Border>
+
+    <Grid Grid.Row="2">
+      <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center"
+                 FontSize="15" Foreground="{DynamicResource TextSecondaryBrush}"
+                 Text="No sync destinations yet. Add Sidecar, Majel, a provider preset, or a custom community target.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock">
+            <Setter Property="Visibility" Value="Collapsed" />
+            <Style.Triggers><DataTrigger Binding="{Binding Targets.Count}" Value="0"><Setter Property="Visibility" Value="Visible" /></DataTrigger></Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+      <ListBox ItemsSource="{Binding Targets}" Background="Transparent" BorderThickness="0"
+               ScrollViewer.CanContentScroll="True" ScrollViewer.VerticalScrollBarVisibility="Auto"
+               VirtualizingPanel.IsVirtualizing="True" VirtualizingPanel.VirtualizationMode="Recycling"
+               KeyboardNavigation.TabNavigation="Continue"
+               automation:AutomationProperties.Name="Configured sync targets">
+        <ListBox.ItemsPanel><ItemsPanelTemplate><VirtualizingStackPanel /></ItemsPanelTemplate></ListBox.ItemsPanel>
+        <ListBox.ItemContainerStyle>
+          <Style TargetType="ListBoxItem">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="Focusable" Value="False" />
+            <Setter Property="IsTabStop" Value="False" />
+            <Setter Property="Margin" Value="0,0,0,10" />
+          </Style>
+        </ListBox.ItemContainerStyle>
+        <ListBox.ItemTemplate>
+          <DataTemplate DataType="{x:Type viewModels:SyncTargetCardViewModel}">
+            <Border Padding="15" Background="{DynamicResource SurfaceBrush}"
+                    BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1" CornerRadius="8"
+                    automation:AutomationProperties.Name="{Binding Name, StringFormat='Sync target {0}'}"
+                    automation:AutomationProperties.HelpText="{Binding ValidationSummary}">
+              <StackPanel>
+                <Grid>
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+                  <StackPanel Orientation="Horizontal">
+                    <TextBlock FontSize="18" FontWeight="SemiBold" Text="{Binding Name}" TextTrimming="CharacterEllipsis" />
+                    <Border Margin="10,0,0,0" Padding="7,2" Background="{DynamicResource SurfaceMutedBrush}" CornerRadius="4">
+                      <TextBlock FontSize="11" Text="{Binding KindLabel}" />
+                    </Border>
+                    <TextBlock Margin="10,2,0,0" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding WireContract}" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="1" Orientation="Horizontal">
+                    <CheckBox Margin="0,0,12,0" VerticalAlignment="Center" Content="Enabled"
+                              IsChecked="{Binding IsEnabled}" IsEnabled="{Binding CanDisable}"
+                              ToolTip="External targets are active when present; remove one to disable it." />
+                    <Button Command="{Binding RemoveCommand}" Content="Remove"
+                            automation:AutomationProperties.Name="{Binding Name, StringFormat='Remove sync target {0}'}" />
+                  </StackPanel>
+                </Grid>
+
+                <TextBlock Margin="0,5,0,0" FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="{Binding EffectiveFeeds, StringFormat='Effective feeds: {0}'}" TextWrapping="Wrap" />
+                <TextBlock Margin="0,4,0,0" FontSize="12" Text="{Binding ValidationSummary}"
+                           TextWrapping="Wrap" automation:AutomationProperties.LiveSetting="Polite" />
+
+                <Grid Margin="0,10,0,0">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="70" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                  <TextBlock VerticalAlignment="Center" Text="Endpoint" />
+                  <TextBox Grid.Column="1" Style="{StaticResource SyncTextBox}"
+                           Text="{Binding Url, UpdateSourceTrigger=LostFocus}"
+                           automation:AutomationProperties.Name="{Binding Name, StringFormat='Endpoint for {0}'}" />
+                </Grid>
+
+                <Grid Margin="0,8,0,0">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="70" /><ColumnDefinition Width="220" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                  <TextBlock VerticalAlignment="Center" Text="Token" />
+                  <PasswordBox Grid.Column="1" MinHeight="34" Padding="9,6"
+                               PasswordChanged="ReplacementToken_PasswordChanged"
+                               automation:AutomationProperties.Name="{Binding Name, StringFormat='Replacement token for {0}'}"
+                               automation:AutomationProperties.HelpText="Saved tokens are never displayed. Enter a new token, then choose Replace." />
+                  <Button Grid.Column="2" Margin="7,0,0,0" Command="{Binding ReplaceTokenCommand}" Content="Replace" />
+                  <Button Grid.Column="3" Margin="7,0,0,0" Command="{Binding ClearTokenCommand}" Content="Clear" />
+                  <TextBlock Grid.Column="4" Margin="12,0,0,0" VerticalAlignment="Center"
+                             FontSize="12" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding TokenStatus}" />
+                </Grid>
+
+                <Grid Margin="0,8,0,0">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="70" /><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /><ColumnDefinition Width="240" /><ColumnDefinition Width="240" /></Grid.ColumnDefinitions>
+                  <TextBlock VerticalAlignment="Center" Text="Proxy" />
+                  <TextBox Grid.Column="1" Style="{StaticResource SyncTextBox}"
+                           Text="{Binding ProxyText, UpdateSourceTrigger=LostFocus}"
+                           automation:AutomationProperties.Name="{Binding Name, StringFormat='Proxy override for {0}'}"
+                           automation:AutomationProperties.HelpText="An empty saved value explicitly clears the inherited proxy." />
+                  <Button Grid.Column="2" Margin="7,0,14,0" Command="{Binding UseInheritedProxyCommand}" Content="Use inherited" />
+                  <ComboBox Grid.Column="3" Margin="0,0,8,0" Style="{StaticResource SyncComboBox}"
+                            ItemsSource="{Binding BooleanChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                            SelectedValue="{Binding VerifySslChoice, UpdateSourceTrigger=PropertyChanged}"
+                            automation:AutomationProperties.Name="TLS verification override" />
+                  <ComboBox Grid.Column="4" Style="{StaticResource SyncComboBox}"
+                            ItemsSource="{Binding BooleanChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                            SelectedValue="{Binding UnsafeTlsChoice, UpdateSourceTrigger=PropertyChanged}"
+                            automation:AutomationProperties.Name="Unsafe TLS acknowledgement override" />
+                </Grid>
+                <TextBlock Margin="70,3,0,0" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}"
+                           Text="{Binding ProxySummary}" />
+
+                <Grid Margin="70,8,0,0"
+                      Visibility="{Binding ShowSidecarControls, Converter={StaticResource BooleanToVisibilityConverter}}">
+                  <Grid.ColumnDefinitions><ColumnDefinition Width="255" /><ColumnDefinition Width="300" /><ColumnDefinition Width="*" /></Grid.ColumnDefinitions>
+                  <StackPanel>
+                    <TextBlock FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Text="Battle-log enrichment" />
+                    <ComboBox Margin="0,3,8,0" Style="{StaticResource SyncComboBox}"
+                              ItemsSource="{Binding BooleanChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                              SelectedValue="{Binding BattlelogEnrichmentChoice, UpdateSourceTrigger=PropertyChanged}"
+                              automation:AutomationProperties.Name="Sidecar battle-log enrichment override" />
+                  </StackPanel>
+                  <StackPanel Grid.Column="1">
+                    <TextBlock FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}" Text="Fleet runtime mode" />
+                    <ComboBox Margin="0,3,8,0" Style="{StaticResource SyncComboBox}"
+                              ItemsSource="{Binding FleetRuntimeModeChoices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                              SelectedValue="{Binding FleetRuntimeModeChoice, UpdateSourceTrigger=PropertyChanged}"
+                              automation:AutomationProperties.Name="Sidecar fleet runtime mode" />
+                  </StackPanel>
+                  <TextBlock Grid.Column="2" Margin="8,15,0,0" VerticalAlignment="Center"
+                             FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
+                             Text="These controls exist only for the local Sidecar wire contract." TextWrapping="Wrap" />
+                </Grid>
+
+                <ItemsControl Margin="0,10,0,0" ItemsSource="{Binding Feeds}">
+                  <ItemsControl.ItemsPanel><ItemsPanelTemplate><WrapPanel /></ItemsPanelTemplate></ItemsControl.ItemsPanel>
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate DataType="{x:Type viewModels:SyncTargetFeedViewModel}">
+                      <Border Width="255" Margin="0,0,8,8" Padding="9"
+                              Background="{DynamicResource SurfaceMutedBrush}" CornerRadius="6">
+                        <Grid>
+                          <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="112" /></Grid.ColumnDefinitions>
+                          <StackPanel>
+                            <TextBlock FontWeight="SemiBold" Text="{Binding Label}" />
+                            <TextBlock Margin="0,3,0,0" FontSize="10" Foreground="{DynamicResource TextSecondaryBrush}" Text="{Binding EffectiveSummary}" />
+                          </StackPanel>
+                          <ComboBox Grid.Column="1" Style="{StaticResource SyncComboBox}"
+                                    ItemsSource="{Binding Choices}" DisplayMemberPath="Label" SelectedValuePath="Value"
+                                    SelectedValue="{Binding Choice, UpdateSourceTrigger=PropertyChanged}"
+                                    automation:AutomationProperties.Name="{Binding Label}" />
+                        </Grid>
+                      </Border>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
+            </Border>
+          </DataTemplate>
+        </ListBox.ItemTemplate>
+      </ListBox>
+    </Grid>
+
+    <Border Grid.Row="3" Margin="0,8,0,0" Padding="0,8,0,8" BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,1,0,0">
+      <Grid>
+        <Grid.ColumnDefinitions><ColumnDefinition Width="*" /><ColumnDefinition Width="Auto" /></Grid.ColumnDefinitions>
+        <StackPanel>
+          <TextBlock FontWeight="SemiBold" Text="{Binding PendingChangesText}" />
+          <TextBlock Margin="0,3,0,0" FontSize="11" Foreground="{DynamicResource TextSecondaryBrush}"
+                     Text="{Binding OperationStatus}" automation:AutomationProperties.LiveSetting="Polite" />
+        </StackPanel>
+        <StackPanel Grid.Column="1" Orientation="Horizontal">
+          <Button Margin="0,0,8,0" Command="{Binding DiscardCommand}" Content="Discard" />
+          <Button Command="{Binding SaveCommand}" Content="Save sync setup" ToolTip="{Binding SaveAvailability}"
+                  automation:AutomationProperties.HelpText="{Binding SaveAvailability}" />
+        </StackPanel>
+      </Grid>
+    </Border>
+  </Grid>
+</UserControl>

--- a/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml.cs
+++ b/windows-launcher/src/STFCCommunityMod.Launcher/Views/SyncView.xaml.cs
@@ -1,0 +1,21 @@
+using System.Windows;
+using System.Windows.Controls;
+using STFCCommunityMod.Launcher.ViewModels;
+
+namespace STFCCommunityMod.Launcher.Views;
+
+public partial class SyncView : UserControl
+{
+    public SyncView()
+    {
+        InitializeComponent();
+    }
+
+    private void ReplacementToken_PasswordChanged(object sender, RoutedEventArgs e)
+    {
+        if (sender is PasswordBox { DataContext: SyncTargetCardViewModel target } passwordBox)
+        {
+            target.SetReplacementToken(passwordBox.Password);
+        }
+    }
+}

--- a/windows-launcher/tests/STFCCommunityMod.Launcher.Tests/SyncWorkspaceViewModelTests.cs
+++ b/windows-launcher/tests/STFCCommunityMod.Launcher.Tests/SyncWorkspaceViewModelTests.cs
@@ -1,0 +1,255 @@
+using System.Text;
+using STFCCommunityMod.Launcher.Core;
+using STFCCommunityMod.Launcher.ViewModels;
+
+namespace STFCCommunityMod.Launcher.Tests;
+
+[TestClass]
+public sealed class SyncWorkspaceViewModelTests
+{
+    [TestMethod]
+    public void OpeningExistingTopologyDoesNotMutateSourceOrRevealSavedToken()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            # source must remain byte-identical
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "vip-secret-value"
+            """);
+        var before = File.ReadAllBytes(fixture.Path);
+
+        var viewModel = fixture.CreateViewModel();
+        var target = viewModel.Targets.Single();
+
+        CollectionAssert.AreEqual(before, File.ReadAllBytes(fixture.Path));
+        Assert.AreEqual("community", target.Name);
+        Assert.AreEqual("Saved token configured", target.TokenStatus);
+        Assert.IsFalse(target.TokenStatus.Contains("vip-secret-value", StringComparison.Ordinal));
+        Assert.IsFalse(target.ValidationSummary.Contains("vip-secret-value", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void AddSurfaceSupportsMixedTypedTargetsAndSidecarSingleton()
+    {
+        using var fixture = SyncFixture.Create("# empty\n");
+        var viewModel = fixture.CreateViewModel();
+
+        viewModel.AddSidecarCommand.Execute(null);
+        viewModel.NewTargetName = "majel-vip";
+        viewModel.AddMajelCommand.Execute(null);
+        viewModel.AddSpocksClubCommand.Execute(null);
+
+        Assert.AreEqual(3, viewModel.Targets.Count);
+        Assert.IsTrue(viewModel.Targets.Any(target => target.Name == "local-sidecar"));
+        Assert.IsTrue(viewModel.Targets.Any(target => target.Name == "majel-vip"));
+        Assert.IsTrue(viewModel.Targets.Any(target => target.Name == "spocksclub"));
+        Assert.IsFalse(viewModel.AddSidecarCommand.CanExecute(null));
+        Assert.AreEqual("Local Sidecar", viewModel.Targets.Single(target => target.Name == "local-sidecar").KindLabel);
+        Assert.AreEqual("Majel", viewModel.Targets.Single(target => target.Name == "majel-vip").KindLabel);
+    }
+
+    [TestMethod]
+    public void FeedOverrideShowsEffectiveValueAndProvenance()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            jobs = false
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var target = fixture.CreateViewModel().Targets.Single();
+        var jobs = target.Feeds.Single(feed => feed.Label == "Jobs");
+
+        Assert.AreEqual(SyncBooleanOverrideChoice.UseGlobal, jobs.Choice);
+        Assert.IsFalse(jobs.EffectiveEnabled);
+        StringAssert.Contains(jobs.EffectiveSummary, "inherited");
+
+        jobs.Choice = SyncBooleanOverrideChoice.Enabled;
+
+        Assert.IsTrue(jobs.EffectiveEnabled);
+        StringAssert.Contains(jobs.EffectiveSummary, "target override");
+    }
+
+    [TestMethod]
+    public void SecretReplacementRequiresExplicitActionAndDisplayRemainsOpaque()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "old-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        var target = viewModel.Targets.Single();
+        target.SetReplacementToken("new-secret");
+
+        Assert.IsFalse(viewModel.HasPendingChanges);
+        target.ReplaceTokenCommand.Execute(null);
+
+        Assert.IsTrue(viewModel.HasPendingChanges);
+        Assert.AreEqual("Saved token configured", viewModel.Targets.Single().TokenStatus);
+        Assert.IsFalse(viewModel.Targets.Single().TokenStatus.Contains("new-secret", StringComparison.Ordinal));
+        Assert.IsFalse(File.ReadAllText(fixture.Path).Contains("new-secret", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void TargetOverridesRepresentInheritedExplicitFalseAndExplicitClear()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            proxy = "http://global-proxy.example.invalid:8080"
+            verify_ssl = true
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var target = fixture.CreateViewModel().Targets.Single();
+
+        StringAssert.Contains(target.ProxySummary, "Inherited");
+        Assert.AreEqual(SyncBooleanOverrideChoice.UseGlobal, target.VerifySslChoice);
+
+        target.ProxyText = string.Empty;
+        target.VerifySslChoice = SyncBooleanOverrideChoice.Disabled;
+        target.UnsafeTlsChoice = SyncBooleanOverrideChoice.Enabled;
+
+        Assert.AreEqual("Explicitly cleared", target.ProxySummary);
+        Assert.AreEqual(SyncBooleanOverrideChoice.Disabled, target.VerifySslChoice);
+        Assert.AreEqual(SyncBooleanOverrideChoice.Enabled, target.UnsafeTlsChoice);
+    }
+
+    [TestMethod]
+    public void SidecarOnlyControlsAreExposedOnlyForSidecar()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sidecar.sync]
+            enabled = true
+            url = "http://127.0.0.1:43127/api/sidecar/ingest"
+            token = "fixture-sidecar-secret"
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-community-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        var sidecar = viewModel.Targets.Single(target => target.Name == "local-sidecar");
+        var community = viewModel.Targets.Single(target => target.Name == "community");
+
+        Assert.IsTrue(sidecar.ShowSidecarControls);
+        Assert.IsFalse(community.ShowSidecarControls);
+        sidecar.BattlelogEnrichmentChoice = SyncBooleanOverrideChoice.Enabled;
+        sidecar.FleetRuntimeModeChoice = "request_only";
+        Assert.AreEqual(SyncBooleanOverrideChoice.Enabled, sidecar.BattlelogEnrichmentChoice);
+        Assert.AreEqual("request_only", sidecar.FleetRuntimeModeChoice);
+    }
+
+    [TestMethod]
+    public void SiblingDraftBlocksSyncSaveWithoutDiscardingEitherDraft()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var siblingPending = false;
+        var viewModel = fixture.CreateViewModel(() => siblingPending);
+        viewModel.GlobalVerifySsl = false;
+        viewModel.GlobalUnsafeTls = true;
+        Assert.IsTrue(viewModel.CanSave);
+
+        siblingPending = true;
+
+        Assert.IsFalse(viewModel.CanSave);
+        Assert.IsTrue(viewModel.HasPendingChanges);
+        StringAssert.Contains(viewModel.SaveAvailability, "non-sync settings");
+    }
+
+    [TestMethod]
+    public void LegacyRootEditRequiresExplicitMigrationConfirmation()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-legacy-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        viewModel.Targets.Single().Url = "https://replacement.example.invalid/sync";
+
+        Assert.IsTrue(viewModel.HasLegacyRootTarget);
+        Assert.IsFalse(viewModel.CanSave);
+
+        viewModel.MigrateLegacyRoot = true;
+
+        Assert.IsTrue(viewModel.CanSave);
+    }
+
+    [TestMethod]
+    public async Task SaveUsesAtomicWorkspaceAndReloadsCommittedTopology()
+    {
+        using var fixture = SyncFixture.Create(
+            """
+            [sync]
+            jobs = true
+
+            [sync.targets.community]
+            url = "https://community.example.invalid/sync"
+            token = "fixture-secret"
+            """);
+        var viewModel = fixture.CreateViewModel();
+        viewModel.GlobalFeeds.Single(feed => feed.Label == "Jobs").IsEnabled = false;
+
+        viewModel.SaveCommand.Execute(null);
+        await WaitUntilAsync(() => !viewModel.HasPendingChanges);
+
+        StringAssert.Contains(File.ReadAllText(fixture.Path), "jobs = false");
+        Assert.IsTrue(File.Exists(fixture.Path + ".bak"));
+        StringAssert.Contains(viewModel.OperationStatus, "Restart the game");
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition)
+    {
+        for (var attempt = 0; attempt < 100 && !condition(); ++attempt)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.IsTrue(condition(), "The asynchronous view-model action did not finish.");
+    }
+
+    private sealed class SyncFixture : IDisposable
+    {
+        private SyncFixture(string path) => Path = path;
+        public string Path { get; }
+
+        public static SyncFixture Create(string contents)
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"stfc-launcher-sync-{Guid.NewGuid():N}.toml");
+            File.WriteAllText(path, contents, new UTF8Encoding(false));
+            return new(path);
+        }
+
+        public SyncWorkspaceViewModel CreateViewModel(Func<bool>? siblingPending = null) =>
+            new(() => Path, new TomlConfigurationRepository(), siblingPending);
+
+        public void Dispose()
+        {
+            foreach (var path in new[] { Path, Path + ".bak" })
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #226
Completes the implementation slices for #221

## Summary
- promote Data Sync into a dedicated typed WPF workspace
- separate global defaults from virtualized target cards for Sidecar, Majel, provider presets, and custom community instances
- expose inherited/on/off/value/clear provenance, effective feeds, Sidecar-only controls, validation, and explicit legacy migration
- keep saved tokens opaque with unchanged/replace/clear intent
- coordinate ordinary settings and sync drafts so two optimistic baselines cannot race
- extend packaged UI Automation with live and disposable TOML integrity checks
- retain one public `STFCCommunityMod.Launcher.Setup.exe` install artifact

## Validation
- 275 launcher tests passed (263 core + 12 WPF)
- 21 schema-contract tests passed; generated schema current at 333 settings
- warning-free Windows Release solution build and clean `dotnet format --verify-no-changes`
- Windows native release build passed
- packaged UI Automation passed against the live manual configuration without mutation
- packaged UI Automation passed against a disposable mixed-target fixture; the real launcher selection was restored byte-for-byte
- one-file setup inspection passed; setup output contains only `STFCCommunityMod.Launcher.Setup.exe`
- `git diff --check` passed