### PR TITLE
Add authenticated named-pipe Battle Bridge producer

### DIFF
--- a/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
+++ b/docs/BATTLE_BRIDGE_PRODUCER_CONTRACT.md
@@ -41,8 +41,25 @@ any compatible subset without copying the Guffawaffle distribution ID.
 - Fleet alert evidence remains unproven because this producer has no matching
   emitter. It is not advertised.
 - A disabled or incomplete `[sidecar.sync]` configuration starts no local
-  worker and performs no local HTTP request. Enabled hooks copy into a bounded
-  asynchronous queue; connect and request timeouts remain 2.5 and 8 seconds.
+  worker and performs no local transport request. Enabled hooks copy into a
+  bounded asynchronous queue; connect and total request timeouts remain 2.5
+  and 8 seconds.
+- `sidecar.sync.transport = "named_pipe"` is the Windows Battle Bridge path.
+  It requires a bare safe pipe name plus the exact 43-character unpadded
+  base64url projection of the launcher-owned 32-byte credential. It uses
+  length-prefixed byte frames, protocol
+  `stfc.battle-bridge.local-ipc.v1`, role `stfc-mod-runtime`, operation
+  `ingest`, and a closed bounded response contract. Each frame begins with an
+  unsigned 32-bit little-endian byte count; the authentication header and each
+  response are capped at 4 KiB, and payload frames at 512 KiB. The client uses
+  Windows `SecurityIdentification` quality-of-service so the pipe server can
+  identify it without receiving an impersonation-capable token. It does not
+  construct a URL, proxy, TLS policy, socket, or network listener. Invalid
+  explicit modes, names, and credentials fail closed rather than falling back
+  to HTTP.
+- `legacy_http` remains the default only for compatibility with older Sidecar
+  installations. It retains the existing URL/proxy/TLS behavior and is not the
+  Battle Bridge transport. Named-pipe failure never falls through to it.
 - Canonical local Battle events are losslessly chunked above 256 KiB in 64 KiB
   pieces. Legacy non-Majel battle delivery is unchanged. Majel targets reject
   both `Battles` and `BattlelogsRealtime` before envelope construction, so raw
@@ -51,5 +68,10 @@ any compatible subset without copying the Guffawaffle distribution ID.
 - Repeated JSONL bounded-suffix warnings are coalesced to at most one report per
   minute, with the next report carrying the suppressed count.
 
-No command channel, cloud destination, gameplay automation, or persistent
-secret is introduced by this contract.
+The named-pipe response carries acknowledgement state only; it is not a command
+channel. No cloud destination, gameplay automation, or new persistent secret is
+introduced by this contract. The existing plaintext TOML token is a
+launcher-managed projection of the authoritative DPAPI record and is never
+logged. Battle Bridge remains responsible for the pipe ACL, caller-process and
+runtime-evidence validation, protocol version, and per-operation authorization;
+the header's requested role is not caller proof.

--- a/docs/windows-launcher/config-schema.guffawaffle.v1.json
+++ b/docs/windows-launcher/config-schema.guffawaffle.v1.json
@@ -16625,7 +16625,7 @@
       },
       "presentation": {
         "label": "Allow unverified sidecar TLS",
-        "help": "Allows an encrypted sidecar connection without checking its certificate. Use only for a trusted local setup.",
+        "help": "Legacy HTTP only. Allows an encrypted Sidecar connection without checking its certificate.",
         "group": "Local sidecar",
         "searchTerms": [
           "sidecar.sync.allow_unsafe_tls_without_certificate_validation",
@@ -16637,7 +16637,7 @@
         "editorWidth": "compact",
         "applyTiming": "Next launch",
         "accessibleName": "Allow unverified sidecar TLS",
-        "accessibleHelp": "Allows an encrypted sidecar connection without checking its certificate. Use only for a trusted local setup. Applies: Next launch."
+        "accessibleHelp": "Legacy HTTP only. Allows an encrypted Sidecar connection without checking its certificate. Applies: Next launch."
       }
     },
     {
@@ -16734,7 +16734,7 @@
     {
       "path": "sidecar.sync.enabled",
       "title": "Enabled",
-      "description": "Dedicated local STFC Mod Sidecar delivery. This is the only supported home for sidecar-local HTTP config. Local Battle Workbench reads the sidecar event store through /api/events. Cloud Sync Monitor and Majel/cloud targets are not required for local sidecar ingest.",
+      "description": "Dedicated local STFC Mod Sidecar or Battle Bridge delivery. Battle Bridge uses authenticated Windows named pipes. legacy_http remains for older Sidecar installations and is not used by Battle Bridge. Local Battle Workbench reads the sidecar event store through /api/events. Cloud Sync Monitor and Majel/cloud targets are not required for local sidecar ingest.",
       "category": "sidecar",
       "control": "scalar",
       "valueType": {
@@ -16758,19 +16758,19 @@
       },
       "presentation": {
         "label": "Local sidecar delivery",
-        "help": "Sends supported mod data to the STFC Mod Sidecar running on this PC.",
+        "help": "Sends supported mod data to Battle Bridge or a legacy Sidecar running on this PC.",
         "group": "Local sidecar",
         "searchTerms": [
           "sidecar.sync.enabled",
           "Enabled",
-          "Dedicated local STFC Mod Sidecar delivery. This is the only supported home for sidecar-local HTTP config. Local Battle Workbench reads the sidecar event store through /api/events. Cloud Sync Monitor and Majel/cloud targets are not required for local sidecar ingest.",
+          "Dedicated local STFC Mod Sidecar or Battle Bridge delivery. Battle Bridge uses authenticated Windows named pipes. legacy_http remains for older Sidecar installations and is not used by Battle Bridge. Local Battle Workbench reads the sidecar event store through /api/events. Cloud Sync Monitor and Majel/cloud targets are not required for local sidecar ingest.",
           "sidecar",
           "Local sidecar"
         ],
         "editorWidth": "compact",
         "applyTiming": "Next launch",
         "accessibleName": "Local sidecar delivery",
-        "accessibleHelp": "Sends supported mod data to the STFC Mod Sidecar running on this PC. Applies: Next launch."
+        "accessibleHelp": "Sends supported mod data to Battle Bridge or a legacy Sidecar running on this PC. Applies: Next launch."
       }
     },
     {
@@ -16818,7 +16818,7 @@
     {
       "path": "sidecar.sync.fleet_runtime_mode",
       "title": "Fleet Runtime Mode",
-      "description": "Fleet runtime sidecar safety/probe mode: normal, request_only, snapshot_only, or enqueue_no_transport. request_only records requests but skips snapshot reads. snapshot_only reads/builds owned snapshots but skips publish/enqueue. enqueue_no_transport enqueues latest-wins runtime snapshots but suppresses HTTP transport.",
+      "description": "Fleet runtime sidecar safety/probe mode: normal, request_only, snapshot_only, or enqueue_no_transport. request_only records requests but skips snapshot reads. snapshot_only reads/builds owned snapshots but skips publish/enqueue. enqueue_no_transport enqueues latest-wins runtime snapshots but suppresses transport delivery.",
       "category": "sidecar",
       "control": "scalar",
       "valueType": {
@@ -16853,7 +16853,7 @@
         "searchTerms": [
           "sidecar.sync.fleet_runtime_mode",
           "Fleet Runtime Mode",
-          "Fleet runtime sidecar safety/probe mode: normal, request_only, snapshot_only, or enqueue_no_transport. request_only records requests but skips snapshot reads. snapshot_only reads/builds owned snapshots but skips publish/enqueue. enqueue_no_transport enqueues latest-wins runtime snapshots but suppresses HTTP transport.",
+          "Fleet runtime sidecar safety/probe mode: normal, request_only, snapshot_only, or enqueue_no_transport. request_only records requests but skips snapshot reads. snapshot_only reads/builds owned snapshots but skips publish/enqueue. enqueue_no_transport enqueues latest-wins runtime snapshots but suppresses transport delivery.",
           "sidecar",
           "Local sidecar"
         ],
@@ -16886,6 +16886,48 @@
       }
     },
     {
+      "path": "sidecar.sync.pipe_name",
+      "title": "Pipe Name",
+      "description": "Configure pipe name.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "string"
+      },
+      "default": "",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.pipe_name",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.pipe_name"
+      },
+      "presentation": {
+        "label": "Battle Bridge pipe",
+        "help": "Launcher-managed local pipe name. Do not set this manually.",
+        "group": "Local sidecar",
+        "searchTerms": [
+          "sidecar.sync.pipe_name",
+          "Pipe Name",
+          "Configure pipe name.",
+          "sidecar",
+          "Local sidecar"
+        ],
+        "editorWidth": "wide",
+        "applyTiming": "Next launch",
+        "accessibleName": "Battle Bridge pipe",
+        "accessibleHelp": "Launcher-managed local pipe name. Do not set this manually. Applies: Next launch."
+      }
+    },
+    {
       "path": "sidecar.sync.proxy",
       "title": "Proxy",
       "description": "Configure proxy.",
@@ -16911,7 +16953,7 @@
         "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.proxy"
       },
       "presentation": {
-        "label": "Sidecar proxy",
+        "label": "Legacy Sidecar proxy",
         "group": "Local sidecar",
         "searchTerms": [
           "sidecar.sync.proxy",
@@ -16922,7 +16964,7 @@
         ],
         "editorWidth": "wide",
         "applyTiming": "Next launch",
-        "accessibleName": "Sidecar proxy",
+        "accessibleName": "Legacy Sidecar proxy",
         "accessibleHelp": "Applies: Next launch."
       }
     },
