### PR TITLE
Stop reusing stale zoom scene pointers after server transfer

### DIFF
--- a/mods/src/patches/parts/zoom.cc
+++ b/mods/src/patches/parts/zoom.cc
@@ -50,9 +50,9 @@ namespace
 {
 constexpr HookDescriptor kPlanetViewUtilsCameraZoomedEventHandlerHook{
     "PlanetViewUtils.CameraZoomedEventHandler",
-    "Re-apply backdrop presentation and trigger flat-renderable scaling after system zoom events.",
+    "Trigger flat-renderable scaling after system zoom events.",
     {"Assembly-CSharp", "Digit.Prime.Navigation", "PlanetViewUtils", "CameraZoomedEventHandler"},
-    "System-view border suppression can regress after zoom changes."};
+    "System-view backdrop scaling can regress after zoom changes."};
 
 constexpr HookDescriptor kPlanetViewUtilsGetFlatRenderableHook{
     "PlanetViewUtils.get_FlatRenderable",
@@ -169,9 +169,7 @@ vec3 GetMouseWorldPos(void *cam, vec3 *pos)
 auto do_default_zoom = false;
 
 static float           s_expectedScale = 0.0f;
-static void           *s_cachedFR      = nullptr;
 static void           *s_lastScaledFR  = nullptr;
-static NavigationZoom *s_navZoom       = nullptr;
 
 inline void SetSceneCameraFarClip(NavigationZoom *zoom, float farClipPlane)
 {
@@ -201,7 +199,6 @@ void ApplySystemZoomRange(NavigationZoom *zoom, const float radius)
   const auto ratio                 = configured_maximum / radius;
   zoom->_farRatioSystemNormal      = 0.55f * ratio;
   zoom->_farRatioSystemExtended    = ratio;
-  s_navZoom                        = zoom;
 }
 
 void EnsureSystemZoomRange(NavigationZoom *zoom)
@@ -437,15 +434,6 @@ void PlanetViewUtils_CameraZoomedEventHandler_Hook(auto original, PlanetViewUtil
   if (_this) {
     _this->GetFlatRenderable();
   }
-
-  if (!s_navZoom || !s_navZoom->_sceneCamera) {
-    return;
-  }
-
-  const auto clear_flags = s_navZoom->_sceneCamera->clearFlags;
-  if (clear_flags >= 0 && clear_flags <= 4 && clear_flags != 2) {
-    SetSceneCameraPresentation(s_navZoom);
-  }
 }
 
 // ─── View Parameter / Depth Hooks ──────────────────────────────────────────
@@ -521,9 +509,6 @@ void NavigationZoom_SetDepth_Hook(auto original, NavigationZoom *_this, NodeDept
     original(_this, depth);
     SetSceneCameraPresentation(_this);
     do_default_zoom = true;
-    if (s_cachedFR) {
-      ScaleFR(s_cachedFR);
-    }
   } else {
     original(_this, depth);
   }
@@ -536,7 +521,6 @@ void *PlanetViewUtils_get_FlatRenderable_Hook(auto original, PlanetViewUtils *_t
     return fr;
   }
 
-  s_cachedFR = fr;
   ScaleFR(fr);
   return fr;
 }


### PR DESCRIPTION
## What changed

- Stop retaining `NavigationZoom` and flat-renderable scene objects in process-lifetime raw-pointer caches.
- Keep the camera-zoom event hook scoped to its current `PlanetViewUtils` instance.
- Continue scaling the current flat renderable through the existing accessor hook.
- Leave camera presentation updates on hooks that receive the active `NavigationZoom` instance.

## Root cause

An Incursions server transfer replaces the navigation scene. The zoom patch kept `s_navZoom` and `s_cachedFR` after that scene was destroyed. Those pointers could remain non-null but invalid.

The captured crash was a `0xc0000005` access violation in `VERSION.dll`, resolving directly to `PlanetViewUtils_CameraZoomedEventHandler_Hook` while reading `s_navZoom->_sceneCamera->clearFlags`.

## Scope

This is a bounded stale-pointer mitigation. It removes the two known process-lifetime scene-object caches and their dereference paths; it does not claim that every possible Incursions or Arenas transfer crash is resolved.

## Impact

The first system view after a server transfer can no longer dereference navigation objects through these two caches. Existing zoom ranges, presets, camera presentation, and backdrop scaling remain on active-instance hook paths.

## Validation

- Rebased cleanly onto current `main`
- `git diff --check`
- Full test suite: 347 tests and 4,433 assertions passed
- Windows x64 release build
- Built and deployed DLL hashes match
- Fresh game/sidecar cycle completed with no new post-boot errors
- Zoom hook audit: 5 installed, 0 failed
- Exact Incursions/Arenas transfer reproduction remains pending until the event is available again