### PR TITLE
Publish Battle Bridge producer groundwork

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,18 +108,27 @@ jobs:
       - name: Test
         run: |
           node --test scripts/test_config_schema.mjs
+          node --test scripts/test_battle_bridge_producer_contract.mjs
           node scripts/generate_config_schema.mjs --check
           xmake build stfc-mod-tests
           xmake run stfc-mod-tests
 
       - name: Package
-        run: mv build/windows/x64/release/stfc-community-mod.dll version.dll
+        shell: pwsh
+        run: |
+          Move-Item build/windows/x64/release/stfc-community-mod.dll version.dll
+          node scripts/generate_battle_bridge_runtime_manifest.mjs `
+            --dll version.dll `
+            --output stfc-runtime-manifest.json `
+            --source-revision ${{ github.sha }}
 
       - name: Upload
         uses: actions/upload-artifact@v7
         with:
           name: ${{ startsWith(github.ref, 'refs/tags/v') && 'stfc-community-mod-unsigned' || 'stfc-community-mod' }}
-          path: version.dll
+          path: |
+            version.dll
+            stfc-runtime-manifest.json
           if-no-files-found: error
 
   launcher-win:
@@ -286,6 +295,14 @@ jobs:
             }
           }
 
+      - name: Bind runtime capability manifest to signed DLL
+        shell: pwsh
+        run: |
+          node scripts/generate_battle_bridge_runtime_manifest.mjs `
+            --dll "${{ runner.temp }}/stfc-community-mod/version.dll" `
+            --output "${{ runner.temp }}/stfc-community-mod/stfc-runtime-manifest.json" `
+            --source-revision ${{ github.sha }}
+
       - name: Package signed launcher
         shell: pwsh
         run: |
@@ -347,7 +364,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: stfc-community-mod
-          path: ${{ runner.temp }}/stfc-community-mod/version.dll
+          path: |
+            ${{ runner.temp }}/stfc-community-mod/version.dll
+            ${{ runner.temp }}/stfc-community-mod/stfc-runtime-manifest.json
           if-no-files-found: error
 
       - name: Upload signed Windows launcher

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,7 +76,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y zstd
           mkdir -p stfc-community-mod-windows-x64
-          tar -cf - -C stfc-community-mod version.dll \
+          tar -cf - -C stfc-community-mod version.dll stfc-runtime-manifest.json \
             | zstd -19 -T0 -o stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst
           sha256sum stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \
             | awk '{print $1}' \
@@ -85,10 +85,12 @@ jobs:
       - name: Prepare release assets
         run: |
           cp stfc-community-mod/version.dll version.dll
+          cp stfc-community-mod/stfc-runtime-manifest.json stfc-runtime-manifest.json
           cp stfc-community-mod.zip stfc-community-mod-${{ github.ref_name }}.zip
           test -f stfc-community-mod-launcher-win-x64/stfc-community-mod-launcher-win-x64.zip
           test -f stfc-community-mod-launcher-win-x64/setup/STFCCommunityMod.Launcher.Setup.exe
           sha256sum version.dll \
+            stfc-runtime-manifest.json \
             stfc-community-mod.zip \
             stfc-community-mod-${{ github.ref_name }}.zip \
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \
@@ -170,6 +172,7 @@ jobs:
         run: |
           gh release upload "${{ github.ref_name }}" \
             version.dll \
+            stfc-runtime-manifest.json \
             stfc-community-mod.zip \
             stfc-community-mod-${{ github.ref_name }}.zip \
             stfc-community-mod-windows-x64/stfc-community-mod-windows-x64.tar.zst \

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ current sidecar/Majel proof path has working local projection reads.
   transitions.
 - Remaining weirdness is documented rather than promoted into a new roadmap:
   packaged Fleet-page live-update still wants an explicit operator smoke
-  record, reconnect/stale-state notes belong in Companion QA, and oversized
-  `battlelogs_realtime` payloads remain a separate bug.
+  record, and reconnect/stale-state notes belong in Companion QA. Raw battle
+  journals and realtime captures are intentionally rejected for Majel targets;
+  canonical local delivery remains bounded and legacy delivery is unchanged.
 - This is maintenance/harvest mode, not a new roadmap. The useful chain
   exists, the diagnostics are in place, and follow-on work such as durable
   outbox, cloud auth/token lifecycle, and storage generalization is

--- a/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
+++ b/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
@@ -1,0 +1,50 @@
+# Battle Bridge Producer Contract
+
+This repository contains producer-side groundwork for three portable Battle
+Bridge runtime capabilities:
+
+- `ingest.stfc-sidecar.v1` — authenticated, bounded local ingest using outer
+  protocol `stfc.sidecar.ingest.v1`;
+- `battle.capture.v1` — canonical Battle capture using
+  `stfc.battle.capture.v1`; and
+- `fleet.runtime-snapshot.v1` — Fleet runtime observations using
+  `stfc.fleet.runtime_snapshot.v1`.
+
+The machine-readable contract is
+[`battle-bridge-producer-capabilities.v1.json`](battle-bridge-producer-capabilities.v1.json).
+It pins the reviewed Sidecar golden-corpus inventory. After this work reaches a
+trusted CI or release build, that workflow emits `stfc-runtime-manifest.json`
+beside the exact `version.dll`. The manifest names the three producer
+declarations and binds them to the DLL's size, SHA-256, source commit, and
+numeric version.
+
+The runtime manifest is compatibility evidence, not authenticity, safety, or
+gameplay authorization. The current Bridge still uses its embedded provider
+manifest: it neither installs nor consumes this adjacent producer JSON. The
+first exact qualifying artifact can therefore exist only after a trusted
+workflow publishes one, and operational activation still requires a separate
+Bridge change for transactional installation, artifact binding, and adjacent
+manifest consumption after provider authentication. The wave-one
+current-release corpus remains unchanged with zero accepted runtime contracts.
+Another provider can publish any compatible subset without copying the
+Guffawaffle distribution ID.
+
+## Deliberate boundaries
+
+- Report, analytics, and catalog snapshot events remain source-observed only.
+  They are not advertised as Battle Bridge runtime capabilities.
+- Fleet alert evidence remains unproven because this producer has no matching
+  emitter. It is not advertised.
+- A disabled or incomplete `[sidecar.sync]` configuration starts no local
+  worker and performs no local HTTP request. Enabled hooks copy into a bounded
+  asynchronous queue; connect and request timeouts remain 2.5 and 8 seconds.
+- Canonical local Battle events are losslessly chunked above 256 KiB in 64 KiB
+  pieces. Legacy non-Majel battle delivery is unchanged. Majel targets reject
+  both `Battles` and `BattlelogsRealtime` before envelope construction, so raw
+  journals and capture tokens cannot enter a Majel request body and partial
+  capture groups cannot be lost to its bounded queue.
+- Repeated JSONL bounded-suffix warnings are coalesced to at most one report per
+  minute, with the next report carrying the suppressed count.
+
+No command channel, cloud destination, gameplay automation, or persistent
+secret is introduced by this contract.