@@ -16969,6 +17011,52 @@
       }
     },
     {
+      "path": "sidecar.sync.transport",
+      "title": "Transport",
+      "description": "Configure transport.",
+      "category": "sidecar",
+      "control": "scalar",
+      "valueType": {
+        "kind": "enum",
+        "values": [
+          "legacy_http",
+          "named_pipe"
+        ]
+      },
+      "default": "legacy_http",
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "stable",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "sidecar.sync.transport",
+        "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.transport"
+      },
+      "presentation": {
+        "label": "Local transport",
+        "help": "Uses authenticated Windows named pipes for Battle Bridge, or legacy HTTP for older Sidecar installations.",
+        "group": "Local sidecar",
+        "searchTerms": [
+          "sidecar.sync.transport",
+          "Transport",
+          "Configure transport.",
+          "sidecar",
+          "Local sidecar"
+        ],
+        "editorWidth": "standard",
+        "applyTiming": "Next launch",
+        "accessibleName": "Local transport",
+        "accessibleHelp": "Uses authenticated Windows named pipes for Battle Bridge, or legacy HTTP for older Sidecar installations. Applies: Next launch."
+      }
+    },
+    {
       "path": "sidecar.sync.url",
       "title": "URL",
       "description": "Configure url.",
@@ -16994,8 +17082,8 @@
         "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.url"
       },
       "presentation": {
-        "label": "Sidecar address",
-        "help": "Address of the STFC Mod Sidecar running on this PC.",
+        "label": "Legacy Sidecar address",
+        "help": "Used only with the legacy HTTP transport. Battle Bridge uses the launcher-managed named pipe.",
         "group": "Local sidecar",
         "searchTerms": [
           "sidecar.sync.url",
@@ -17006,8 +17094,8 @@
         ],
         "editorWidth": "wide",
         "applyTiming": "Next launch",
-        "accessibleName": "Sidecar address",
-        "accessibleHelp": "Address of the STFC Mod Sidecar running on this PC. Applies: Next launch."
+        "accessibleName": "Legacy Sidecar address",
+        "accessibleHelp": "Used only with the legacy HTTP transport. Battle Bridge uses the launcher-managed named pipe. Applies: Next launch."
       }
     },
     {
@@ -17036,8 +17124,8 @@
         "defaultSource": "mods/src/defaultconfig.h:sidecar.sync.verify_ssl"
       },
       "presentation": {
-        "label": "Verify sidecar TLS certificates",
-        "help": "Rejects sidecar connections whose TLS certificate cannot be verified.",
+        "label": "Verify legacy Sidecar TLS",
+        "help": "Used only with the legacy HTTP transport; named pipes do not use TLS.",
         "group": "Local sidecar",
         "searchTerms": [
           "sidecar.sync.verify_ssl",
@@ -17048,8 +17136,8 @@
         ],
         "editorWidth": "compact",
         "applyTiming": "Next launch",
-        "accessibleName": "Verify sidecar TLS certificates",
-        "accessibleHelp": "Rejects sidecar connections whose TLS certificate cannot be verified. Applies: Next launch."
+        "accessibleName": "Verify legacy Sidecar TLS",
+        "accessibleHelp": "Used only with the legacy HTTP transport; named pipes do not use TLS. Applies: Next launch."
       }
     },
     {

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -784,11 +784,14 @@ allow_unsafe_tls_without_certificate_validation = false
 #  <[======================================================================]>
 
 [sidecar.sync]
-# Dedicated local STFC Mod Sidecar delivery.
-# This is the only supported home for sidecar-local HTTP config.
+# Dedicated local STFC Mod Sidecar or Battle Bridge delivery.
+# Battle Bridge uses authenticated Windows named pipes. legacy_http remains for
+# older Sidecar installations and is not used by Battle Bridge.
 # Local Battle Workbench reads the sidecar event store through /api/events.
 # Cloud Sync Monitor and Majel/cloud targets are not required for local sidecar ingest.
 enabled = false
+transport = "legacy_http" # launcher-managed Battle Bridge value: named_pipe
+pipe_name = ""            # launcher-managed; bare safe name, never a path
 token = ""
 url = "http://127.0.0.1:43127/api/sidecar/ingest"
 proxy = ""
@@ -807,7 +810,7 @@ fleet_runtime = false
 # normal, request_only, snapshot_only, or enqueue_no_transport.
 # request_only records requests but skips snapshot reads.
 # snapshot_only reads/builds owned snapshots but skips publish/enqueue.
-# enqueue_no_transport enqueues latest-wins runtime snapshots but suppresses HTTP transport.
+# enqueue_no_transport enqueues latest-wins runtime snapshots but suppresses transport delivery.
 fleet_runtime_mode = "normal"
 
 [sidecar.logging]

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -171,7 +171,9 @@ enum class MissionHudVisibility {
  * sidecar routing can move off the external/community sync surface.
  */
 struct SidecarSyncConfig {
-  bool        enabled = false;
+  bool        enabled   = false;
+  std::string transport = "legacy_http";
+  std::string pipe_name;
   std::string url;
   std::string token;
   std::string proxy;

--- a/mods/src/config_release_validation.cc
+++ b/mods/src/config_release_validation.cc
@@ -77,6 +77,8 @@ namespace
       "sidecar.sync.battlelogs_realtime",
       "sidecar.sync.enabled",
       "sidecar.sync.fleet_runtime",
+      "sidecar.sync.pipe_name",
+      "sidecar.sync.transport",
       "sidecar.sync.proxy",
       "sidecar.sync.token",
       "sidecar.sync.url",

--- a/mods/src/config_sidecar.cc
+++ b/mods/src/config_sidecar.cc
@@ -308,6 +308,20 @@ SidecarConfigParseResult ParseSidecarConfig(const toml::table& config)
 
   read_bool_value(result.config.sync.enabled,
                   {"sidecar.sync.enabled", DCSidecar::Sync::enabled, {}, "enable local sidecar delivery"});
+  const auto* transport_node = node_at_path(config, "sidecar.sync.transport");
+  read_string_value(result.config.sync.transport, "sidecar.sync.transport", DCSidecar::Sync::transport,
+                    "local sidecar transport: legacy_http or named_pipe");
+  if (transport_node && !transport_node->is_string()) {
+    result.config.sync.transport = "invalid";
+  }
+  if (result.config.sync.transport != "legacy_http" && result.config.sync.transport != "named_pipe") {
+    result.diagnostics.push_back(make_diagnostic(
+        config_schema::DiagnosticSeverity::Error, "sidecar.sync.transport", "sidecar.sync.transport",
+        "Invalid sidecar.sync.transport. Expected legacy_http or named_pipe; local delivery is disabled."));
+    result.config.sync.transport = "invalid";
+  }
+  read_string_value(result.config.sync.pipe_name, "sidecar.sync.pipe_name", DCSidecar::Sync::pipe_name,
+                    "Battle Bridge named-pipe name");
   read_string_value(result.config.sync.url, "sidecar.sync.url", DCSidecar::Sync::url,
                     "loopback or local sidecar ingest URL");
   read_string_value(result.config.sync.token, "sidecar.sync.token", DCSidecar::Sync::token, "sidecar ingest token");
@@ -479,9 +493,9 @@ SidecarConfigParseResult ParseSidecarConfig(const toml::table& config)
       message << "Invalid config " << kLegacyQueueAddHideViewersPath << ". Expected boolean, found "
               << toml_type_name(legacy_hide_viewers->type())
               << "; deprecated key is ignored and successful queue-add actions always dismiss the target viewer.";
-      result.diagnostics.push_back(
-          make_diagnostic(config_schema::DiagnosticSeverity::Warning, kLegacyQueueAddHideViewersPath,
-                          kLegacyQueueAddHideViewersPath, message.str()));
+      result.diagnostics.push_back(make_diagnostic(config_schema::DiagnosticSeverity::Warning,
+                                                   kLegacyQueueAddHideViewersPath, kLegacyQueueAddHideViewersPath,
+                                                   message.str()));
     } else {
       const auto severity = configured_value.value() ? config_schema::DiagnosticSeverity::Info
                                                      : config_schema::DiagnosticSeverity::Warning;
@@ -568,6 +582,8 @@ SidecarConfigParseResult ParseSidecarConfig(const toml::table& config)
 void WriteSidecarConfigRuntimeSnapshot(toml::table& runtime_config, const SidecarConfig& config)
 {
   config_schema::write_bool(runtime_config, "sidecar.sync.enabled", config.sync.enabled);
+  write_scalar(runtime_config, "sidecar.sync.transport", config.sync.transport);
+  write_scalar(runtime_config, "sidecar.sync.pipe_name", config.sync.pipe_name);
   write_scalar(runtime_config, "sidecar.sync.url", config.sync.url);
   write_scalar(runtime_config, "sidecar.sync.token",
                config_redaction::redact_secret_for_runtime_snapshot(config.sync.token));

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -434,6 +434,8 @@ namespace Sidecar
   namespace Sync
   {
     constexpr bool        enabled                                         = false;
+    constexpr const char* transport                                       = "legacy_http";
+    constexpr const char* pipe_name                                       = "";
     constexpr const char* url                                             = "";
     constexpr const char* token                                           = "";
     constexpr const char* proxy                                           = "";

--- a/mods/src/patches/sidecar_local_ingest.cc
+++ b/mods/src/patches/sidecar_local_ingest.cc
@@ -4,6 +4,7 @@
 #include "patches/async_work_queue.h"
 #include "patches/sidecar_local_chunking.h"
 #include "patches/sidecar_local_ingest_policy.h"
+#include "patches/sidecar_named_pipe_transport.h"
 #include "patches/sync_transport.h"
 #include "patches/sync_transport_policy.h"
 #include "version.h"
@@ -258,6 +259,9 @@ std::shared_ptr<cpr::Session> create_sidecar_local_session()
   }
 
   auto session = std::make_shared<cpr::Session>();
+  if (SidecarLocalSyncUsesNamedPipe(config)) {
+    return session;
+  }
   session->SetUrl(config.url);
   session->SetUserAgent("stfc community patch " VER_RUNTIME_VERSION_STR " (libcurl/" LIBCURL_VERSION ")");
   session->SetAcceptEncoding(cpr::AcceptEncoding{});
@@ -326,6 +330,27 @@ void post_sidecar_local_envelope(cpr::Session& session,
   }
 
   const auto post_serialized_body = [&](const std::string& body) {
+    const auto& config = SidecarSyncSettings();
+    if (SidecarLocalSyncUsesNamedPipe(config)) {
+      const auto result = sidecar_named_pipe_transport::Send(
+          config.pipe_name,
+          config.token,
+          body,
+          std::chrono::milliseconds(kSidecarLocalConnectTimeoutMs),
+          std::chrono::milliseconds(kSidecarLocalRequestTimeoutMs));
+      if (result.code == sidecar_named_pipe_transport::ResultCode::Sent
+          || result.code == sidecar_named_pipe_transport::ResultCode::ChunkPending) {
+        return true;
+      }
+      const auto reason = result.code == sidecar_named_pipe_transport::ResultCode::TimedOut
+          ? "named-pipe-timeout"
+          : result.code == sidecar_named_pipe_transport::ResultCode::Rejected
+          ? "named-pipe-rejected"
+          : "named-pipe-unavailable";
+      sidecar_local_transport_failure(kind, context, reason);
+      return false;
+    }
+
     session.SetBody(cpr::Body{body});
     const auto response = session.Post();
     if (response.error.code != cpr::ErrorCode::OK) {
@@ -365,7 +390,7 @@ void post_sidecar_local_envelope(cpr::Session& session,
 
   sidecar_local_transport_success(kind, context);
   spdlog::debug("[SidecarLocal] kind={} boundary={} classification={} source={} owner={} seam={} reason={} effect={} "
-                "transport=sent transportMode={} bytes={} chunkCount={} url={}",
+                "transport=sent transportMode={} bytes={} chunkCount={} localTransport={}",
                 sidecar_local_kind_name(kind),
                 context.boundary,
                 context.classification,
@@ -377,7 +402,7 @@ void post_sidecar_local_envelope(cpr::Session& session,
                 transport_mode,
                 serialized_envelope.size(),
                 chunk_count,
-                SidecarSyncSettings().url);
+                SidecarSyncSettings().transport);
 }
 
 void process_sidecar_local_batch(cpr::Session& session, std::vector<SidecarLocalWorkItem>&& batch)

--- a/mods/src/patches/sidecar_local_ingest_policy.cc
+++ b/mods/src/patches/sidecar_local_ingest_policy.cc
@@ -1,7 +1,43 @@
 #include "patches/sidecar_local_ingest_policy.h"
 
+#include <algorithm>
+
+bool SidecarLocalNamedPipeNameValid(const std::string_view value)
+{
+  return !value.empty() && value.size() <= 128 && std::ranges::all_of(value, [](const char character) {
+    return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')
+        || (character >= '0' && character <= '9') || character == '.' || character == '-' || character == '_';
+  });
+}
+
+bool SidecarLocalNamedPipeCredentialValid(const std::string_view value)
+{
+  constexpr std::string_view valid_final_characters = "AEIMQUYcgkosw048";
+  return value.size() == 43
+      && std::ranges::all_of(value, [](const char character) {
+           return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z')
+               || (character >= '0' && character <= '9') || character == '-' || character == '_';
+         })
+      && valid_final_characters.contains(value.back());
+}
+
+bool SidecarLocalSyncUsesNamedPipe(const SidecarSyncConfig& config)
+{ return config.transport == "named_pipe"; }
+
 bool SidecarLocalSyncTransportReady(const SidecarSyncConfig& config)
-{ return config.enabled && !config.url.empty() && !config.token.empty(); }
+{
+  if (!config.enabled || config.token.empty()) {
+    return false;
+  }
+  if (SidecarLocalSyncUsesNamedPipe(config)) {
+#if _WIN32
+    return SidecarLocalNamedPipeNameValid(config.pipe_name) && SidecarLocalNamedPipeCredentialValid(config.token);
+#else
+    return false;
+#endif
+  }
+  return config.transport == "legacy_http" && !config.url.empty();
+}
 
 bool SidecarLocalSyncEnabledFor(const SidecarSyncConfig& config, const SidecarLocalIngestKind kind)
 {
@@ -10,8 +46,10 @@ bool SidecarLocalSyncEnabledFor(const SidecarSyncConfig& config, const SidecarLo
   }
 
   switch (kind) {
-    case SidecarLocalIngestKind::BattleEvents: return config.battlelogs_realtime;
-    case SidecarLocalIngestKind::FleetRuntime: return config.fleet_runtime;
+    case SidecarLocalIngestKind::BattleEvents:
+      return config.battlelogs_realtime;
+    case SidecarLocalIngestKind::FleetRuntime:
+      return config.fleet_runtime;
   }
 
   return false;
@@ -20,12 +58,11 @@ bool SidecarLocalSyncEnabledFor(const SidecarSyncConfig& config, const SidecarLo
 bool BattleHeaderProcessingNeedsSidecarLocal(const SidecarSyncConfig& config)
 { return SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::BattleEvents); }
 
-bool BattleHeaderProcessingEnabledForSync(const bool               sync_battlelogs,
-                                          const bool               sidecar_logging_jsonl,
+bool BattleHeaderProcessingEnabledForSync(const bool sync_battlelogs, const bool sidecar_logging_jsonl,
                                           const bool               external_battles_enabled,
                                           const bool               external_battlelogs_realtime_enabled,
                                           const SidecarSyncConfig& sidecar_sync)
 {
   return sync_battlelogs || sidecar_logging_jsonl || external_battles_enabled || external_battlelogs_realtime_enabled
-      || BattleHeaderProcessingNeedsSidecarLocal(sidecar_sync);
+         || BattleHeaderProcessingNeedsSidecarLocal(sidecar_sync);
 }

--- a/mods/src/patches/sidecar_local_ingest_policy.h
+++ b/mods/src/patches/sidecar_local_ingest_policy.h
@@ -8,10 +8,11 @@ enum class SidecarLocalIngestKind {
 };
 
 bool SidecarLocalSyncTransportReady(const SidecarSyncConfig& config);
+bool SidecarLocalSyncUsesNamedPipe(const SidecarSyncConfig& config);
+bool SidecarLocalNamedPipeNameValid(std::string_view value);
+bool SidecarLocalNamedPipeCredentialValid(std::string_view value);
 bool SidecarLocalSyncEnabledFor(const SidecarSyncConfig& config, SidecarLocalIngestKind kind);
 bool BattleHeaderProcessingNeedsSidecarLocal(const SidecarSyncConfig& config);
-bool BattleHeaderProcessingEnabledForSync(bool                   sync_battlelogs,
-                                          bool                   sidecar_logging_jsonl,
-                                          bool                   external_battles_enabled,
-                                          bool                   external_battlelogs_realtime_enabled,
+bool BattleHeaderProcessingEnabledForSync(bool sync_battlelogs, bool sidecar_logging_jsonl,
+                                          bool external_battles_enabled, bool external_battlelogs_realtime_enabled,
                                           const SidecarSyncConfig& sidecar_sync);

--- a/mods/src/patches/sidecar_named_pipe_transport.cc
+++ b/mods/src/patches/sidecar_named_pipe_transport.cc
@@ -1,0 +1,281 @@
+#include "patches/sidecar_named_pipe_transport.h"
+
+#include "patches/sidecar_local_ingest_policy.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <limits>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#if _WIN32
+#include <windows.h>
+#endif
+
+namespace sidecar_named_pipe_transport
+{
+namespace
+{
+  using json = nlohmann::json;
+
+  constexpr std::array<std::string_view, 15> kFailureValues{
+      "none",
+      "unauthorized",
+      "invalid-request",
+      "unsupported-protocol",
+      "payload-too-large",
+      "rate-limited",
+      "busy",
+      "chunk-conflict",
+      "batch-conflict",
+      "timed-out",
+      "storage-rejected",
+      "pipe-unavailable",
+      "start-failed",
+      "listener-failed",
+      "shutdown-timed-out",
+  };
+
+  bool safe_failure(const std::string_view value)
+  { return std::ranges::find(kFailureValues, value) != kFailureValues.end(); }
+
+  json parse_closed_json(const std::string_view value, bool& duplicate)
+  {
+    std::vector<std::unordered_set<std::string>> object_keys;
+    const auto callback = [&object_keys, &duplicate](const int, const json::parse_event_t event, json& parsed) {
+      if (event == json::parse_event_t::object_start) {
+        object_keys.emplace_back();
+      } else if (event == json::parse_event_t::key) {
+        if (object_keys.empty() || !object_keys.back().insert(parsed.get<std::string>()).second) {
+          duplicate = true;
+        }
+      } else if (event == json::parse_event_t::object_end) {
+        if (object_keys.empty())
+          duplicate = true;
+        else
+          object_keys.pop_back();
+      }
+      return true;
+    };
+    return json::parse(value.begin(), value.end(), callback, false, false);
+  }
+
+  bool has_exact_response_shape(const json& response)
+  {
+    return response.is_object() && response.size() == 4 && response.contains("protocolVersion")
+           && response.contains("status") && response.contains("acceptedRecords") && response.contains("failure")
+           && response["protocolVersion"].is_string() && response["status"].is_string()
+           && response["acceptedRecords"].is_number_integer() && response["failure"].is_string();
+  }
+
+#if _WIN32
+  class unique_handle
+  {
+  public:
+    explicit unique_handle(HANDLE value = INVALID_HANDLE_VALUE)
+        : value_(value)
+    {
+    }
+    ~unique_handle()
+    {
+      if (valid())
+        CloseHandle(value_);
+    }
+    unique_handle(const unique_handle&)            = delete;
+    unique_handle& operator=(const unique_handle&) = delete;
+    unique_handle(unique_handle&& other) noexcept
+        : value_(std::exchange(other.value_, INVALID_HANDLE_VALUE))
+    {
+    }
+    bool valid() const
+    { return value_ != nullptr && value_ != INVALID_HANDLE_VALUE; }
+    HANDLE get() const
+    { return value_; }
+
+  private:
+    HANDLE value_ = INVALID_HANDLE_VALUE;
+  };
+
+  enum class IoResult { Complete, Failed, TimedOut };
+
+  DWORD remaining_timeout(const std::chrono::steady_clock::time_point deadline)
+  {
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline)
+      return 0;
+    const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+    return static_cast<DWORD>(std::clamp<int64_t>(remaining, 1, std::numeric_limits<DWORD>::max() - 1));
+  }
+
+  IoResult transfer_exact(HANDLE handle, void* data, const size_t size, const bool write,
+                          const std::chrono::steady_clock::time_point deadline)
+  {
+    auto*  bytes     = static_cast<std::byte*>(data);
+    size_t completed = 0;
+    while (completed < size) {
+      const auto remaining = remaining_timeout(deadline);
+      if (remaining == 0)
+        return IoResult::TimedOut;
+      unique_handle event(CreateEventW(nullptr, TRUE, FALSE, nullptr));
+      if (!event.valid())
+        return IoResult::Failed;
+      OVERLAPPED operation{};
+      operation.hEvent     = event.get();
+      const auto requested = static_cast<DWORD>(std::min<size_t>(size - completed, std::numeric_limits<DWORD>::max()));
+      DWORD      immediate = 0;
+      const auto started   = write ? WriteFile(handle, bytes + completed, requested, &immediate, &operation)
+                                   : ReadFile(handle, bytes + completed, requested, &immediate, &operation);
+      DWORD      transferred = immediate;
+      if (!started) {
+        const auto error = GetLastError();
+        if (error != ERROR_IO_PENDING)
+          return IoResult::Failed;
+        const auto wait = WaitForSingleObject(event.get(), remaining);
+        if (wait == WAIT_TIMEOUT) {
+          CancelIoEx(handle, &operation);
+          WaitForSingleObject(event.get(), INFINITE);
+          return IoResult::TimedOut;
+        }
+        if (wait != WAIT_OBJECT_0 || !GetOverlappedResult(handle, &operation, &transferred, FALSE)) {
+          return IoResult::Failed;
+        }
+      }
+      if (transferred == 0)
+        return IoResult::Failed;
+      completed += transferred;
+    }
+    return IoResult::Complete;
+  }
+
+  IoResult write_frame(HANDLE handle, const std::string_view bytes,
+                       const std::chrono::steady_clock::time_point deadline)
+  {
+    if (bytes.empty() || bytes.size() > static_cast<size_t>(std::numeric_limits<int32_t>::max()))
+      return IoResult::Failed;
+    const auto               length = static_cast<uint32_t>(bytes.size());
+    std::array<std::byte, 4> prefix{
+        std::byte(length & 0xff),
+        std::byte((length >> 8) & 0xff),
+        std::byte((length >> 16) & 0xff),
+        std::byte((length >> 24) & 0xff),
+    };
+    auto result = transfer_exact(handle, prefix.data(), prefix.size(), true, deadline);
+    if (result != IoResult::Complete)
+      return result;
+    return transfer_exact(handle, const_cast<char*>(bytes.data()), bytes.size(), true, deadline);
+  }
+
+  std::pair<IoResult, std::string> read_frame(HANDLE handle, const size_t maximum_bytes,
+                                              const std::chrono::steady_clock::time_point deadline)
+  {
+    std::array<std::byte, 4> prefix{};
+    auto                     result = transfer_exact(handle, prefix.data(), prefix.size(), false, deadline);
+    if (result != IoResult::Complete)
+      return {result, {}};
+    const auto length = std::to_integer<uint32_t>(prefix[0]) | (std::to_integer<uint32_t>(prefix[1]) << 8)
+                        | (std::to_integer<uint32_t>(prefix[2]) << 16) | (std::to_integer<uint32_t>(prefix[3]) << 24);
+    if (length == 0 || length > maximum_bytes)
+      return {IoResult::Failed, {}};
+    std::string bytes(length, '\0');
+    result = transfer_exact(handle, bytes.data(), bytes.size(), false, deadline);
+    return {result, result == IoResult::Complete ? std::move(bytes) : std::string{}};
+  }
+#endif
+} // namespace
+
+Result ParseResponse(const std::string_view response_bytes, const bool handshake)
+{
+  if (response_bytes.empty() || response_bytes.size() > kMaximumResponseBytes)
+    return {ResultCode::InvalidResponse};
+  bool       duplicate = false;
+  const auto response  = parse_closed_json(response_bytes, duplicate);
+  if (duplicate || response.is_discarded() || !has_exact_response_shape(response)) {
+    return {ResultCode::InvalidResponse};
+  }
+  const auto protocol = response["protocolVersion"].get<std::string>();
+  const auto status   = response["status"].get<std::string>();
+  const auto accepted = response["acceptedRecords"].get<int64_t>();
+  const auto failure  = response["failure"].get<std::string>();
+  if (protocol != kProtocolVersion || accepted < 0 || accepted > 4096 || !safe_failure(failure)) {
+    return {ResultCode::InvalidResponse};
+  }
+  if (handshake) {
+    return status == "ready" && accepted == 0 && failure == "none" ? Result{ResultCode::Sent}
+                                                                   : Result{ResultCode::Rejected};
+  }
+  if (status == "accepted" && failure == "none")
+    return {ResultCode::Sent, static_cast<int>(accepted)};
+  if (status == "chunk-pending" && accepted == 0 && failure == "none")
+    return {ResultCode::ChunkPending};
+  if (status == "rejected" && failure != "none")
+    return {ResultCode::Rejected};
+  return {ResultCode::InvalidResponse};
+}
+
+Result Send(const std::string_view pipe_name, const std::string_view credential, const std::string_view payload,
+            const std::chrono::milliseconds connect_timeout, const std::chrono::milliseconds request_timeout)
+{
+  if (!SidecarLocalNamedPipeNameValid(pipe_name) || !SidecarLocalNamedPipeCredentialValid(credential) || payload.empty()
+      || payload.size() > kMaximumPayloadBytes || connect_timeout.count() <= 0 || request_timeout.count() <= 0) {
+    return {ResultCode::Unavailable};
+  }
+#if !_WIN32
+  return {ResultCode::UnsupportedPlatform};
+#else
+  const std::wstring path = L"\\\\.\\pipe\\" + std::wstring(pipe_name.begin(), pipe_name.end());
+  const auto         connect_millis =
+      static_cast<DWORD>(std::clamp<int64_t>(connect_timeout.count(), 1, std::numeric_limits<DWORD>::max() - 1));
+  if (!WaitNamedPipeW(path.c_str(), connect_millis)) {
+    return {GetLastError() == ERROR_SEM_TIMEOUT ? ResultCode::TimedOut : ResultCode::Unavailable};
+  }
+  unique_handle pipe(CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr, OPEN_EXISTING,
+                                 FILE_FLAG_OVERLAPPED | SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION, nullptr));
+  if (!pipe.valid())
+    return {ResultCode::Unavailable};
+  DWORD mode = PIPE_READMODE_BYTE;
+  if (!SetNamedPipeHandleState(pipe.get(), &mode, nullptr, nullptr))
+    return {ResultCode::Unavailable};
+
+  auto header = json{
+      {"protocolVersion", kProtocolVersion},
+      {"role", kRuntimeRole},
+      {"operation", kIngestOperation},
+      {"credential",
+       credential}}.dump();
+  if (header.size() > kMaximumHeaderBytes)
+    return {ResultCode::Unavailable};
+  const auto deadline = std::chrono::steady_clock::now() + request_timeout;
+  auto       outcome  = write_frame(pipe.get(), header, deadline);
+  std::ranges::fill(header, '\0');
+  if (outcome == IoResult::TimedOut)
+    return {ResultCode::TimedOut};
+  if (outcome != IoResult::Complete)
+    return {ResultCode::Unavailable};
+  auto [read_outcome, handshake_bytes] = read_frame(pipe.get(), kMaximumResponseBytes, deadline);
+  if (read_outcome == IoResult::TimedOut)
+    return {ResultCode::TimedOut};
+  if (read_outcome != IoResult::Complete)
+    return {ResultCode::Unavailable};
+  const auto handshake = ParseResponse(handshake_bytes, true);
+  if (handshake.code != ResultCode::Sent)
+    return handshake;
+
+  outcome = write_frame(pipe.get(), payload, deadline);
+  if (outcome == IoResult::TimedOut)
+    return {ResultCode::TimedOut};
+  if (outcome != IoResult::Complete)
+    return {ResultCode::Unavailable};
+  auto [response_outcome, response_bytes] = read_frame(pipe.get(), kMaximumResponseBytes, deadline);
+  if (response_outcome == IoResult::TimedOut)
+    return {ResultCode::TimedOut};
+  if (response_outcome != IoResult::Complete)
+    return {ResultCode::Unavailable};
+  return ParseResponse(response_bytes, false);
+#endif
+}
+} // namespace sidecar_named_pipe_transport

--- a/mods/src/patches/sidecar_named_pipe_transport.h
+++ b/mods/src/patches/sidecar_named_pipe_transport.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+
+namespace sidecar_named_pipe_transport
+{
+inline constexpr std::string_view kProtocolVersion      = "stfc.battle-bridge.local-ipc.v1";
+inline constexpr std::string_view kRuntimeRole          = "stfc-mod-runtime";
+inline constexpr std::string_view kIngestOperation      = "ingest";
+inline constexpr size_t           kMaximumHeaderBytes   = 4096;
+inline constexpr size_t           kMaximumResponseBytes = 4096;
+inline constexpr size_t           kMaximumPayloadBytes  = 512 * 1024;
+
+enum class ResultCode {
+  Sent,
+  ChunkPending,
+  Rejected,
+  Unavailable,
+  TimedOut,
+  InvalidResponse,
+  UnsupportedPlatform,
+};
+
+struct Result {
+  ResultCode code             = ResultCode::Unavailable;
+  int        accepted_records = 0;
+};
+
+Result Send(std::string_view pipe_name, std::string_view credential, std::string_view payload,
+            std::chrono::milliseconds connect_timeout, std::chrono::milliseconds request_timeout);
+
+Result ParseResponse(std::string_view response, bool handshake);
+} // namespace sidecar_named_pipe_transport

--- a/scripts/config_presentation_overrides.mjs
+++ b/scripts/config_presentation_overrides.mjs
@@ -65,7 +65,19 @@ export const configPresentationOverrides = [
   {
     path: "sidecar.sync.enabled",
     label: "Local sidecar delivery",
-    help: "Sends supported mod data to the STFC Mod Sidecar running on this PC.",
+    help: "Sends supported mod data to Battle Bridge or a legacy Sidecar running on this PC.",
+    group: "Local sidecar",
+  },
+  {
+    path: "sidecar.sync.transport",
+    label: "Local transport",
+    help: "Uses authenticated Windows named pipes for Battle Bridge, or legacy HTTP for older Sidecar installations.",
+    group: "Local sidecar",
+  },
+  {
+    path: "sidecar.sync.pipe_name",
+    label: "Battle Bridge pipe",
+    help: "Launcher-managed local pipe name. Do not set this manually.",
     group: "Local sidecar",
   },
   {
@@ -116,8 +128,8 @@ export const configPresentationOverrides = [
   },
   {
     path: "sidecar.sync.url",
-    label: "Sidecar address",
-    help: "Address of the STFC Mod Sidecar running on this PC.",
+    label: "Legacy Sidecar address",
+    help: "Used only with the legacy HTTP transport. Battle Bridge uses the launcher-managed named pipe.",
     group: "Local sidecar",
   },
   {
@@ -128,20 +140,20 @@ export const configPresentationOverrides = [
   },
   {
     path: "sidecar.sync.proxy",
-    label: "Sidecar proxy",
+    label: "Legacy Sidecar proxy",
     help: null,
     group: "Local sidecar",
   },
   {
     path: "sidecar.sync.verify_ssl",
-    label: "Verify sidecar TLS certificates",
-    help: "Rejects sidecar connections whose TLS certificate cannot be verified.",
+    label: "Verify legacy Sidecar TLS",
+    help: "Used only with the legacy HTTP transport; named pipes do not use TLS.",
     group: "Local sidecar",
   },
   {
     path: "sidecar.sync.allow_unsafe_tls_without_certificate_validation",
     label: "Allow unverified sidecar TLS",
-    help: "Allows an encrypted sidecar connection without checking its certificate. Use only for a trusted local setup.",
+    help: "Legacy HTTP only. Allows an encrypted Sidecar connection without checking its certificate.",
     group: "Local sidecar",
   },
   {

--- a/scripts/generate_config_schema.mjs
+++ b/scripts/generate_config_schema.mjs
@@ -510,6 +510,7 @@ function schemaType(settingPath, value, configMemberTypes = new Map()) {
     "input.original_frame_policy": ["mod", "fallthrough_unhandled", "fallthrough_all"],
     "advanced.diagnostics.runtime_trace": ["off", "summary", "detailed", "verbose"],
     "sidecar.sync.fleet_runtime_mode": ["normal", "request_only", "snapshot_only", "enqueue_no_transport"],
+    "sidecar.sync.transport": ["legacy_http", "named_pipe"],
   };
   if (settingPath.startsWith("ui.mission_hud.")) {
     return { kind: "enum", values: ["auto", "always", "never"] };

--- a/tests/src/test_sidecar_config.cc
+++ b/tests/src/test_sidecar_config.cc
@@ -2,6 +2,7 @@
 
 #include "config_redaction.h"
 #include "config_sidecar.h"
+#include "patches/sidecar_local_ingest_policy.h"
 
 #include <string>
 #include <vector>
@@ -32,8 +33,8 @@ bool has_diagnostic_source(const std::vector<config_schema::Diagnostic>& diagnos
   return false;
 }
 
-bool has_diagnostic_message_fragment(const std::vector<config_schema::Diagnostic>& diagnostics,
-                                     std::string_view path, std::string_view fragment)
+bool has_diagnostic_message_fragment(const std::vector<config_schema::Diagnostic>& diagnostics, std::string_view path,
+                                     std::string_view fragment)
 {
   for (const auto& diagnostic : diagnostics) {
     if (diagnostic.path == path && diagnostic.message.find(fragment) != std::string::npos) {
@@ -67,6 +68,8 @@ TEST_SUITE("sidecar_config")
     const auto result = ParseSidecarConfig(config);
 
     CHECK_FALSE(result.config.sync.enabled);
+    CHECK(result.config.sync.transport == "legacy_http");
+    CHECK(result.config.sync.pipe_name.empty());
     CHECK_FALSE(result.config.sync.battlelogs_realtime);
     CHECK_FALSE(result.config.sync.battlelog_enrichment);
     CHECK_FALSE(result.config.sync.fleet_runtime);
@@ -78,6 +81,8 @@ TEST_SUITE("sidecar_config")
     auto config = toml::parse(R"(
 [sidecar.sync]
 enabled = true
+transport = "named_pipe"
+pipe_name = "stfc-mod-bridge.battle.v1"
 url = "http://127.0.0.1:43127/api/sidecar/ingest"
 
 [sidecar.logging]
@@ -89,6 +94,8 @@ jsonl_recent_logs = 300
     const auto result = ParseSidecarConfig(config);
 
     CHECK(result.config.sync.enabled);
+    CHECK(result.config.sync.transport == "named_pipe");
+    CHECK(result.config.sync.pipe_name == "stfc-mod-bridge.battle.v1");
     CHECK(result.config.sync.url == "http://127.0.0.1:43127/api/sidecar/ingest");
     CHECK_FALSE(result.advanced.diagnostics.ship_identity);
     CHECK_FALSE(result.advanced.diagnostics.battle_log_decoder);
@@ -114,6 +121,29 @@ jsonl_recent_logs = 300
     CHECK(result.advanced.queue.thin_queue_protection);
     CHECK_FALSE(result.advanced.queue.queue_add_direct_handler);
     CHECK(result.diagnostics.empty());
+  }
+
+  TEST_CASE("invalid explicit sidecar transport stays invalid and emits an error")
+  {
+    auto config = toml::parse(R"(
+[sidecar.sync]
+enabled = true
+transport = "Named_Pipe"
+pipe_name = "stfc-mod-bridge.battle.v1"
+token = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+url = "http://127.0.0.1:43127/api/sidecar/ingest"
+)");
+
+    const auto result = ParseSidecarConfig(config);
+
+    CHECK(result.config.sync.transport == "invalid");
+    CHECK(has_diagnostic(result.diagnostics, "sidecar.sync.transport", config_schema::DiagnosticSeverity::Error));
+    CHECK_FALSE(SidecarLocalSyncTransportReady(result.config.sync));
+
+    config            = toml::parse("[sidecar.sync]\nenabled = true\ntransport = 1\n");
+    const auto typed  = ParseSidecarConfig(config);
+    CHECK(typed.config.sync.transport == "invalid");
+    CHECK_FALSE(SidecarLocalSyncTransportReady(typed.config.sync));
   }
 
   TEST_CASE("parses advanced diagnostics including runtime trace, keeps sidecar sync and logging canonical, and "
@@ -255,8 +285,7 @@ queue_add_hide_viewers = "false"
     const auto result = ParseSidecarConfig(config);
 
     CHECK(has_diagnostic_source(result.diagnostics, "advanced.queue.queue_add_hide_viewers",
-                                "advanced.queue.queue_add_hide_viewers",
-                                config_schema::DiagnosticSeverity::Warning));
+                                "advanced.queue.queue_add_hide_viewers", config_schema::DiagnosticSeverity::Warning));
     CHECK(has_diagnostic_message_fragment(result.diagnostics, "advanced.queue.queue_add_hide_viewers",
                                           "Expected boolean, found string"));
   }
@@ -400,6 +429,8 @@ mode = "majel"
     SidecarConfig  sidecar;
     AdvancedConfig advanced;
     sidecar.sync.enabled                                  = true;
+    sidecar.sync.transport                                = "named_pipe";
+    sidecar.sync.pipe_name                                = "stfc-mod-bridge.battle.v1";
     sidecar.sync.url                                      = "http://127.0.0.1:43127/api/sidecar/ingest";
     sidecar.sync.token                                    = "secret-sidecar-token";
     sidecar.sync.proxy                                    = "http://user:pass@example.invalid:8080";
@@ -435,6 +466,9 @@ mode = "majel"
 
     REQUIRE(runtime_snapshot["sidecar"]["sync"]["token"].is_string());
     REQUIRE(runtime_snapshot["sidecar"]["sync"]["proxy"].is_string());
+    CHECK(runtime_snapshot["sidecar"]["sync"]["transport"].value<std::string>().value_or("") == "named_pipe");
+    CHECK(runtime_snapshot["sidecar"]["sync"]["pipe_name"].value<std::string>().value_or("")
+          == "stfc-mod-bridge.battle.v1");
     CHECK(runtime_snapshot["sidecar"]["sync"]["token"].value<std::string>().value_or("")
           == config_redaction::redact_secret_for_runtime_snapshot(sidecar.sync.token));
     CHECK(runtime_snapshot["sidecar"]["sync"]["proxy"].value<std::string>().value_or("")

--- a/tests/src/test_sidecar_local_ingest_policy.cc
+++ b/tests/src/test_sidecar_local_ingest_policy.cc
@@ -6,14 +6,24 @@
 
 namespace
 {
-  SidecarSyncConfig configured_sidecar_sync()
-  {
-    SidecarSyncConfig config;
-    config.enabled = true;
-    config.url = "http://127.0.0.1:43127/api/sidecar/ingest";
-    config.token = "local-sidecar-token";
-    return config;
-  }
+SidecarSyncConfig configured_sidecar_sync()
+{
+  SidecarSyncConfig config;
+  config.enabled = true;
+  config.url     = "http://127.0.0.1:43127/api/sidecar/ingest";
+  config.token   = "local-sidecar-token";
+  return config;
+}
+
+SidecarSyncConfig configured_named_pipe_sync()
+{
+  auto config      = configured_sidecar_sync();
+  config.transport = "named_pipe";
+  config.url.clear();
+  config.pipe_name = "stfc-mod-bridge.battle.v1";
+  config.token     = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  return config;
+}
 } // namespace
 
 TEST_SUITE("sidecar_local_ingest_policy")
@@ -45,7 +55,7 @@ TEST_SUITE("sidecar_local_ingest_policy")
 
   TEST_CASE("missing sidecar token or url disables only the local sidecar path")
   {
-    auto config = configured_sidecar_sync();
+    auto config                = configured_sidecar_sync();
     config.battlelogs_realtime = true;
 
     CHECK(SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::BattleEvents));
@@ -54,11 +64,55 @@ TEST_SUITE("sidecar_local_ingest_policy")
     CHECK_FALSE(SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::BattleEvents));
     CHECK(BattleHeaderProcessingEnabledForSync(false, false, true, false, config));
 
-    config = configured_sidecar_sync();
+    config                     = configured_sidecar_sync();
     config.battlelogs_realtime = true;
     config.url.clear();
     CHECK_FALSE(SidecarLocalSyncEnabledFor(config, SidecarLocalIngestKind::BattleEvents));
     CHECK(BattleHeaderProcessingEnabledForSync(false, true, false, false, config));
+  }
+
+  TEST_CASE("named pipe transport requires an exact safe name and 32-byte base64url credential")
+  {
+    auto config = configured_named_pipe_sync();
+#if _WIN32
+    CHECK(SidecarLocalSyncTransportReady(config));
+#else
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+#endif
+    CHECK(SidecarLocalSyncUsesNamedPipe(config));
+    CHECK(SidecarLocalNamedPipeNameValid(config.pipe_name));
+    CHECK(SidecarLocalNamedPipeCredentialValid(config.token));
+    for (const auto final_character : std::string_view{"AEIMQUYcgkosw048"}) {
+      config.token.back() = final_character;
+      CHECK(SidecarLocalNamedPipeCredentialValid(config.token));
+    }
+
+    config.pipe_name = R"(\\.\pipe\attacker)";
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    config           = configured_named_pipe_sync();
+    config.pipe_name = "../battle";
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    config       = configured_named_pipe_sync();
+    config.token = "short";
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    config              = configured_named_pipe_sync();
+    config.token.back() = '=';
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    config              = configured_named_pipe_sync();
+    config.token.back() = '_';
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    config           = configured_named_pipe_sync();
+    config.pipe_name = "battle\xC3\xA9";
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+  }
+
+  TEST_CASE("malformed or incomplete explicit transport never falls back to HTTP")
+  {
+    auto config      = configured_sidecar_sync();
+    config.transport = "named-pipe";
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
+    config.transport.clear();
+    CHECK_FALSE(SidecarLocalSyncTransportReady(config));
   }
 
   TEST_CASE("disabled and unconfigured local producer paths remain inert despite per-kind requests")
@@ -82,30 +136,25 @@ TEST_SUITE("sidecar_local_ingest_policy")
 
   TEST_CASE("battle header processing stays alive for dedicated sidecar realtime delivery")
   {
-    auto config = configured_sidecar_sync();
+    auto config                = configured_sidecar_sync();
     config.battlelogs_realtime = true;
 
     CHECK(BattleHeaderProcessingNeedsSidecarLocal(config));
     CHECK(BattleHeaderProcessingEnabledForSync(false, false, false, false, config));
 
     SidecarSyncConfig disabled_config = config;
-    disabled_config.enabled = false;
+    disabled_config.enabled           = false;
     CHECK_FALSE(BattleHeaderProcessingNeedsSidecarLocal(disabled_config));
     CHECK_FALSE(BattleHeaderProcessingEnabledForSync(false, false, false, false, disabled_config));
   }
 
   TEST_CASE("sidecar local dispatch context preserves copied payload provenance")
   {
-    const auto dispatch = gameplay_dispatch_context("battle-result-headers",
-                                                    "SyncEntityGroupHooks",
+    const auto dispatch = gameplay_dispatch_context("battle-result-headers", "SyncEntityGroupHooks",
                                                     "entity-group-json.battle_result_headers",
-                                                    "battle-result-headers-observed",
-                                                    "enqueue-battle-journal-fetch");
-    const auto context = sidecar_local_dispatch_context(dispatch,
-                                                        "stfc.sidecar.events.v0",
-                                                        "runtime-evidence",
-                                                        "sidecar-local.battle-events",
-                                                        "copied battle events only");
+                                                    "battle-result-headers-observed", "enqueue-battle-journal-fetch");
+    const auto context  = sidecar_local_dispatch_context(dispatch, "stfc.sidecar.events.v0", "runtime-evidence",
+                                                         "sidecar-local.battle-events", "copied battle events only");
 
     CHECK(context.dispatch.source == "battle-result-headers");
     CHECK(context.dispatch.owner == "SyncEntityGroupHooks");

--- a/tests/src/test_sidecar_named_pipe_transport.cc
+++ b/tests/src/test_sidecar_named_pipe_transport.cc
@@ -1,0 +1,227 @@
+#include <doctest/doctest.h>
+
+#include "patches/sidecar_named_pipe_transport.h"
+
+#include <nlohmann/json.hpp>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+#if _WIN32
+#include <windows.h>
+#endif
+
+using namespace std::chrono_literals;
+
+TEST_SUITE("sidecar_named_pipe_transport")
+{
+  TEST_CASE("closed response contract accepts only exact handshake and terminal states")
+  {
+    using sidecar_named_pipe_transport::ParseResponse;
+    using sidecar_named_pipe_transport::ResultCode;
+
+    CHECK(
+        ParseResponse(
+            R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"ready","acceptedRecords":0,"failure":"none"})",
+            true)
+            .code
+        == ResultCode::Sent);
+    const auto accepted = ParseResponse(
+        R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"accepted","acceptedRecords":3,"failure":"none"})",
+        false);
+    CHECK(accepted.code == ResultCode::Sent);
+    CHECK(accepted.accepted_records == 3);
+    CHECK(
+        ParseResponse(
+            R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"chunk-pending","acceptedRecords":0,"failure":"none"})",
+            false)
+            .code
+        == ResultCode::ChunkPending);
+    CHECK(
+        ParseResponse(
+            R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"rejected","acceptedRecords":0,"failure":"busy"})",
+            false)
+            .code
+        == ResultCode::Rejected);
+  }
+
+  TEST_CASE("hostile or noncanonical response shapes fail closed")
+  {
+    using sidecar_named_pipe_transport::ParseResponse;
+    using sidecar_named_pipe_transport::ResultCode;
+    const std::array hostile{
+        R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"ready","statu\u0073":"ready","acceptedRecords":0,"failure":"none"})",
+        R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"ready","acceptedRecords":0,"failure":"none","extra":"x"})",
+        R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v2","status":"ready","acceptedRecords":0,"failure":"none"})",
+        R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"ready","acceptedRecords":"0","failure":"none"})",
+        R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"ready","acceptedRecords":0,"failure":"secret text"})",
+        R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"accepted","acceptedRecords":1,"failure":"busy"})",
+        R"([])",
+        R"({)",
+    };
+    for (const auto* response : hostile) {
+      CHECK(ParseResponse(response, false).code == ResultCode::InvalidResponse);
+    }
+  }
+
+  TEST_CASE("invalid input rejects without opening a transport")
+  {
+    using sidecar_named_pipe_transport::ResultCode;
+    using sidecar_named_pipe_transport::Send;
+    const std::string credential(43, 'A');
+    CHECK(Send("../pipe", credential, "{}", 10ms, 10ms).code == ResultCode::Unavailable);
+    CHECK(Send("valid.pipe", "short", "{}", 10ms, 10ms).code == ResultCode::Unavailable);
+    CHECK(Send("valid.pipe", credential, "", 10ms, 10ms).code == ResultCode::Unavailable);
+    CHECK(Send("valid.pipe", credential, std::string(sidecar_named_pipe_transport::kMaximumPayloadBytes + 1, 'x'), 10ms,
+               10ms)
+              .code
+          == ResultCode::Unavailable);
+  }
+
+#if _WIN32
+  namespace
+  {
+    bool read_exact(HANDLE pipe, void* data, size_t size)
+    {
+      auto*  bytes = static_cast<std::byte*>(data);
+      size_t read  = 0;
+      while (read < size) {
+        DWORD current = 0;
+        if (!ReadFile(pipe, bytes + read, static_cast<DWORD>(size - read), &current, nullptr) || current == 0)
+          return false;
+        read += current;
+      }
+      return true;
+    }
+
+    bool write_exact(HANDLE pipe, const void* data, size_t size)
+    {
+      const auto* bytes   = static_cast<const std::byte*>(data);
+      size_t      written = 0;
+      while (written < size) {
+        DWORD current = 0;
+        if (!WriteFile(pipe, bytes + written, static_cast<DWORD>(size - written), &current, nullptr) || current == 0)
+          return false;
+        written += current;
+      }
+      return true;
+    }
+
+    std::string read_frame(HANDLE pipe)
+    {
+      std::array<std::byte, 4> prefix{};
+      if (!read_exact(pipe, prefix.data(), prefix.size()))
+        return {};
+      const auto length = std::to_integer<uint32_t>(prefix[0]) | (std::to_integer<uint32_t>(prefix[1]) << 8)
+                          | (std::to_integer<uint32_t>(prefix[2]) << 16) | (std::to_integer<uint32_t>(prefix[3]) << 24);
+      if (length == 0 || length > sidecar_named_pipe_transport::kMaximumPayloadBytes)
+        return {};
+      std::string value(length, '\0');
+      return read_exact(pipe, value.data(), value.size()) ? value : std::string{};
+    }
+
+    bool write_frame(HANDLE pipe, std::string_view value)
+    {
+      const auto               length = static_cast<uint32_t>(value.size());
+      std::array<std::byte, 4> prefix{
+          std::byte(length & 0xff),
+          std::byte((length >> 8) & 0xff),
+          std::byte((length >> 16) & 0xff),
+          std::byte((length >> 24) & 0xff),
+      };
+      return write_exact(pipe, prefix.data(), prefix.size()) && write_exact(pipe, value.data(), value.size());
+    }
+
+    HANDLE create_server(std::string_view pipe_name)
+    {
+      const std::wstring path = L"\\\\.\\pipe\\" + std::wstring(pipe_name.begin(), pipe_name.end());
+      return CreateNamedPipeW(path.c_str(), PIPE_ACCESS_DUPLEX, PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT, 1,
+                              4096, 4096, 0, nullptr);
+    }
+  } // namespace
+
+  TEST_CASE("windows client sends the exact authenticated header and payload")
+  {
+    using sidecar_named_pipe_transport::ResultCode;
+    const auto        pipe_name = "stfc-mod-pipe-test-" + std::to_string(GetCurrentProcessId()) + "-exact";
+    const std::string credential(43, 'A');
+    const std::string payload = R"({"exact":"payload bytes"})";
+    const auto        server  = create_server(pipe_name);
+    REQUIRE(server != INVALID_HANDLE_VALUE);
+    std::string      observed_header;
+    std::string      observed_payload;
+    std::atomic<int> observed_impersonation_level{-1};
+    std::thread      server_thread([&] {
+      const auto connected = ConnectNamedPipe(server, nullptr) || GetLastError() == ERROR_PIPE_CONNECTED;
+      if (!connected)
+        return;
+      if (ImpersonateNamedPipeClient(server)) {
+        HANDLE token = nullptr;
+        if (OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &token)) {
+          SECURITY_IMPERSONATION_LEVEL level{};
+          DWORD                        returned = 0;
+          if (GetTokenInformation(token, TokenImpersonationLevel, &level, sizeof(level), &returned)) {
+            observed_impersonation_level.store(static_cast<int>(level));
+          }
+          CloseHandle(token);
+        }
+        RevertToSelf();
+      }
+      observed_header = read_frame(server);
+      write_frame(
+          server,
+          R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"ready","acceptedRecords":0,"failure":"none"})");
+      observed_payload = read_frame(server);
+      write_frame(
+          server,
+          R"({"protocolVersion":"stfc.battle-bridge.local-ipc.v1","status":"accepted","acceptedRecords":1,"failure":"none"})");
+      FlushFileBuffers(server);
+      DisconnectNamedPipe(server);
+    });
+
+    const auto result = sidecar_named_pipe_transport::Send(pipe_name, credential, payload, 2s, 2s);
+    server_thread.join();
+    CloseHandle(server);
+
+    CHECK(result.code == ResultCode::Sent);
+    CHECK(result.accepted_records == 1);
+    CHECK(observed_impersonation_level.load() == static_cast<int>(SecurityIdentification));
+    CHECK(observed_payload == payload);
+    const auto header = nlohmann::json::parse(observed_header);
+    CHECK(header.size() == 4);
+    CHECK(header["protocolVersion"].get<std::string>() == std::string(sidecar_named_pipe_transport::kProtocolVersion));
+    CHECK(header["role"].get<std::string>() == std::string(sidecar_named_pipe_transport::kRuntimeRole));
+    CHECK(header["operation"].get<std::string>() == std::string(sidecar_named_pipe_transport::kIngestOperation));
+    CHECK(header["credential"].get<std::string>() == credential);
+  }
+
+  TEST_CASE("windows client applies one bounded request deadline")
+  {
+    using sidecar_named_pipe_transport::ResultCode;
+    const auto        pipe_name = "stfc-mod-pipe-test-" + std::to_string(GetCurrentProcessId()) + "-timeout";
+    const std::string credential(43, 'A');
+    const auto        server = create_server(pipe_name);
+    REQUIRE(server != INVALID_HANDLE_VALUE);
+    std::thread server_thread([&] {
+      const auto connected = ConnectNamedPipe(server, nullptr) || GetLastError() == ERROR_PIPE_CONNECTED;
+      if (!connected)
+        return;
+      static_cast<void>(read_frame(server));
+      std::this_thread::sleep_for(150ms);
+      DisconnectNamedPipe(server);
+    });
+
+    const auto started = std::chrono::steady_clock::now();
+    const auto result  = sidecar_named_pipe_transport::Send(pipe_name, credential, "{}", 1s, 40ms);
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+    server_thread.join();
+    CloseHandle(server);
+
+    CHECK(result.code == ResultCode::TimedOut);
+    CHECK(elapsed < 500ms);
+  }
+#endif
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -41,6 +41,7 @@ do
     add_files("../mods/src/patches/patch_install_policy.cc")
     add_files("../mods/src/patches/sidecar_local_chunking.cc")
     add_files("../mods/src/patches/sidecar_local_ingest_policy.cc")
