### PR TITLE
Promote repair action interlock to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 
 ### Fixes
 
+- Kept Repair action presentation coherent through the client model's post-completion transition and suppressed
+  stale Instant clicks during the same bounded window
 - Routed generic Armada victory and defeat results through their dedicated
   notification policies while preserving generic battle fallbacks
 - Repaired mission HUD visibility controls against the current game UI: Q Trials,

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -237,6 +237,36 @@ Risk classes are also defined there: R0 static, R1 passive runtime, R2 managed l
 - Status: runtime-observed, state-correlated, and release-promoted with a configurable, enforced 0-160 UI ceiling.
 - Next action: revalidate after relevant game updates or test a materially different non-recruit chest category.
 
+### Repair action coherence and stale-click interlock - 2026-08-11
+
+- Seams: `FleetPlayerData.GetActionStatus(ActionType)`,
+  `ActionElementWidget.GetInstantButtonContext()`, and
+  `ActionElementWidget.OnInstantButtonClickCallback()`.
+- Owner / file: `RepairActionInterlock` in `mods/src/patches/parts/repair_action_interlock.cc`; pure policy in
+  `mods/src/patches/repair_action_interlock_policy.h`.
+- Intended behavior: preserve the last coherent in-progress Repair status while the fleet is still `Repairing`, hold
+  the current instant-button presentation for at most 2.5 seconds across the proven `Docked` / previous `Repairing`
+  / native `Ready` race, and suppress an actionable stale Instant click only inside that same bounded window.
+- Static evidence: PR #168 mapped the caller chain through `JobService.UpdateJobList`,
+  `ActionElementWidget.HandleReactiveInt`, and `GetInstantButtonContext`; current dump lookup reports one exact
+  overload for each promoted seam.
+- Risk class: R5 behavioral. The interlock changes a returned status/context or omits one native click only for the
+  runtime-proven stale tuple.
+- Confidence rung: repeated in-game interception plus pure policy coverage. The science canary suppressed stale paid
+  and zero-amount clicks without blocking the following genuine Ask-for-Help request; promotion removes stack
+  capture, passive action-click observation, help-request observation, and live-debug event emission.
+- Payload confidence: `FleetPlayerData`, `ActionType`, `GenericButtonContext`, and the widget context/property shapes
+  were runtime-proven by PR #168. No managed pointer is retained.
+- Original/trampoline confidence: all three seams installed and returned normally during the investigation smokes;
+  the instant-click original is called exactly once unless the bounded stale predicate suppresses it.
+- Performance boundary: one early action-type branch for non-Repair status queries; Repair-only paths use a single
+  mutex over a fixed 16-entry array. There are no heap allocations, frame-tick work, polling, or normal-path logs;
+  only an actual suppression writes one informational line.
+- Flag / rollback path: `[patches].repairactioninterlock`, default `true`; set it to `false` and restart to remove all
+  three hooks.
+- Status: promoted from PR #168 science evidence to release-supported production behavior for issue #166.
+- Next action: revalidate the three exact seams and the bounded overhead comparison after relevant client updates.
+
 ### Static Inventory Snapshot - 2026-05-23
 
 This inventory records source-level seams from a static-only review. It does not claim new runtime observation, payload confidence, original/trampoline confidence, or product-safe status. "Operationally relied on" below means the seam is part of current product code paths; it is not a new confidence rung and is not evidence from this pass.

--- a/docs/NATIVE_SEAM_LEDGER.md
+++ b/docs/NATIVE_SEAM_LEDGER.md
@@ -262,6 +262,12 @@ Risk classes are also defined there: R0 static, R1 passive runtime, R2 managed l
 - Performance boundary: one early action-type branch for non-Repair status queries; Repair-only paths use a single
   mutex over a fixed 16-entry array. There are no heap allocations, frame-tick work, polling, or normal-path logs;
   only an actual suppression writes one informational line.