--- a/docs/CONFIG_SYSTEM_RETHINK.md
+++ b/docs/CONFIG_SYSTEM_RETHINK.md
@@ -346,8 +346,8 @@ For non-sidecar external sync targets, the current nested table pattern is good 
 [sync.targets.majel]
 url = "https://majel.example.test/api/ingest/events"
 token = "..."
-battlelogs_realtime = true
-battlelogs = false
+battlelogs_realtime = false # Raw realtime battle capture is not supported in Majel mode.
+battlelogs = false # Raw battle journals are not supported in Majel mode.
 ```
 
 Local sidecar delivery should move to its own root namespace instead of staying under `[sync.targets.*]`:

--- a/docs/MAJEL_INGEST_CONTRACT.md
+++ b/docs/MAJEL_INGEST_CONTRACT.md
@@ -11,6 +11,8 @@ dedicated `[sidecar.*]` namespace and is no longer configured through sync targe
 - `mode = "majel"`: sends a Majel-safe ingest envelope directly to Majel with `Authorization: Bearer <token>`.
 
 `mode = "sidecar_broker"` is now invalid in the config parser. Local sidecar settings belong under `[sidecar.sync]`.
+Omitting `mode` preserves legacy compatibility. An explicit mode must be exactly lowercase `legacy` or `majel`; any
+other value rejects the complete target rather than falling back to raw-capable Legacy delivery.
 Direct Majel mode is best-effort from the mod process. Neither supported mode enables callbacks, remote settings
 writes, or gameplay commands.
 
@@ -44,7 +46,10 @@ Payload rules:
 - Existing legacy sync arrays are wrapped as `stfc.sync.delta_batch.v1` with `syncType` and `items`.
 - Fleet preset slot deltas also emit Majel-only `stfc.fleet.assignment_snapshot.v1` events.
 - Fleet runtime snapshots emit as `stfc.fleet.runtime_snapshot.v1`.
-- Battle sync targets map to `stfc.battle.summary.v1` until a narrower battle projection is split out.
+- `Battles` and `BattlelogsRealtime` are not accepted by Majel targets. This prevents raw journals and capture tokens
+  from entering a Majel request body under a misleading summary label. Configured `battlelogs = true` or
+  `battlelogs_realtime = true` values are reported and normalized to `false` in the runtime snapshot. Legacy non-Majel
+  delivery and the canonical local Sidecar Battle stream are unchanged.
 - Majel-envelope targets also receive `stfc.mod.capability_snapshot.v1` once at sync startup.
 
 ## Privacy

--- a/docs/battle-bridge-producer-capabilities.v1.json
+++ b/docs/battle-bridge-producer-capabilities.v1.json
@@ -1,0 +1,52 @@
+{
+  "contractSchema": "stfc.battle-bridge.producer-capabilities.v1",
+  "distributionId": "guffawaffle.stfc-community-mod",
+  "activationStatus": "producer-groundwork",
+  "capabilityEvidencePin": {
+    "schema": "stfc.battle-bridge.capability-evidence-pin.v1",
+    "sha256": "aa6b738eab60a3bcb17a0c37cfcd533198096dd05d98abfd4a43308e891a9cc9"
+  },
+  "runtimeCapabilities": [
+    {
+      "id": "ingest.stfc-sidecar.v1",
+      "schema": "stfc.sidecar.ingest.v1",
+      "evidenceStatus": "payload-fixture-only",
+      "payloadKinds": ["battle.events", "fleet.runtime", "transport.chunk"]
+    },
+    {
+      "id": "battle.capture.v1",
+      "schema": "stfc.battle.capture.v1",
+      "evidenceStatus": "payload-fixture-only",
+      "envelopeKind": "battle.events"
+    },
+    {
+      "id": "fleet.runtime-snapshot.v1",
+      "schema": "stfc.fleet.runtime_snapshot.v1",
+      "evidenceStatus": "payload-fixture-only",
+      "envelopeKind": "fleet.runtime"
+    }
+  ],
+  "sourceObservedOnly": [
+    {"id": "battle.report.v0", "schema": "stfc.sidecar.battle-report.v0"},
+    {"id": "battle.analytics.v0", "schema": "stfc.battle.analytics.v0"},
+    {"id": "battle.catalog-snapshot.v0", "schema": "stfc.catalog.snapshot.v0"}
+  ],
+  "unproven": [
+    {"id": "fleet.alert-evidence.v0", "schema": "stfc.fleet.alert_evidence.v0"}
+  ],
+  "transportPolicy": {
+    "majelBattlelogs": "unsupported",
+    "majelBattlelogsRealtime": "unsupported",
+    "legacyBattlelogs": "unchanged",
+    "legacyBattlelogsRealtime": "unchanged",
+    "canonicalLocalBattleStream": "unchanged"
+  },
+  "bounds": {
+    "localQueueDepth": 128,
+    "localChunkThresholdBytes": 262144,
+    "localChunkDataBytes": 65536,
+    "localConnectTimeoutMs": 2500,
+    "localRequestTimeoutMs": 8000,
+    "warningCoalescingIntervalMs": 60000
+  }
+}

--- a/docs/windows-launcher/config-schema.guffawaffle.v1.json
+++ b/docs/windows-launcher/config-schema.guffawaffle.v1.json
@@ -17097,7 +17097,7 @@
     {
       "path": "sync.battlelogs",
       "title": "Battlelogs",
-      "description": "Sync battle-log reports.",
+      "description": "Legacy-only battle journal export; Majel disables this setting.",
       "category": "sync",
       "control": "scalar",
       "valueType": {
@@ -17121,25 +17121,25 @@
       },
       "presentation": {
         "label": "Battle-log reports",
-        "help": "Shares completed battle reports with configured sync targets.",
+        "help": "Shares battle journals with legacy sync targets. Majel targets disable this setting.",
         "group": "Shared data",
         "searchTerms": [
           "sync.battlelogs",
           "Battlelogs",
-          "Sync battle-log reports.",
+          "Legacy-only battle journal export; Majel disables this setting.",
           "sync",
           "Shared data"
         ],
         "editorWidth": "compact",
         "applyTiming": "Next launch",
         "accessibleName": "Battle-log reports",
-        "accessibleHelp": "Shares completed battle reports with configured sync targets. Applies: Next launch."
+        "accessibleHelp": "Shares battle journals with legacy sync targets. Majel targets disable this setting. Applies: Next launch."
       }
     },
     {
       "path": "sync.battlelogs_realtime",
       "title": "Battlelogs Realtime",
-      "description": "Export canonical battle feed events to realtime ingest targets.",
+      "description": "Legacy-only battle capture export; Majel disables this setting.",
       "category": "sync",
       "control": "scalar",
       "valueType": {
@@ -17163,19 +17163,19 @@
       },
       "presentation": {
         "label": "Real-time battle events",
-        "help": "Shares battle events with configured sync targets as they occur.",
+        "help": "Shares battle captures with legacy sync targets as they occur. Majel targets disable this setting.",
         "group": "Shared data",
         "searchTerms": [
           "sync.battlelogs_realtime",
           "Battlelogs Realtime",
-          "Export canonical battle feed events to realtime ingest targets.",
+          "Legacy-only battle capture export; Majel disables this setting.",
           "sync",
           "Shared data"
         ],
         "editorWidth": "compact",
         "applyTiming": "Next launch",
         "accessibleName": "Real-time battle events",
-        "accessibleHelp": "Shares battle events with configured sync targets as they occur. Applies: Next launch."
+        "accessibleHelp": "Shares battle captures with legacy sync targets as they occur. Majel targets disable this setting. Applies: Next launch."
       }
     },
     {
@@ -17841,7 +17841,7 @@
     {
       "path": "sync.targets.*.battlelogs",
       "title": "Battlelogs",
-      "description": "Sync battle-log reports.",
+      "description": "Legacy-only battle journal export; Majel disables this setting.",
       "category": "sync",
       "control": "scalar",
       "valueType": {
@@ -17865,24 +17865,24 @@
       },
       "presentation": {
         "label": "Battle logs",
-        "help": "Sync battle-log reports.",
+        "help": "Legacy-only battle journal export; Majel disables this setting.",
         "group": "Sync",
         "searchTerms": [
           "sync.targets.*.battlelogs",
           "Battlelogs",
-          "Sync battle-log reports.",
+          "Legacy-only battle journal export; Majel disables this setting.",
           "sync"
         ],
         "editorWidth": "compact",
         "applyTiming": "Next launch",
         "accessibleName": "Battle logs",
-        "accessibleHelp": "Sync battle-log reports. Applies: Next launch."
+        "accessibleHelp": "Legacy-only battle journal export; Majel disables this setting. Applies: Next launch."
       }
     },
     {
       "path": "sync.targets.*.battlelogs_realtime",
       "title": "Battlelogs Realtime",
-      "description": "Export canonical battle feed events to realtime ingest targets.",
+      "description": "Legacy-only battle capture export; Majel disables this setting.",
       "category": "sync",
       "control": "scalar",
       "valueType": {
@@ -17906,18 +17906,18 @@
       },
       "presentation": {
         "label": "Battle logs real-time",
-        "help": "Export canonical battle feed events to realtime ingest targets.",
+        "help": "Legacy-only battle capture export; Majel disables this setting.",
         "group": "Sync",
         "searchTerms": [
           "sync.targets.*.battlelogs_realtime",
           "Battlelogs Realtime",
-          "Export canonical battle feed events to realtime ingest targets.",
+          "Legacy-only battle capture export; Majel disables this setting.",
           "sync"
         ],
         "editorWidth": "compact",
         "applyTiming": "Next launch",
         "accessibleName": "Battle logs real-time",
-        "accessibleHelp": "Export canonical battle feed events to realtime ingest targets. Applies: Next launch."
+        "accessibleHelp": "Legacy-only battle capture export; Majel disables this setting. Applies: Next launch."
       }
     },
     {
@@ -18169,7 +18169,7 @@
     {
       "path": "sync.targets.*.mode",
       "title": "Mode",
-      "description": "Outbound sync contract used by this target.",
+      "description": "Outbound contract: legacy or majel. Omission defaults to legacy; invalid explicit values reject the target.",
       "category": "sync",
       "control": "scalar",
       "valueType": {
@@ -18197,18 +18197,18 @@
       },
       "presentation": {
         "label": "Mode",
-        "help": "Outbound sync contract used by this target.",
+        "help": "Outbound contract: legacy or majel. Omission defaults to legacy; invalid explicit values reject the target.",
         "group": "Sync",
         "searchTerms": [
           "sync.targets.*.mode",
           "Mode",
-          "Outbound sync contract used by this target.",
+          "Outbound contract: legacy or majel. Omission defaults to legacy; invalid explicit values reject the target.",
           "sync"
         ],
         "editorWidth": "standard",
         "applyTiming": "Next launch",
         "accessibleName": "Mode",
-        "accessibleHelp": "Outbound sync contract used by this target. Applies: Next launch."
+        "accessibleHelp": "Outbound contract: legacy or majel. Omission defaults to legacy; invalid explicit values reject the target. Applies: Next launch."
       }
     },
     {

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -899,7 +899,8 @@ action_queue_probe_files = 3
 # The url of the server to send data to
 # url = ""
 
-# Outbound contract for this target: legacy or majel.
+# Outbound contract for this target: exactly legacy or majel. Omission defaults
+# to legacy; invalid explicit values reject the target.
 # mode = "legacy"
 
 # Optional direct Majel target. This sends one-way cloud-safe ingest envelopes
@@ -910,8 +911,8 @@ action_queue_probe_files = 3
 # token = ""
 # url = "https://majel.example.test/api/ingest/events"
 # mode = "majel"
-# battlelogs = false
-# battlelogs_realtime = true
+# battlelogs = false          # Raw battle journals are not supported by Majel targets.
+# battlelogs_realtime = false # Raw battle captures are not supported by Majel targets.
 # Fleet runtime is sidecar-only. Configure [sidecar.sync].fleet_runtime instead.
 
 #  <[=============================================================================================================]>

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -18,6 +18,7 @@
 #include "patches/mapkey.h"
 #include "patches/mod_impact_monitor.h"
 #include "patches/notification_policy.h"
+#include "patches/sync_transport_policy.h"
 #include "prime/KeyCode.h"
 #include "str_utils.h"
 #include "testable_functions.h"
@@ -871,19 +872,6 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
     return;
   }
 
-  const auto parse_mode = [](const std::string_view            target_section,
-                             const std::optional<std::string>& value) -> SyncTargetConfig::Mode {
-    if (!value.has_value() || value->empty() || *value == "legacy") {
-      return SyncTargetConfig::Mode::Legacy;
-    }
-    if (*value == "majel") {
-      return SyncTargetConfig::Mode::Majel;
-    }
-
-    spdlog::warn("Invalid target [{}] mode '{}'; using legacy.", target_section, *value);
-    return SyncTargetConfig::Mode::Legacy;
-  };
-
   for (const auto& [target_key, target_config] : *targets) {
     if (!target_config.is_table()) {
       continue;
@@ -904,10 +892,17 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
         continue;
       }
 
+      const auto mode = http::ParseSyncTargetMode(values.contains("mode"), values["mode"].value<std::string>());
+      if (!mode) {
+        spdlog::warn("Skipping sync target with invalid explicit mode; mode must be exactly 'legacy' or 'majel'. "
+                     "Omit mode to use legacy.");
+        continue;
+      }
+
       target.url        = url.value();
       target.token      = token.value();
       target.proxy      = proxy.value_or(defaults.proxy);
-      target.mode       = parse_mode(target_section, values["mode"].value<std::string>());
+      target.mode       = *mode;
       target.verify_ssl = values["verify_ssl"].value<bool>().value_or(defaults.verify_ssl);
       target.allow_unsafe_tls_without_certificate_validation =
           values["allow_unsafe_tls_without_certificate_validation"].value<bool>().value_or(
@@ -932,6 +927,14 @@ void read_sync_targets(toml::table& config, toml::table& new_config,
                      "[sidecar.sync].fleet_runtime instead.",
                      target_section);
         target.*opt.option = false;
+      } else if (opt.type == SyncConfig::Type::Battles || opt.type == SyncConfig::Type::BattlelogsRealtime) {
+        const auto normalized = http::NormalizeSyncTargetTypeForMode(target.mode, opt.type, target.*opt.option);
+        if (target.*opt.option && !normalized) {
+          spdlog::warn("Ignoring unsupported {}.{}=true. Raw battle payloads cannot be sent to Majel; configure the "
+                       "local [sidecar.sync] battle pipeline instead.",
+                       target_section, opt.option_str);
+        }
+        target.*opt.option = normalized;
       }
       parsed_target.insert(opt.option_str, target.*opt.option);
     }

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -403,8 +403,8 @@ namespace Sync
 {
   // Per-category defaults — each maps to a [sync] TOML key.
   // Individual [sync.targets.<name>] sections can override these.
-  constexpr bool battlelogs          = true;  ///< Sync battle-log reports.
-  constexpr bool battlelogs_realtime = false; ///< Export canonical battle feed events to realtime ingest targets.
+  constexpr bool battlelogs          = true;  ///< Legacy-only battle journal export; Majel disables this setting.
+  constexpr bool battlelogs_realtime = false; ///< Legacy-only battle capture export; Majel disables this setting.
   constexpr bool buffs               = true;  ///< Sync buff / Emerald Chain data.
   constexpr bool buildings           = true;  ///< Sync station module data.
   constexpr bool fleet_runtime       = false; ///< Sync low-rate fleet-bar runtime state.

--- a/mods/src/patches/sync_battle_logs.cc
+++ b/mods/src/patches/sync_battle_logs.cc
@@ -11,6 +11,7 @@
 #include "patches/battle_log_decoder.h"
 #include "patches/sidecar_local_ingest.h"
 #include "patches/sync_transport.h"
+#include "patches/sync_transport_policy.h"
 #include "str_utils.h"
 #include "testable_functions.h"
 
@@ -130,6 +131,32 @@ static std::mutex                   battle_feed_file_mtx;
 static constexpr char kBattleFeedFile[] = "community_patch_battle_feed.jsonl";
 static constexpr auto kBattleFeedHardMaxBytes = static_cast<std::uintmax_t>(10 * 1024 * 1024);
 static constexpr auto kBattleFeedRetentionReadMaxBytes = static_cast<std::uintmax_t>(5 * 1024 * 1024);
+static constexpr int64_t kBattleFeedWarningIntervalMs = 60'000;
+static http::WarningCoalescingState s_battle_feed_suffix_warning;
+static std::mutex                   s_battle_feed_warning_mtx;
+
+static void warn_bounded_battle_feed_suffix(const std::filesystem::path& feed_path,
+                                            const std::uintmax_t          feed_size)
+{
+  const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now().time_since_epoch())
+                          .count();
+  http::WarningCoalescingDecision decision;
+  {
+    std::lock_guard lock(s_battle_feed_warning_mtx);
+    decision = http::ObserveWarning(s_battle_feed_suffix_warning, now_ms, kBattleFeedWarningIntervalMs);
+  }
+
+  if (!decision.emit) {
+    return;
+  }
+
+  spdlog::warn("Sidecar feed {} is {} bytes; retention will parse only the newest {} bytes to bound memory use{}",
+               feed_path.string(), feed_size, kBattleFeedRetentionReadMaxBytes,
+               decision.suppressed > 0
+                   ? STR_FORMAT(" ({} similar warning(s) suppressed since the previous report)", decision.suppressed)
+                   : "");
+}
 
 struct RetainedBattleFeedGroup {
   std::string              key;
@@ -249,8 +276,7 @@ static bool seek_to_bounded_battle_feed_suffix(std::ifstream& input, const std::
   }
 
   const auto suffix_offset = feed_size - kBattleFeedRetentionReadMaxBytes;
-  spdlog::warn("Sidecar feed {} is {} bytes; retention will parse only the newest {} bytes to bound memory use",
-               feed_path.string(), feed_size, kBattleFeedRetentionReadMaxBytes);
+  warn_bounded_battle_feed_suffix(feed_path, feed_size);
 
   if (suffix_offset == 0) {
     input.seekg(0, std::ios::beg);

--- a/mods/src/patches/sync_capability_snapshot.cc
+++ b/mods/src/patches/sync_capability_snapshot.cc
@@ -71,13 +71,7 @@ void queue_mod_capability_snapshot()
       .source_version = VER_RUNTIME_VERSION_STR,
       .platform       = current_platform_name(),
       .targets        = std::move(targets),
-      .supported_schemas =
-          {
-              "stfc.mod.capability_snapshot.v1",
-              "stfc.sync.delta_batch.v1",
-              "stfc.fleet.assignment_snapshot.v1",
-              "stfc.battle.summary.v1",
-          },
+      .supported_schemas = http::MajelAdvertisedSchemas(),
   });
 
   queue_data(SyncConfig::Type::ModCapabilities, snapshot, true);

--- a/mods/src/patches/sync_transport_policy.cc
+++ b/mods/src/patches/sync_transport_policy.cc
@@ -1,5 +1,7 @@
 #include "patches/sync_transport_policy.h"
 
+#include <algorithm>
+#include <stdexcept>
 #include <utility>
 
 namespace
@@ -26,9 +28,6 @@ std::string schema_for_sync_type(const SyncConfig::Type type, const nlohmann::js
   }
 
   switch (type) {
-    case SyncConfig::Type::Battles:
-    case SyncConfig::Type::BattlelogsRealtime:
-      return "stfc.battle.summary.v1";
     case SyncConfig::Type::FleetAssignments:
       return "stfc.fleet.assignment_snapshot.v1";
     case SyncConfig::Type::FleetRuntime:
@@ -80,6 +79,27 @@ ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSna
 bool SyncTargetUsesMajelEnvelope(const SyncTargetConfig::Mode mode)
 { return mode == SyncTargetConfig::Mode::Majel; }
 
+std::optional<SyncTargetConfig::Mode> ParseSyncTargetMode(const bool explicitly_configured,
+                                                          const std::optional<std::string>& value)
+{
+  if (!explicitly_configured) {
+    return SyncTargetConfig::Mode::Legacy;
+  }
+  if (value == "legacy") {
+    return SyncTargetConfig::Mode::Legacy;
+  }
+  if (value == "majel") {
+    return SyncTargetConfig::Mode::Majel;
+  }
+  return std::nullopt;
+}
+
+bool NormalizeSyncTargetTypeForMode(const SyncTargetConfig::Mode mode, const SyncConfig::Type type, const bool enabled)
+{
+  const auto is_battle_payload = type == SyncConfig::Type::Battles || type == SyncConfig::Type::BattlelogsRealtime;
+  return enabled && !(is_battle_payload && SyncTargetUsesMajelEnvelope(mode));
+}
+
 bool SyncTargetAcceptsType(const SyncTargetConfig& target_config, const SyncConfig::Type type)
 {
   if (type == SyncConfig::Type::ModCapabilities) {
@@ -89,6 +109,14 @@ bool SyncTargetAcceptsType(const SyncTargetConfig& target_config, const SyncConf
     return SyncTargetUsesMajelEnvelope(target_config.mode) && target_config.slots;
   }
   if (type == SyncConfig::Type::FleetRuntime) {
+    return false;
+  }
+  if (type == SyncConfig::Type::Battles || type == SyncConfig::Type::BattlelogsRealtime) {
+    for (const auto& option : SyncOptions) {
+      if (option.type == type) {
+        return NormalizeSyncTargetTypeForMode(target_config.mode, type, target_config.*option.option);
+      }
+    }
     return false;
   }
 
@@ -116,6 +144,15 @@ std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig
   }
 
   return headers;
+}
+
+std::vector<std::string> MajelAdvertisedSchemas()
+{
+  return {
+      "stfc.mod.capability_snapshot.v1",
+      "stfc.sync.delta_batch.v1",
+      "stfc.fleet.assignment_snapshot.v1",
+  };
 }
 
 nlohmann::json BuildModCapabilitySnapshot(const ModCapabilitySnapshotInput& input)
@@ -220,6 +257,10 @@ std::optional<nlohmann::json> BuildFleetAssignmentSnapshot(const nlohmann::json&
 
 nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input)
 {
+  if (input.sync_type == SyncConfig::Type::Battles || input.sync_type == SyncConfig::Type::BattlelogsRealtime) {
+    throw std::invalid_argument("raw battle payloads are not supported by Majel");
+  }
+
   const auto schema = schema_for_sync_type(input.sync_type, input.payload);
 
   return nlohmann::json{
@@ -235,5 +276,21 @@ nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input)
       {"classification", "cloud_private"},
       {"payload", payload_for_sync_type(input.sync_type, input.payload)},
   };
+}
+
+WarningCoalescingDecision ObserveWarning(WarningCoalescingState& state, const int64_t now_ms,
+                                         const int64_t interval_ms)
+{
+  const auto effective_interval = std::max<int64_t>(interval_ms, 0);
+  if (!state.last_emitted_at_ms || now_ms < *state.last_emitted_at_ms
+      || now_ms - *state.last_emitted_at_ms >= effective_interval) {
+    const auto suppressed = state.suppressed;
+    state.last_emitted_at_ms = now_ms;
+    state.suppressed = 0;
+    return {.emit = true, .suppressed = suppressed};
+  }
+
+  ++state.suppressed;
+  return {};
 }
 } // namespace http

--- a/mods/src/patches/sync_transport_policy.h
+++ b/mods/src/patches/sync_transport_policy.h
@@ -50,14 +50,30 @@ struct ModCapabilitySnapshotInput {
   std::vector<std::string>              supported_schemas;
 };
 
+struct WarningCoalescingState {
+  std::optional<int64_t> last_emitted_at_ms;
+  uint64_t               suppressed = 0;
+};
+
+struct WarningCoalescingDecision {
+  bool     emit = false;
+  uint64_t suppressed = 0;
+};
+
 [[nodiscard]] SyncTlsVerificationDecision DecideSyncTlsVerification(const SyncConfig& config);
 [[nodiscard]] ScopelySessionHeaders BuildScopelySessionHeaders(const headers::SessionHeaderSnapshot& snapshot,
                                                               std::string transaction_id);
 [[nodiscard]] bool SyncTargetUsesMajelEnvelope(SyncTargetConfig::Mode mode);
+[[nodiscard]] std::optional<SyncTargetConfig::Mode> ParseSyncTargetMode(bool explicitly_configured,
+                                                                        const std::optional<std::string>& value);
+[[nodiscard]] bool NormalizeSyncTargetTypeForMode(SyncTargetConfig::Mode mode, SyncConfig::Type type, bool enabled);
 [[nodiscard]] bool SyncTargetAcceptsType(const SyncTargetConfig& target_config, SyncConfig::Type type);
 [[nodiscard]] std::map<std::string, std::string> BuildSyncTargetHeaders(const SyncTargetConfig& target_config,
                                                                         std::string powered_by);
+[[nodiscard]] std::vector<std::string> MajelAdvertisedSchemas();
 [[nodiscard]] nlohmann::json BuildModCapabilitySnapshot(const ModCapabilitySnapshotInput& input);
 [[nodiscard]] std::optional<nlohmann::json> BuildFleetAssignmentSnapshot(const nlohmann::json& slot_delta);
 [[nodiscard]] nlohmann::json BuildMajelIngestEnvelope(const MajelIngestEnvelopeInput& input);
+[[nodiscard]] WarningCoalescingDecision ObserveWarning(WarningCoalescingState& state, int64_t now_ms,
+                                                        int64_t interval_ms);
 } // namespace http

--- a/scripts/config_presentation_overrides.mjs
+++ b/scripts/config_presentation_overrides.mjs
@@ -160,13 +160,13 @@ export const configPresentationOverrides = [
   {
     path: "sync.battlelogs",
     label: "Battle-log reports",
-    help: "Shares completed battle reports with configured sync targets.",
+    help: "Shares battle journals with legacy sync targets. Majel targets disable this setting.",
     group: "Shared data",
   },
   {
     path: "sync.battlelogs_realtime",
     label: "Real-time battle events",
-    help: "Shares battle events with configured sync targets as they occur.",
+    help: "Shares battle captures with legacy sync targets as they occur. Majel targets disable this setting.",
     group: "Shared data",
   },
   {

--- a/scripts/generate_battle_bridge_runtime_manifest.mjs
+++ b/scripts/generate_battle_bridge_runtime_manifest.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(scriptDirectory, "..");
+
+export function parseAuthoritativeProducerContract(raw) {
+  const containers = [];
+  for (let index = 0; index < raw.length; index += 1) {
+    const character = raw[index];
+    if (character === "{") {
+      containers.push(new Set());
+      continue;
+    }
+    if (character === "[") {
+      containers.push(null);
+      continue;
+    }
+    if (character === "}" || character === "]") {
+      containers.pop();
+      continue;
+    }
+    if (character !== "\"") {
+      continue;
+    }
+
+    const start = index;
+    for (index += 1; index < raw.length; index += 1) {
+      if (raw[index] === "\\") {
+        index += 1;
+      } else if (raw[index] === "\"") {
+        break;
+      }
+    }
+
+    let lookahead = index + 1;
+    while (/\s/u.test(raw[lookahead] ?? "")) {
+      lookahead += 1;
+    }
+    const keys = containers.at(-1);
+    if (raw[lookahead] === ":" && keys instanceof Set) {
+      const key = JSON.parse(raw.slice(start, index + 1));
+      if (keys.has(key)) {
+        throw new Error(`producer contract contains duplicate key: ${key}`);
+      }
+      keys.add(key);
+    }
+  }
+
+  return JSON.parse(raw);
+}
+
+export function readNumericRuntimeVersion(versionHeaderPath = path.join(repositoryRoot, "mods", "src", "version.h")) {
+  const versionHeader = readFileSync(versionHeaderPath, "utf8");
+  const parts = ["MAJOR", "MINOR", "REVISION", "PATCH"].map((part) => {
+    const match = versionHeader.match(new RegExp(`#define VERSION_${part}\\s+(\\d+)`));
+    if (!match) {
+      throw new Error(`missing VERSION_${part} in ${versionHeaderPath}`);
+    }
+    return match[1];
+  });
+  return parts.join(".");
+}
+
+export function buildBattleBridgeRuntimeManifest({
+  dllBytes,
+  sourceRevision,
+  contract,
+  runtimeVersion = readNumericRuntimeVersion(),
+}) {
+  if (!(dllBytes instanceof Uint8Array) || dllBytes.byteLength === 0) {
+    throw new Error("version.dll must be non-empty");
+  }
+  if (!/^[0-9a-f]{40}$/u.test(sourceRevision)) {
+    throw new Error("source revision must be a lowercase 40-character commit SHA");
+  }
+  if (contract?.contractSchema !== "stfc.battle-bridge.producer-capabilities.v1") {
+    throw new Error("unsupported Battle Bridge producer contract");
+  }
+
+  const runtimeCapabilities = contract.runtimeCapabilities.map((entry) => entry.id);
+  if (new Set(runtimeCapabilities).size !== runtimeCapabilities.length) {
+    throw new Error("producer contract contains duplicate runtime capability IDs");
+  }
+
+  return {
+    manifestSchema: 1,
+    distributionId: contract.distributionId,
+    runtimeVersion,
+    sourceRevision,
+    capabilities: ["settings.principal-taxonomy.v1", ...runtimeCapabilities],
+    settingsCatalog: {
+      schemaVersion: 1,
+      revision: "guffawaffle-taxonomy-2026-07-29",
+    },
+    producerContract: {
+      schema: contract.contractSchema,
+      capabilityEvidencePin: contract.capabilityEvidencePin,
+      runtimeCapabilities: contract.runtimeCapabilities,
+      artifact: {
+        fileName: "version.dll",
+        size: dllBytes.byteLength,
+        sha256: createHash("sha256").update(dllBytes).digest("hex"),
+      },
+      compatibilityEvidenceOnly: true,
+      operationalActivation: "requires-bridge-transactional-binding",
+    },
+  };
+}
+
+export function generateBattleBridgeRuntimeManifest({ dllPath, outputPath, sourceRevision }) {
+  const contract = parseAuthoritativeProducerContract(readFileSync(
+    path.join(repositoryRoot, "docs", "battle-bridge-producer-capabilities.v1.json"),
+    "utf8",
+  ));
+  const manifest = buildBattleBridgeRuntimeManifest({
+    dllBytes: readFileSync(dllPath),
+    sourceRevision,
+    contract,
+  });
+  writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  return manifest;
+}
+
+function parseArguments(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error("expected --dll, --output, and --source-revision values");
+    }
+    values.set(key, value);
+  }
+  return {
+    dllPath: values.get("--dll"),
+    outputPath: values.get("--output"),
+    sourceRevision: values.get("--source-revision"),
+  };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const options = parseArguments(process.argv.slice(2));
+    if (!options.dllPath || !options.outputPath || !options.sourceRevision) {
+      throw new Error("expected --dll, --output, and --source-revision values");
+    }
+    const manifest = generateBattleBridgeRuntimeManifest(options);
+    process.stdout.write(`${JSON.stringify({
+      output: path.resolve(options.outputPath),
+      sourceRevision: manifest.sourceRevision,
+      artifactSha256: manifest.producerContract.artifact.sha256,
+      capabilities: manifest.capabilities,
+    }, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/generate_config_schema.mjs
+++ b/scripts/generate_config_schema.mjs
@@ -488,7 +488,7 @@ function parseSyncTargetSettings(defaults, configMemberTypes) {
   settings.push({
     path: "sync.targets.*.mode",
     title: "Mode",
-    description: "Outbound sync contract used by this target.",
+    description: "Outbound contract: legacy or majel. Omission defaults to legacy; invalid explicit values reject the target.",
     category: "sync",
     control: "scalar",
     valueType: { kind: "enum", values: ["legacy", "majel"] },

--- a/scripts/test_battle_bridge_producer_contract.mjs
+++ b/scripts/test_battle_bridge_producer_contract.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  buildBattleBridgeRuntimeManifest,
+  parseAuthoritativeProducerContract,
+} from "./generate_battle_bridge_runtime_manifest.mjs";
+
+const contract = parseAuthoritativeProducerContract(readFileSync(
+  new URL("../docs/battle-bridge-producer-capabilities.v1.json", import.meta.url),
+  "utf8",
+));
+const embeddedProviderManifest = JSON.parse(readFileSync(
+  new URL("../docs/windows-launcher/runtime-manifest.guffawaffle.v1.json", import.meta.url),
+  "utf8",
+));
+
+test("producer contract freezes only declarations justified by bounded fixture evidence", () => {
+  assert.equal(contract.contractSchema, "stfc.battle-bridge.producer-capabilities.v1");
+  assert.equal(contract.distributionId, "guffawaffle.stfc-community-mod");
+  assert.equal(contract.distributionId, embeddedProviderManifest.distributionId);
+  assert.equal(contract.activationStatus, "producer-groundwork");
+  assert.deepEqual(
+    contract.runtimeCapabilities.map((entry) => [entry.id, entry.schema]),
+    [
+      ["ingest.stfc-sidecar.v1", "stfc.sidecar.ingest.v1"],
+      ["battle.capture.v1", "stfc.battle.capture.v1"],
+      ["fleet.runtime-snapshot.v1", "stfc.fleet.runtime_snapshot.v1"],
+    ],
+  );
+  assert.deepEqual(
+    contract.runtimeCapabilities.map((entry) => entry.evidenceStatus),
+    ["payload-fixture-only", "payload-fixture-only", "payload-fixture-only"],
+  );
+  assert.deepEqual(
+    contract.sourceObservedOnly.map((entry) => entry.id),
+    ["battle.report.v0", "battle.analytics.v0", "battle.catalog-snapshot.v0"],
+  );
+  assert.deepEqual(contract.unproven.map((entry) => entry.id), ["fleet.alert-evidence.v0"]);
+  assert.deepEqual(contract.transportPolicy, {
+    majelBattlelogs: "unsupported",
+    majelBattlelogsRealtime: "unsupported",
+    legacyBattlelogs: "unchanged",
+    legacyBattlelogsRealtime: "unchanged",
+    canonicalLocalBattleStream: "unchanged",
+  });
+  assert.equal(
+    contract.capabilityEvidencePin.sha256,
+    "aa6b738eab60a3bcb17a0c37cfcd533198096dd05d98abfd4a43308e891a9cc9",
+  );
+});
+
+function readIntegerConstant(relativePath, name) {
+  const source = readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+  const match = source.match(new RegExp(`${name}\\s*=\\s*([0-9' *]+);`, "u"));
+  assert.ok(match, `missing ${name} in ${relativePath}`);
+  return match[1]
+    .split("*")
+    .map((factor) => Number.parseInt(factor.trim().replaceAll("'", ""), 10))
+    .reduce((product, factor) => product * factor, 1);
+}
+
+test("published producer bounds remain contract-checked against runtime source", () => {
+  assert.equal(
+    contract.bounds.localQueueDepth,
+    readIntegerConstant("mods/src/patches/sidecar_local_ingest.cc", "kSidecarLocalQueueMaxDepth"),
+  );
+  assert.equal(
+    contract.bounds.localConnectTimeoutMs,
+    readIntegerConstant("mods/src/patches/sidecar_local_ingest.cc", "kSidecarLocalConnectTimeoutMs"),
+  );
+  assert.equal(
+    contract.bounds.localRequestTimeoutMs,
+    readIntegerConstant("mods/src/patches/sidecar_local_ingest.cc", "kSidecarLocalRequestTimeoutMs"),
+  );
+  assert.equal(
+    contract.bounds.localChunkThresholdBytes,
+    readIntegerConstant("mods/src/patches/sidecar_local_chunking.h", "kChunkingThresholdBytes"),
+  );
+  assert.equal(
+    contract.bounds.localChunkDataBytes,
+    readIntegerConstant("mods/src/patches/sidecar_local_chunking.h", "kChunkDataBytes"),
+  );
+  assert.equal(
+    contract.bounds.warningCoalescingIntervalMs,
+    readIntegerConstant("mods/src/patches/sync_battle_logs.cc", "kBattleFeedWarningIntervalMs"),
+  );
+});
+
+test("authoritative producer JSON rejects duplicate keys", () => {
+  assert.throws(
+    () => parseAuthoritativeProducerContract('{"contractSchema":"one","contractSchema":"two"}'),
+    /duplicate key: contractSchema/u,
+  );
+});
+
+test("exact-build runtime manifest binds compatibility declarations to DLL bytes without secrets", () => {
+  const dllBytes = Buffer.from("synthetic-version-dll", "utf8");
+  const sourceRevision = "0123456789abcdef0123456789abcdef01234567";
+  const manifest = buildBattleBridgeRuntimeManifest({
+    dllBytes,
+    sourceRevision,
+    contract,
+    runtimeVersion: "2.1.0.0",
+  });
+
+  assert.equal(manifest.manifestSchema, 1);
+  assert.equal(manifest.sourceRevision, sourceRevision);
+  assert.deepEqual(manifest.capabilities, [
+    "settings.principal-taxonomy.v1",
+    "ingest.stfc-sidecar.v1",
+    "battle.capture.v1",
+    "fleet.runtime-snapshot.v1",
+  ]);
+  assert.deepEqual(manifest.settingsCatalog, embeddedProviderManifest.settingsCatalog);
+  assert.equal(manifest.producerContract.compatibilityEvidenceOnly, true);
+  assert.equal(manifest.producerContract.operationalActivation, "requires-bridge-transactional-binding");
+  assert.equal(manifest.producerContract.artifact.fileName, "version.dll");
+  assert.equal(manifest.producerContract.artifact.size, dllBytes.byteLength);
+  assert.equal(
+    manifest.producerContract.artifact.sha256,
+    createHash("sha256").update(dllBytes).digest("hex"),
+  );
+  assert.doesNotMatch(JSON.stringify(manifest), /token|authorization|https?:\/\//iu);
+});
+
+test("runtime manifest rejects malformed source identity and empty artifacts", () => {
+  assert.throws(
+    () => buildBattleBridgeRuntimeManifest({
+      dllBytes: Buffer.from("dll"),
+      sourceRevision: "main",
+      contract,
+    }),
+    /40-character commit SHA/u,
+  );
+  assert.throws(
+    () => buildBattleBridgeRuntimeManifest({
+      dllBytes: Buffer.alloc(0),
+      sourceRevision: "0123456789abcdef0123456789abcdef01234567",
+      contract,
+    }),
+    /must be non-empty/u,
+  );
+});

--- a/tests/src/test_sidecar_local_ingest_policy.cc
+++ b/tests/src/test_sidecar_local_ingest_policy.cc
@@ -61,6 +61,25 @@ TEST_SUITE("sidecar_local_ingest_policy")
     CHECK(BattleHeaderProcessingEnabledForSync(false, true, false, false, config));
   }
 
+  TEST_CASE("disabled and unconfigured local producer paths remain inert despite per-kind requests")
+  {
+    SidecarSyncConfig config;
+    config.battlelogs_realtime = true;
+    config.fleet_runtime       = true;
+
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    CHECK_FALSE(SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::BattleEvents));
+    CHECK_FALSE(SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::FleetRuntime));
+    CHECK_FALSE(BattleHeaderProcessingNeedsSidecarLocal(config));
+    CHECK_FALSE(BattleHeaderProcessingEnabledForSync(false, false, false, false, config));
+
+    config.enabled = true;
+    config.url     = "http://127.0.0.1:43127/api/sidecar/ingest";
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    CHECK_FALSE(SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::BattleEvents));
+    CHECK_FALSE(SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::FleetRuntime));
+  }
+
   TEST_CASE("battle header processing stays alive for dedicated sidecar realtime delivery")
   {
     auto config = configured_sidecar_sync();

--- a/tests/src/test_sync_transport_policy.cc
+++ b/tests/src/test_sync_transport_policy.cc
@@ -2,6 +2,8 @@
 
 #include "patches/sync_transport_policy.h"
 
+#include <stdexcept>
+
 TEST_SUITE("sync_transport_policy")
 {
   TEST_CASE("verify_ssl stays enabled unless the explicit unsafe override is also set")
@@ -80,23 +82,61 @@ TEST_SUITE("sync_transport_policy")
     target.ships = true;
     target.slots = true;
     target.fleet_runtime = true;
+    target.battlelogs = true;
+    target.battlelogs_realtime = true;
 
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::Ships));
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetRuntime));
+    CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::Battles));
+    CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::BattlelogsRealtime));
 
     target.mode = SyncTargetConfig::Mode::Majel;
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::ModCapabilities));
     CHECK(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetRuntime));
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::Battles));
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::BattlelogsRealtime));
 
     target.slots = false;
     CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::FleetAssignments));
   }
 