+    add_files("../mods/src/patches/sidecar_named_pipe_transport.cc")
     add_files("../mods/src/patches/sync_transport_policy.cc")
 
     add_packages("doctest", "nlohmann_json", "toml++", "spdlog", "spud")
@@ -50,6 +51,7 @@ do
 
     if is_plat("windows") then
         add_cxflags("/bigobj")
+        add_syslinks("advapi32")
     end
 end
 


### PR DESCRIPTION
## Summary
- add a bounded authenticated Windows named-pipe producer for Battle Bridge while preserving legacy HTTP only for older Sidecar installations
- fail closed on malformed transport, pipe, credential, response, timeout, or rejection; named-pipe failures never fall through to HTTP
- freeze the local IPC protocol, exact frame bounds, acknowledgement-only response, and caller/server responsibility split
- retain per-feature Battle/Fleet routing without provider-name branches

## Security boundary
- exact IPv4/network paths are not used for Battle Bridge local delivery
- pipe client requests SecurityIdentification QoS so the server can identify the caller without receiving an impersonation-capable token
- credential is canonical unpadded base64url for the launcher-owned 32-byte secret and is never logged
- invalid explicit transport values, including case/type drift, disable local delivery instead of selecting legacy HTTP

## Validation
- producer contract 5/5
- config schema 21/21; generated schema current at 335 settings
- native tests 342/342, 4,387 assertions
- Windows release DLL build passed
- release-manifest tests 10/10
- clang-format check for new files and git diff --check passed

Refs #241