+- Performance smoke: canonical 60-second idle-system captures from clean commit `0ba8de7` used the same public
+  release DLL with this module enabled and disabled. Average process CPU was 3.422% enabled versus 3.379% disabled;
+  GPU-time p50 was 16.654 ms versus 16.666 ms and p95 was 17.742 ms versus 17.667 ms. The small, mixed deltas did not
+  reveal a regression signal in this bounded A/B sweep; capture IDs are
+  `20260811T094519Z-repair-interlock-enabled-idle-system-0ba8de7` and
+  `20260811T094720Z-repair-interlock-disabled-idle-system-0ba8de7`.
 - Flag / rollback path: `[patches].repairactioninterlock`, default `true`; set it to `false` and restart to remove all
   three hooks.
 - Status: promoted from PR #168 science evidence to release-supported production behavior for issue #166.

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -272,6 +272,8 @@ loadingscreenhooks = true
 miscpatches = true
 objecttracker = true
 panhooks = true
+# Keep Repair actions coherent while the client settles and block stale post-completion Instant clicks.
+repairactioninterlock = true
 resolutionlistfix = false
 syncpatches = true
 # Capture the game version for sync headers. Disable only to avoid a detour collision with another mod.

--- a/manifests/hook_support_tiers.json
+++ b/manifests/hook_support_tiers.json
@@ -65,6 +65,12 @@
       "rationale": "Release-supported restoration of the localized Manage Ship Below Deck Ability assignment sort through retained game behavior."
     },
     {
+      "id": "RepairActionInterlock",
+      "tier": "production",
+      "source": "mods/src/patches/parts/repair_action_interlock.cc",
+      "rationale": "Release-supported bounded Repair status/presentation hold and stale Instant-click suppression, promoted after repeated in-game interception without blocking the following genuine action."
+    },
+    {
       "id": "OpenBulkClaimGiftsHooks",
       "tier": "production",
       "source": "mods/src/patches/open_bulk_claim_gifts.cc",
@@ -133,6 +139,14 @@
       "release_example_allowed": false,
       "science_example_required": false,
       "rationale": "Detailed action queue breadcrumbs remain hidden, opt-in investigation tooling."
+    },
+    {
+      "path": "patches.repairactioninterlock",
+      "tier": "production",
+      "owner": "RepairActionInterlock",
+      "release_example_allowed": true,
+      "science_example_required": false,
+      "rationale": "Default-on public Repair action coherence and stale-click protection with an explicit rollback switch."
     },
     {
       "path": "advanced.queue.queue_repair_enabled",

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1225,6 +1225,8 @@ void Config::Load()
       get_config_or_default(config, parsed, "patches", "objecttracker", DCP::objecttracker, write_config);
   this->installFleetArrivalHooks =
       get_config_or_default(config, parsed, "patches", "fleetarrivalhooks", DCP::fleetarrivalhooks, write_config);
+  this->installRepairActionInterlock = get_config_or_default(
+      config, parsed, "patches", "repairactioninterlock", DCP::repairactioninterlock, write_config);
   this->installLoadingScreenHooks =
       get_config_or_default(config, parsed, "patches", "loadingscreenhooks", DCP::loadingscreenhooks, write_config);
   this->installTransitionScreenHooks = get_config_or_default(config, parsed, "patches", "transitionscreenhooks",

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -476,6 +476,7 @@ public:
   bool installGameVersionHook;
   bool installObjectTracker;
   bool installFleetArrivalHooks;
+  bool installRepairActionInterlock;
 
   std::string config_settings_url;
   std::string config_assets_url_override;

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -289,6 +289,7 @@ namespace Patches
   constexpr bool objecttracker              = true;  ///< In-system object tracking overlay.
   constexpr bool fleetarrivalhooks          = true;  ///< Fleet arrival detection from player fleet-state changes.
   constexpr bool panhooks                   = true;  ///< Pan-momentum hooks.
+  constexpr bool repairactioninterlock      = true;  ///< Repair action presentation and stale-click protection.
   constexpr bool resolutionlistfix          = false; ///< Resolution-list population fix; disabled after Unity 6 update.
   constexpr bool syncpatches                = true;  ///< Data-sync network hooks.
   constexpr bool game_version               = true;  ///< Capture the game version for sync request headers.

--- a/mods/src/patches/parts/repair_action_interlock.cc
+++ b/mods/src/patches/parts/repair_action_interlock.cc
@@ -1,0 +1,221 @@
+#include "patches/hook_registry.h"
+#include "patches/repair_action_interlock_policy.h"
+#include "prime/ActionData.h"
+#include "prime/FleetPlayerData.h"
+#include "prime/GenericButtonContext.h"
+
+#include <il2cpp/il2cpp_helper.h>
+#include <spdlog/spdlog.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+
+namespace
+{
+constexpr HookDescriptor kRepairActionStatusHook{
+    "FleetPlayerData.GetActionStatus(ActionType)",
+    "Preserve the last coherent Repair progress status while the client model converges.",
+    {"Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "FleetPlayerData", "GetActionStatus"},
+    "Repair action status can briefly regress to a clickable Ready state while repair is still active.",
+    HookSupportTier::Production};
+
+constexpr HookDescriptor kRepairInstantButtonContextHook{
+    "ActionElementWidget.GetInstantButtonContext()",
+    "Hold the current Repair instant-button presentation across a bounded stale post-completion transition.",
+    {"Assembly-CSharp", "Digit.Prime.Actions", "ActionElementWidget", "GetInstantButtonContext"},
+    "Repair can briefly present a stale instant action after completion.",
+    HookSupportTier::Production};
+
+constexpr HookDescriptor kRepairInstantButtonClickHook{
+    "ActionElementWidget.OnInstantButtonClickCallback()",
+    "Suppress stale Repair instant clicks only during the bounded post-completion hold.",
+    {"Assembly-CSharp", "Digit.Prime.Actions", "ActionElementWidget", "OnInstantButtonClickCallback"},
+    "A stale post-completion Repair instant click can reach the game's paid or error path.",
+    HookSupportTier::Production};
+
+struct ActionElementWidget;
+
+repair_action_interlock::State g_state;
+std::mutex                     g_state_mutex;
+
+uint64_t MonotonicMilliseconds()
+{
+  const auto elapsed = std::chrono::steady_clock::now().time_since_epoch();
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+}
+
+IL2CppClassHelper& ActionElementWidgetHelper()
+{
+  static auto helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Actions", "ActionElementWidget");
+  return helper;
+}
+
+ActionType ReadActionType(ActionElementWidget* widget)
+{
+  static auto property = ActionElementWidgetHelper().GetProperty("ActionType");
+  const auto* value    = property.Get<ActionType>(widget);
+  return value == nullptr ? ActionType::Invalid : *value;
+}
+
+FleetPlayerData* ReadFleetContext(ActionElementWidget* widget)
+{
+  static auto property = ActionElementWidgetHelper().GetProperty("Context");
+  auto*       context  = property.GetRaw<void>(widget);
+  if (context == nullptr) {
+    return nullptr;
+  }
+
+  auto* klass = il2cpp_object_get_class(reinterpret_cast<Il2CppObject*>(context));
+  if (klass == nullptr) {
+    return nullptr;
+  }
+
+  const auto* class_name      = il2cpp_class_get_name(klass);
+  const auto* class_namespace = il2cpp_class_get_namespace(klass);
+  if (class_name == nullptr || class_namespace == nullptr || std::strcmp(class_name, "FleetPlayerData") != 0
+      || std::strcmp(class_namespace, "Digit.PrimeServer.Models") != 0) {
+    return nullptr;
+  }
+  return reinterpret_cast<FleetPlayerData*>(context);
+}
+
+GenericButtonContext* ReadCurrentInstantButtonContext(ActionElementWidget* widget)
+{
+  static auto field = ActionElementWidgetHelper().GetField("_instantButtonContext");
+  if (widget == nullptr || !field.isValidHelper()) {
+    return nullptr;
+  }
+  return *reinterpret_cast<GenericButtonContext**>(reinterpret_cast<char*>(widget) + field.offset());
+}
+
+bool ReadInstantAmount(GenericButtonContext* context, int64_t& amount)
+{
+  static auto button_helper     = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "GenericButtonContext");
+  static auto resource_property = button_helper.GetProperty("ResourceData");
+  auto*       resource          = resource_property.GetRaw<void>(context);
+  if (resource == nullptr) {
+    return false;
+  }
+
+  static auto resource_helper =
+      il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "ResourceData");
+  static auto amount_property = resource_helper.GetProperty("Amount");
+  const auto* value           = amount_property.Get<int64_t>(resource);
+  if (value == nullptr) {
+    return false;
+  }
+
+  amount = *value;
+  return true;
+}
+
+int32_t FleetPlayerData_GetActionStatus_Hook(auto original, FleetPlayerData* fleet, ActionType action_type)
+{
+  const auto original_status = original(fleet, action_type);
+  if (fleet == nullptr || action_type != ActionType::Repair) {
+    return original_status;
+  }
+
+  const std::scoped_lock lock(g_state_mutex);
+  return g_state.project_status(fleet->Id, original_status, static_cast<int32_t>(fleet->CurrentState));
+}
+
+GenericButtonContext* ActionElementWidget_GetInstantButtonContext_Hook(auto original, ActionElementWidget* widget)
+{
+  auto* context = original(widget);
+  if (widget == nullptr || ReadActionType(widget) != ActionType::Repair) {
+    return context;
+  }
+
+  auto* fleet = ReadFleetContext(widget);
+  if (fleet == nullptr) {
+    return context;
+  }
+
+  repair_action_interlock::InstantContextSnapshot snapshot{};
+  snapshot.context_present = context != nullptr;
+  if (context != nullptr) {
+    snapshot.interactable = context->Interactable;
+    snapshot.has_amount   = ReadInstantAmount(context, snapshot.amount);
+  }
+
+  repair_action_interlock::PresentationDecision decision{};
+  {
+    const std::scoped_lock lock(g_state_mutex);
+    decision =
+        g_state.observe_instant_context(fleet->Id, static_cast<int32_t>(fleet->CurrentState),
+                                        static_cast<int32_t>(fleet->PreviousState), snapshot, MonotonicMilliseconds());
+  }
+
+  if (!decision.hold) {
+    return context;
+  }
+
+  auto* live_context = ReadCurrentInstantButtonContext(widget);
+  return live_context == nullptr ? context : live_context;
+}
+
+bool ShouldSuppressInstantClick(ActionElementWidget* widget)
+{
+  if (widget == nullptr || ReadActionType(widget) != ActionType::Repair) {
+    return false;
+  }
+
+  auto* fleet = ReadFleetContext(widget);
+  if (fleet == nullptr) {
+    return false;
+  }
+
+  const std::scoped_lock lock(g_state_mutex);
+  return g_state.should_suppress_instant_click(fleet->Id, static_cast<int32_t>(fleet->CurrentState),
+                                               static_cast<int32_t>(fleet->PreviousState), MonotonicMilliseconds());
+}
+
+void ActionElementWidget_OnInstantButtonClickCallback_Hook(auto original, ActionElementWidget* widget)
+{
+  if (ShouldSuppressInstantClick(widget)) {
+    spdlog::info("[RepairActionInterlock] Suppressed a stale post-completion Repair instant click");
+    return;
+  }
+  original(widget);
+}
+} // namespace
+
+void InstallRepairActionInterlockHooks()
+{
+  HookModuleHealth hooks("RepairActionInterlock");
+
+  static auto fleet_helper =
+      il2cpp_get_class_helper("Digit.Client.PrimeLib.Runtime", "Digit.PrimeServer.Models", "FleetPlayerData");
+  if (!fleet_helper.isValidHelper()) {
+    hooks.record_missing_helper(kRepairActionStatusHook);
+  } else if (auto method = fleet_helper.GetMethod("GetActionStatus", 1); method == nullptr) {
+    hooks.record_missing_method(kRepairActionStatusHook);
+  } else {
+    HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kRepairActionStatusHook, method, FleetPlayerData_GetActionStatus_Hook);
+  }
+
+  auto& widget_helper = ActionElementWidgetHelper();
+  if (!widget_helper.isValidHelper()) {
+    hooks.record_missing_helper(kRepairInstantButtonContextHook);
+    hooks.record_missing_helper(kRepairInstantButtonClickHook);
+  } else {
+    if (auto method = widget_helper.GetMethod("GetInstantButtonContext", 0); method == nullptr) {
+      hooks.record_missing_method(kRepairInstantButtonContextHook);
+    } else {
+      HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kRepairInstantButtonContextHook, method,
+                                       ActionElementWidget_GetInstantButtonContext_Hook);
+    }
+
+    if (auto method = widget_helper.GetMethod("OnInstantButtonClickCallback", 0); method == nullptr) {
+      hooks.record_missing_method(kRepairInstantButtonClickHook);
+    } else {
+      HOOK_REGISTRY_SPUD_STATIC_DETOUR(hooks, kRepairInstantButtonClickHook, method,
+                                       ActionElementWidget_OnInstantButtonClickCallback_Hook);
+    }
+  }
+
+  hooks.log_summary();
+}