+  TEST_CASE("battle normalization disables Majel while preserving Legacy")
+  {
+    for (const auto type : {SyncConfig::Type::Battles, SyncConfig::Type::BattlelogsRealtime}) {
+      CHECK(http::NormalizeSyncTargetTypeForMode(SyncTargetConfig::Mode::Legacy, type, true));
+      CHECK_FALSE(http::NormalizeSyncTargetTypeForMode(SyncTargetConfig::Mode::Majel, type, true));
+      CHECK_FALSE(http::NormalizeSyncTargetTypeForMode(SyncTargetConfig::Mode::Legacy, type, false));
+      CHECK_FALSE(http::NormalizeSyncTargetTypeForMode(SyncTargetConfig::Mode::Majel, type, false));
+    }
+    CHECK(http::NormalizeSyncTargetTypeForMode(SyncTargetConfig::Mode::Majel, SyncConfig::Type::Ships, true));
+  }
+
+  TEST_CASE("explicit malformed target modes fail closed while omission preserves Legacy")
+  {
+    CHECK(http::ParseSyncTargetMode(false, std::nullopt) == SyncTargetConfig::Mode::Legacy);
+    CHECK(http::ParseSyncTargetMode(true, std::string("legacy")) == SyncTargetConfig::Mode::Legacy);
+    CHECK(http::ParseSyncTargetMode(true, std::string("majel")) == SyncTargetConfig::Mode::Majel);
+
+    for (const auto& malformed : {std::optional<std::string>(std::nullopt), std::optional<std::string>(""),
+                                  std::optional<std::string>("maje1"), std::optional<std::string>("Majel"),
+                                  std::optional<std::string>("majel ")}) {
+      const auto parsed = http::ParseSyncTargetMode(true, malformed);
+      CHECK_FALSE(parsed.has_value());
+    }
+  }
+
   TEST_CASE("mod capability snapshot is redacted and declares supported schemas")
   {
+    CHECK(http::MajelAdvertisedSchemas()
+          == std::vector<std::string>{
+              "stfc.mod.capability_snapshot.v1",
+              "stfc.sync.delta_batch.v1",
+              "stfc.fleet.assignment_snapshot.v1",
+          });
+
     const auto snapshot = http::BuildModCapabilitySnapshot({
         .source_version = "2.0.1-test",
         .platform = "windows",
@@ -211,4 +251,55 @@ TEST_SUITE("sync_transport_policy")
     CHECK(envelope["payload"]["syncType"] == "slot");
     CHECK(envelope["payload"]["items"] == legacy_items);
   }
+
+  TEST_CASE("Majel routing rejects raw battle journals and captures before envelope construction")
+  {
+    SyncTargetConfig target;
+    target.mode = SyncTargetConfig::Mode::Majel;
+    target.battlelogs = true;
+    target.battlelogs_realtime = true;
+
+    const auto raw_journal = nlohmann::json::array({{{"journal", {{"tokens", {"journal-secret", "-96"}}}}}});
+    const auto raw_capture = nlohmann::json{
+        {"type", "battle.capture"},
+        {"schemaVersion", "stfc.battle.capture.v1"},
+        {"capture", {{"battleLog", {{"tokens", {"secret-token", "-96", "42"}}}}}},
+    };
+
+    CHECK(raw_journal.dump().find("journal-secret") != std::string::npos);
+    CHECK(raw_capture.dump().find("secret-token") != std::string::npos);
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::Battles));
+    CHECK_FALSE(http::SyncTargetAcceptsType(target, SyncConfig::Type::BattlelogsRealtime));
+    CHECK_THROWS_WITH_AS(
+        static_cast<void>(http::BuildMajelIngestEnvelope({.sync_type = SyncConfig::Type::Battles,
+                                                          .payload = raw_journal})),
+        "raw battle payloads are not supported by Majel", std::invalid_argument);
+    CHECK_THROWS_WITH_AS(
+        static_cast<void>(http::BuildMajelIngestEnvelope({.sync_type = SyncConfig::Type::BattlelogsRealtime,
+                                                          .payload = raw_capture})),
+        "raw battle payloads are not supported by Majel", std::invalid_argument);
+  }
+
+  TEST_CASE("warning coalescing is deterministic and reports suppressed occurrences")
+  {
+    http::WarningCoalescingState state;
+
+    auto decision = http::ObserveWarning(state, 1'000, 60'000);
+    CHECK(decision.emit);
+    CHECK(decision.suppressed == 0);
+
+    decision = http::ObserveWarning(state, 1'001, 60'000);
+    CHECK_FALSE(decision.emit);
+    decision = http::ObserveWarning(state, 60'999, 60'000);
+    CHECK_FALSE(decision.emit);
+
+    decision = http::ObserveWarning(state, 61'000, 60'000);
+    CHECK(decision.emit);
+    CHECK(decision.suppressed == 2);
+
+    decision = http::ObserveWarning(state, 500, 60'000);
+    CHECK(decision.emit);
+    CHECK(decision.suppressed == 0);
+  }
+
 }


### PR DESCRIPTION
## Summary

- publish a provider-neutral Battle Bridge producer contract and exact-build `stfc-runtime-manifest.json` beside `version.dll`
- bind the descriptive manifest to the exact DLL size, SHA-256, source commit, and runtime version in CI and signed release artifacts
- fail closed for both raw battle journal and realtime-capture routes on Majel targets while preserving Legacy and canonical local Sidecar delivery
- reject malformed explicit target modes instead of silently falling back to raw-capable Legacy
- coalesce bounded JSONL retention warnings without changing retention behavior

## Trust boundary

The adjacent manifest is compatibility evidence only. It is not authenticity, safety, or gameplay authorization. The current Bridge neither installs nor consumes it; operational use remains blocked on Guffawaffle/stfc-mod-bridge#134 and the existing reviewed artifact trust policy.

## Validation

- producer contract: 5/5
- config schema: 21/21; generated schema current at 333 settings
- native suite: 334/334, 4,318 assertions
- Windows release DLL build: passed
- YAML lint: passed
- exact DLL/manifest SHA-256 and size binding: passed
- `git diff --check`: passed
- independent privacy/security review: clear

Closes #131
Progresses #241