### PR TITLE
Clarify Battle Bridge consumer compatibility

### DIFF
--- a/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
+++ b/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
@@ -22,15 +22,17 @@ Windows release manifest; both that schema-v1 manifest and the producer JSON
 remain unsigned.
 
 The runtime manifest is compatibility evidence, not authenticity, safety, or
-gameplay authorization. The current Bridge still uses its embedded provider
-manifest: it neither installs nor consumes this adjacent producer JSON. The
-first exact qualifying artifact can therefore exist only after a trusted
-workflow publishes one, and operational activation still requires a separate
-Bridge change for transactional installation, artifact binding, and adjacent
-manifest consumption after provider authentication. The wave-one
-current-release corpus remains unchanged with zero accepted runtime contracts.
-Another provider can publish any compatible subset without copying the
-Guffawaffle distribution ID.
+gameplay authorization. Bridge releases predating the transactional consumer in
+[`Guffawaffle/stfc-mod-bridge#134`](https://github.com/Guffawaffle/stfc-mod-bridge/issues/134)
+use only their embedded provider manifest. Compatible Bridge releases may
+install and consume the adjacent JSON only when its exact bytes and the DLL are
+both bound by a launcher-bundled reviewed release certification; neither this
+unsigned JSON nor the unsigned schema-v1 release manifest can activate a
+capability on its own. The first operational activation still requires a
+trusted workflow to publish an exact pair and a deliberate launcher catalog
+update to review that pair. The wave-one current-release corpus remains
+unchanged with zero accepted runtime contracts. Another provider can publish
+any compatible subset without copying the Guffawaffle distribution ID.
 
 ## Deliberate boundaries
 


### PR DESCRIPTION
## Outcome

Temporalizes the Battle Bridge producer contract now that the transactional consumer is landing in Guffawaffle/stfc-mod-bridge#134.

Older Bridge releases remain embedded/base-only. Compatible Bridge releases may install and consume the adjacent runtime JSON only when a launcher-bundled reviewed certification binds the exact DLL and JSON pair. The unsigned producer JSON and unsigned schema-v1 Windows release manifest never activate capabilities on their own.

The first operational activation still requires a trusted workflow to publish an exact pair and a deliberate launcher catalog update to review it. The wave-one corpus remains at zero accepted runtime contracts.

Progresses #241.

## Validation

- `node --test scripts/test_battle_bridge_producer_contract.mjs` — 5/5 passed
- `git diff --check`