--- a/mods/src/patches/patches.cc
+++ b/mods/src/patches/patches.cc
@@ -134,6 +134,7 @@ void InstallHotkeyHooks();
 void InstallOpenBulkClaimGiftsHooks();
 void InstallMissionHudTweaksHooks();
 void InstallOfficerAssignmentSortHooks();
+void InstallRepairActionInterlockHooks();
 void InstallSectionChangeRouterHooks();
 void InstallActionQueueGuardHooks();
 #if !defined(STFC_ENABLE_DEV_SCIENCE_TOOLS) || STFC_ENABLE_DEV_SCIENCE_TOOLS
@@ -288,6 +289,8 @@ __int64 il2cpp_init_hook(auto original, const char* domain_name)
        install_mission_hud_tweaks_hooks, false, true},
       {"OfficerAssignmentSort", "ui.restore_below_decks_assignment_sort", "", "OfficerAssignmentSort",
        InstallOfficerAssignmentSortHooks, install_officer_assignment_sort, false, true},
+      {"RepairActionInterlock", "patches.repairactioninterlock", "", "RepairActionInterlock",
+       InstallRepairActionInterlockHooks, cfg.installRepairActionInterlock, false, true},
       {"DeploymentRuntimeObservers", "", "fleet-runtime-observers", "", InstallDeploymentRuntimeObserverHooks, false,
        install_deployment_runtime_observers, true},
 #if !defined(STFC_ENABLE_DEV_SCIENCE_TOOLS) || STFC_ENABLE_DEV_SCIENCE_TOOLS

