### PR TITLE
Inventory Battle runtime manifest in releases

### DIFF
--- a/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
+++ b/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
@@ -16,7 +16,10 @@ It pins the reviewed Sidecar golden-corpus inventory. After this work reaches a
 trusted CI or release build, that workflow emits `stfc-runtime-manifest.json`
 beside the exact `version.dll`. The manifest names the three producer
 declarations and binds them to the DLL's size, SHA-256, source commit, and
-numeric version.
+numeric version. The tagged-release workflow also inventories those exact JSON
+bytes as the optional `windows-mod-runtime-manifest-x64` artifact in the
+Windows release manifest; both that schema-v1 manifest and the producer JSON
+remain unsigned.
 
 The runtime manifest is compatibility evidence, not authenticity, safety, or
 gameplay authorization. The current Bridge still uses its embedded provider

--- a/docs/windows-launcher/RELEASE_MANIFEST.md
+++ b/docs/windows-launcher/RELEASE_MANIFEST.md
@@ -91,6 +91,7 @@ Each artifact has a stable `id` and a semantic `kind`. Schema v1 publishes:
 | ID | Kind | Purpose |
 |---|---|---|
 | `windows-mod-dll-x64` | `windows-mod` | Direct signed `version.dll` used by the transactional installer and retained for manual installation. |
+| `windows-mod-runtime-manifest-x64` | `windows-mod-runtime-manifest` | Descriptive runtime-capability metadata bound to the exact DLL bytes and deployed only as its verified companion. |
 | `windows-mod-archive-x64` | `windows-mod-archive` | Existing Windows archive containing the signed mod DLL. |
 | `windows-launcher-archive-x64` | `windows-launcher` | Self-contained launcher archive containing the signed launcher and replace-on-exit helper executables. |
 | `windows-launcher-setup-x64` | `windows-launcher-setup` | User-facing signed single executable that embeds, installs, and starts the signed launcher archive. |
@@ -103,6 +104,17 @@ The launcher consumer uses a closed schema and rejects unknown properties. For
 mod deployment it selects exactly one `windows-mod-dll-x64` artifact and
 requires `windows` / `x64`, the direct PE media type, `version.dll`, bounded
 size, lowercase SHA-256, and `authenticode` / `artifact` authenticity. The
+optional `windows-mod-runtime-manifest-x64` companion requires `windows` /
+`x64`, JSON media type, the exact `stfc-runtime-manifest.json` basename,
+bounded size, lowercase SHA-256, and the explicit `none` / `none` authenticity
+declaration. That declaration is truthful: the companion is descriptive data,
+not an independently signed artifact. Its checksum supplies integrity only
+relative to this schema-v1 release manifest; neither document is an independent
+authorization boundary. The launcher must additionally bind its declared DLL
+hash and size to the exact selected signed DLL, and runtime capability activation
+requires a launcher-bundled reviewed exact-hash certification for the companion
+and pair. Releases without the companion—or without that reviewed
+certification—remain valid base-mod releases and imply no Battle capability. The
 manifest repository must be exactly `Guffawaffle/stfc-mod`, the release must be
 active and match the user-selected channel, and `minimumLauncherVersion` must
 not exceed the running launcher. Asset URLs are derived from the immutable tag

--- a/scripts/windows_release_manifest_spec.json
+++ b/scripts/windows_release_manifest_spec.json
@@ -16,6 +16,19 @@
       }
     },
     {
+      "id": "windows-mod-runtime-manifest-x64",
+      "kind": "windows-mod-runtime-manifest",
+      "platform": "windows",
+      "architecture": "x64",
+      "sourcePath": "stfc-runtime-manifest.json",
+      "fileName": "stfc-runtime-manifest.json",
+      "mediaType": "application/json",
+      "authenticity": {
+        "scheme": "none",
+        "scope": "none"
+      }
+    },
+    {
       "id": "windows-mod-archive-x64",
       "kind": "windows-mod-archive",
       "platform": "windows",

--- a/tests/test_generate_release_manifest.py
+++ b/tests/test_generate_release_manifest.py
@@ -136,12 +136,26 @@ class ReleaseManifestTests(unittest.TestCase):
         self.assertEqual(
             [
                 "windows-mod-dll-x64",
+                "windows-mod-runtime-manifest-x64",
                 "windows-mod-archive-x64",
                 "windows-launcher-archive-x64",
                 "windows-launcher-setup-x64",
             ],
             [artifact["id"] for artifact in manifest["artifacts"]],
         )
+        runtime_manifest_artifact = next(
+            artifact
+            for artifact in manifest["artifacts"]
+            if artifact["id"] == "windows-mod-runtime-manifest-x64"
+        )
+        self.assertEqual("windows-mod-runtime-manifest", runtime_manifest_artifact["kind"])
+        self.assertEqual("stfc-runtime-manifest.json", runtime_manifest_artifact["fileName"])
+        self.assertEqual("application/json", runtime_manifest_artifact["mediaType"])
+        self.assertEqual(
+            {"scheme": "none", "scope": "none"},
+            runtime_manifest_artifact["authenticity"],
+        )
+        self.assertRegex(runtime_manifest_artifact["sha256"], r"^[0-9a-f]{64}$")
 
     def test_preview_channel_is_derived_from_supported_tag(self) -> None:
         manifest = self._build("v2.2.0-guffa.rc1")


### PR DESCRIPTION
## Summary

- inventory `stfc-runtime-manifest.json` as a stable `windows-mod-runtime-manifest-x64` artifact in the generated Windows release manifest
- publish exact size/SHA-256 and truthful `application/json`, `none`/`none` authenticity metadata
- freeze the exact artifact identity in generator tests and document legacy/base-only behavior

## Trust boundary

This does **not** authenticate the producer JSON or schema-v1 release manifest. Both remain unsigned. The release entry provides discovery and integrity metadata only. Battle capability activation requires the exact JSON+DLL+source pair to match Mod Bridge's launcher-bundled reviewed exact-hash certification; releases or consumers without that certification remain base-only. The operational consumer is Guffawaffle/stfc-mod-bridge#134.

## Validation

- release-manifest generator/validator: 10/10
- Battle producer contract: 5/5
- `git diff --check`: passed
- independent cross-repo trust review: clear

Progresses #241