--- a/mods/src/patches/repair_action_interlock_policy.h
+++ b/mods/src/patches/repair_action_interlock_policy.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace repair_action_interlock
+{
+struct InstantContextSnapshot {
+  int64_t amount          = 0;
+  bool    context_present = false;
+  bool    interactable    = false;
+  bool    has_amount      = false;
+};
+
+struct PresentationDecision {
+  bool     hold       = false;
+  bool     changed    = false;
+  uint64_t elapsed_ms = 0;
+};
+
+class State
+{
+public:
+  static constexpr size_t   kCapacity       = 16;
+  static constexpr uint64_t kHoldDurationMs = 2500;
+
+  int32_t project_status(uint64_t fleet_id, int32_t original_status, int32_t current_fleet_state)
+  {
+    auto& entry = find_or_insert(fleet_id);
+
+    auto returned_status = original_status;
+    if (entry.status_initialized && original_status == kActionStatusReady && current_fleet_state == kFleetStateRepairing
+        && is_coherent_repair_progress(entry.last_coherent_status)) {
+      returned_status = entry.last_coherent_status;
+    } else {
+      entry.last_coherent_status = original_status;
+    }
+
+    entry.original_status    = original_status;
+    entry.returned_status    = returned_status;
+    entry.status_initialized = true;
+    return returned_status;
+  }
+
+  PresentationDecision observe_instant_context(uint64_t fleet_id, int32_t current_fleet_state,
+                                               int32_t                       previous_fleet_state,
+                                               const InstantContextSnapshot& instant_context, uint64_t now_ms)
+  {
+    auto& entry               = find_or_insert(fleet_id);
+    entry.instant_context     = instant_context;
+    entry.context_initialized = true;
+
+    const auto stale_transition = entry.status_initialized && current_fleet_state == kFleetStateDocked
+                                  && previous_fleet_state == kFleetStateRepairing
+                                  && entry.original_status == kActionStatusReady;
+    if (!stale_transition) {
+      const auto changed          = entry.presentation_holding;
+      entry.presentation_active   = false;
+      entry.presentation_released = false;
+      entry.presentation_holding  = false;
+      return {false, changed, 0};
+    }
+
+    if (!entry.presentation_active) {
+      entry.presentation_started_ms = now_ms;
+      entry.presentation_active     = true;
+      entry.presentation_released   = false;
+    }
+
+    const auto elapsed_ms = elapsed_since(entry.presentation_started_ms, now_ms);
+    if (elapsed_ms >= kHoldDurationMs) {
+      entry.presentation_released = true;
+    }
+
+    const auto hold            = !entry.presentation_released;
+    const auto changed         = hold != entry.presentation_holding;
+    entry.presentation_holding = hold;
+    return {hold, changed, elapsed_ms};
+  }
+
+  bool should_suppress_instant_click(uint64_t fleet_id, int32_t current_fleet_state, int32_t previous_fleet_state,
+                                     uint64_t now_ms) const
+  {
+    const auto* entry = find(fleet_id);
+    if (entry == nullptr || !entry->status_initialized || !entry->context_initialized || !entry->presentation_active
+        || entry->presentation_released || elapsed_since(entry->presentation_started_ms, now_ms) >= kHoldDurationMs) {
+      return false;
+    }
+
+    return current_fleet_state == kFleetStateDocked && previous_fleet_state == kFleetStateRepairing
+           && entry->original_status == kActionStatusReady && entry->instant_context.context_present
+           && entry->instant_context.interactable && entry->instant_context.has_amount;
+  }
+
+  size_t occupied_count() const
+  {
+    size_t count = 0;
+    for (const auto& entry : entries_) {
+      count += entry.occupied ? 1 : 0;
+    }
+    return count;
+  }
+
+private:
+  static constexpr int32_t kActionStatusReady   = 100;
+  static constexpr int32_t kFleetStateDocked    = 2;
+  static constexpr int32_t kFleetStateRepairing = 32;
+
+  struct Entry {
+    uint64_t               fleet_id             = 0;
+    int32_t                original_status      = 0;
+    int32_t                returned_status      = 0;
+    int32_t                last_coherent_status = 0;
+    InstantContextSnapshot instant_context{};
+    uint64_t               presentation_started_ms = 0;
+    bool                   status_initialized      = false;
+    bool                   context_initialized     = false;
+    bool                   presentation_active     = false;
+    bool                   presentation_released   = false;
+    bool                   presentation_holding    = false;
+    bool                   occupied                = false;
+  };
+
+  static constexpr bool is_coherent_repair_progress(int32_t status)
+  { return status == 200 || status == 201 || status == 202 || status == 300; }
+
+  static constexpr uint64_t elapsed_since(uint64_t started_ms, uint64_t now_ms)
+  { return now_ms >= started_ms ? now_ms - started_ms : 0; }
+
+  Entry* find(uint64_t fleet_id)
+  {
+    for (auto& entry : entries_) {
+      if (entry.occupied && entry.fleet_id == fleet_id) {
+        return &entry;
+      }
+    }
+    return nullptr;
+  }
+
+  const Entry* find(uint64_t fleet_id) const
+  {
+    for (const auto& entry : entries_) {
+      if (entry.occupied && entry.fleet_id == fleet_id) {
+        return &entry;
+      }
+    }
+    return nullptr;
+  }
+
+  Entry& find_or_insert(uint64_t fleet_id)
+  {
+    if (auto* entry = find(fleet_id); entry != nullptr) {
+      return *entry;
+    }
+
+    for (auto& entry : entries_) {
+      if (!entry.occupied) {
+        entry = {.fleet_id = fleet_id, .occupied = true};
+        return entry;
+      }
+    }
+
+    auto& entry = entries_[replacement_index_++ % entries_.size()];
+    entry       = {.fleet_id = fleet_id, .occupied = true};
+    return entry;
+  }
+
+  std::array<Entry, kCapacity> entries_{};
+  size_t                       replacement_index_ = 0;
+};
+} // namespace repair_action_interlock

--- a/tests/src/test_config_release_validation.cc
+++ b/tests/src/test_config_release_validation.cc
@@ -81,6 +81,7 @@ TEST_CASE("example config does not reintroduce abandoned ghost or manual refresh
   const auto* debug          = config["debug"].as_table();
   const auto* advanced       = config["advanced"]["diagnostics"].as_table();
   const auto* advanced_files = config["advanced"]["diagnostics"]["files"].as_table();
+  const auto* patches        = config["patches"].as_table();
 
   CHECK(source.find("manual_navigation_refresh") == std::string::npos);
   CHECK(source.find("ghost_owner_diagnostics") == std::string::npos);
@@ -90,6 +91,7 @@ TEST_CASE("example config does not reintroduce abandoned ghost or manual refresh
   CHECK(source.find("example_science_patch_settings.toml") != std::string::npos);
   REQUIRE(advanced != nullptr);
   REQUIRE(advanced_files != nullptr);
+  REQUIRE(patches != nullptr);
   const auto debug_has_live_query    = debug != nullptr && debug->contains("live_query");
   const auto debug_has_runtime_trace = debug != nullptr && debug->contains("runtime_trace");
   const auto debug_has_runtime_trace_track_overhead =
@@ -127,6 +129,8 @@ TEST_CASE("example config does not reintroduce abandoned ghost or manual refresh
   CHECK_FALSE(advanced_files->contains("main_log_files"));
   CHECK(advanced_files->get("root")->value<std::string>().value_or("non-empty").empty());
   CHECK(config["advanced"]["queue"]["thin_queue_protection"].value<bool>().value_or(false));
+  REQUIRE(patches->contains("repairactioninterlock"));
+  CHECK(patches->get("repairactioninterlock")->value<bool>().value_or(false));
 }
 
 TEST_CASE("example config exposes only the public supported notification event surface")

--- a/tests/src/test_repair_action_interlock_policy.cc
+++ b/tests/src/test_repair_action_interlock_policy.cc
@@ -1,0 +1,93 @@
+#include <doctest/doctest.h>
+
+#include "patches/repair_action_interlock_policy.h"
+
+TEST_SUITE("repair_action_interlock_policy")
+{
+  using repair_action_interlock::InstantContextSnapshot;
+  using repair_action_interlock::State;
+
+  TEST_CASE("holds the last coherent Repair progress status across transient Ready")
+  {
+    State state;
+
+    CHECK(state.project_status(7, 202, 32) == 202);
+    CHECK(state.project_status(7, 100, 32) == 202);
+    CHECK(state.project_status(7, 100, 32) == 202);
+    CHECK(state.project_status(7, 200, 32) == 200);
+  }
+
+  TEST_CASE("does not invent progress without a coherent prior status")
+  {
+    State state;
+
+    CHECK(state.project_status(7, 100, 32) == 100);
+    CHECK(state.project_status(8, 202, 32) == 202);
+    CHECK(state.project_status(8, 100, 2) == 100);
+  }
+
+  TEST_CASE("holds stale post-completion presentation for a bounded window")
+  {
+    State state;
+    state.project_status(7, 202, 32);
+    state.project_status(7, 100, 2);
+
+    const InstantContextSnapshot stale_paid{101558, true, true, true};
+    const auto                   first = state.observe_instant_context(7, 2, 32, stale_paid, 1000);
+    CHECK(first.hold);
+    CHECK(first.changed);
+    CHECK(first.elapsed_ms == 0);
+
+    const auto still_held = state.observe_instant_context(7, 2, 32, stale_paid, 3499);
+    CHECK(still_held.hold);
+    CHECK_FALSE(still_held.changed);
+
+    const auto released = state.observe_instant_context(7, 2, 32, stale_paid, 3500);
+    CHECK_FALSE(released.hold);
+    CHECK(released.changed);
+    CHECK(released.elapsed_ms == State::kHoldDurationMs);
+  }
+
+  TEST_CASE("suppresses only actionable stale clicks inside the hold window")
+  {
+    State state;
+    state.project_status(7, 202, 32);
+    state.project_status(7, 100, 2);
+    state.observe_instant_context(7, 2, 32, {0, true, true, true}, 1000);
+
+    CHECK(state.should_suppress_instant_click(7, 2, 32, 1001));
+    CHECK_FALSE(state.should_suppress_instant_click(7, 32, 2, 1001));
+    CHECK_FALSE(state.should_suppress_instant_click(7, 2, 32, 3500));
+
+    State missing_amount;
+    missing_amount.project_status(8, 202, 32);
+    missing_amount.project_status(8, 100, 2);
+    missing_amount.observe_instant_context(8, 2, 32, {0, true, true, false}, 1000);
+    CHECK_FALSE(missing_amount.should_suppress_instant_click(8, 2, 32, 1001));
+  }
+
+  TEST_CASE("coherent re-entry releases presentation and click suppression immediately")
+  {
+    State state;
+    state.project_status(7, 202, 32);
+    state.project_status(7, 100, 2);
+    state.observe_instant_context(7, 2, 32, {970810, true, true, true}, 1000);
+    CHECK(state.should_suppress_instant_click(7, 2, 32, 1001));
+
+    state.project_status(7, 202, 32);
+    const auto released = state.observe_instant_context(7, 32, 2, {7, true, true, true}, 1100);
+    CHECK_FALSE(released.hold);
+    CHECK(released.changed);
+    CHECK_FALSE(state.should_suppress_instant_click(7, 32, 2, 1101));
+  }
+
+  TEST_CASE("retains a fixed maximum number of fleet records")
+  {
+    State state;
+    for (uint64_t fleet_id = 1; fleet_id <= State::kCapacity + 4; ++fleet_id) {
+      state.project_status(fleet_id, 202, 32);
+    }
+    CHECK(state.occupied_count() == State::kCapacity);
+    CHECK(sizeof(State) <= 2048);
+  }
+}


### PR DESCRIPTION
## Summary

- promote the runtime-proven Repair action-state coherence fix from the science work in #168
- preserve the last coherent in-progress Repair status while the client model converges
- hold the current Instant-button presentation for at most 2.5 seconds across the proven Docked / previous Repairing / native Ready race
- suppress an actionable stale Instant click only inside that same bounded window
- ship the module as production-tier, default-on behavior with `patches.repairactioninterlock = false` as an explicit restart rollback

## Promotion boundary

This intentionally leaves the investigation machinery behind: no stack capture, passive action-click hook, help-request hook, live-debug events, polling, retained managed pointers, or normal-path logging. It addresses the proven repair click race from #166; it does not claim to solve the broader stuck-fleet investigation in #167.

PR #168 remains the research/evidence record. This PR is its focused production successor.

## Evidence

- two in-game stale Repair Instant clicks were intercepted without blocking the following genuine action
- current client dump exposes exactly one matching overload for each of the three promoted seams
- release runtime smoke installed all 3/3 production hooks with no recent runtime errors
- fixed-capacity 16-fleet policy state; non-Repair status queries exit before the mutex
- no heap allocation, frame-tick work, polling, or normal-path logs

## Performance sweep

Canonical 60-second idle-system A/B captures used the same public release DLL from clean commit `0ba8de7`:

| Metric | Enabled | Disabled |
| --- | ---: | ---: |
| Average process CPU | 3.422% | 3.379% |
| GPU time p50 | 16.654 ms | 16.666 ms |
| GPU time p95 | 17.742 ms | 17.667 ms |

The small, mixed deltas did not reveal a regression signal in this bounded smoke comparison.

## Validation

- `353/353` pure tests passed, `4461/4461` assertions
- strict Windows public-release build passed
- hook support-tier validation passed with zero warnings
- release validation passed
- `git diff --check` passed
- full review-contract scanner has one pre-existing stale `sync.cc` baseline entry on `main`; it reports zero new unmanaged findings from this PR

Closes #166
