### PR TITLE
Fix Scopely hotkeys after M94 cold restart

### DIFF
--- a/docs/windows-launcher/config-schema.guffawaffle.v1.json
+++ b/docs/windows-launcher/config-schema.guffawaffle.v1.json
@@ -157,53 +157,6 @@
       }
     },
     {
-      "path": "advanced.diagnostics.debug",
-      "title": "Debug",
-      "description": "Configure debug.",
-      "category": "advanced",
-      "control": "scalar",
-      "valueType": {
-        "kind": "boolean"
-      },
-      "default": false,
-      "platforms": [
-        "windows",
-        "macos"
-      ],
-      "apply": "next-session",
-      "sensitivity": "public",
-      "stability": "internal",
-      "sourceSupport": [
-        "guffawaffle"
-      ],
-      "aliases": [
-        {
-          "path": "sidecar.diagnostics.debug",
-          "status": "deprecated",
-          "precedence": "canonical-wins"
-        }
-      ],
-      "provenance": {
-        "runtimePath": "advanced.diagnostics.debug",
-        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.debug"
-      },
-      "presentation": {
-        "label": "Debug",
-        "group": "Advanced",
-        "searchTerms": [
-          "advanced.diagnostics.debug",
-          "Debug",
-          "Configure debug.",
-          "advanced",
-          "sidecar.diagnostics.debug"
-        ],
-        "editorWidth": "compact",
-        "applyTiming": "Next launch",
-        "accessibleName": "Debug",
-        "accessibleHelp": "Applies: Next launch."
-      }
-    },
-    {
       "path": "advanced.diagnostics.files.action_queue_probe_files",
       "title": "Action Queue Probe Files",
       "description": "Configure action queue probe files.",
@@ -461,7 +414,7 @@
     {
       "path": "advanced.diagnostics.hotkey_suppression_logging",
       "title": "Hotkey Suppression Logging",
-      "description": "Verbose breadcrumbs for noisy diagnostics. These remain off by default even when advanced.diagnostics.debug is enabled.",
+      "description": "Verbose breadcrumbs for noisy diagnostics. These are independent; the reserved compatibility keys above do not gate them.",
       "category": "advanced",
       "control": "scalar",
       "valueType": {
@@ -485,18 +438,18 @@
       },
       "presentation": {
         "label": "Hotkey suppression logging",
-        "help": "Verbose breadcrumbs for noisy diagnostics. These remain off by default even when advanced.diagnostics.debug is enabled.",
+        "help": "Verbose breadcrumbs for noisy diagnostics. These are independent; the reserved compatibility keys above do not gate them.",
         "group": "Advanced",
         "searchTerms": [
           "advanced.diagnostics.hotkey_suppression_logging",
           "Hotkey Suppression Logging",
-          "Verbose breadcrumbs for noisy diagnostics. These remain off by default even when advanced.diagnostics.debug is enabled.",
+          "Verbose breadcrumbs for noisy diagnostics. These are independent; the reserved compatibility keys above do not gate them.",
           "advanced"
         ],
         "editorWidth": "compact",
         "applyTiming": "Next launch",
         "accessibleName": "Hotkey suppression logging",
-        "accessibleHelp": "Verbose breadcrumbs for noisy diagnostics. These remain off by default even when advanced.diagnostics.debug is enabled. Applies: Next launch."
+        "accessibleHelp": "Verbose breadcrumbs for noisy diagnostics. These are independent; the reserved compatibility keys above do not gate them. Applies: Next launch."
       }
     },
     {
@@ -1023,53 +976,6 @@
       }
     },
     {
-      "path": "advanced.diagnostics.logging",
-      "title": "Logging",
-      "description": "Configure logging.",
-      "category": "advanced",
-      "control": "scalar",
-      "valueType": {
-        "kind": "boolean"
-      },
-      "default": false,
-      "platforms": [
-        "windows",
-        "macos"
-      ],
-      "apply": "next-session",
-      "sensitivity": "public",
-      "stability": "internal",
-      "sourceSupport": [
-        "guffawaffle"
-      ],
-      "aliases": [
-        {
-          "path": "sidecar.diagnostics.logging",
-          "status": "deprecated",
-          "precedence": "canonical-wins"
-        }
-      ],
-      "provenance": {
-        "runtimePath": "advanced.diagnostics.logging",
-        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.logging"
-      },
-      "presentation": {
-        "label": "Logging",
-        "group": "Advanced",
-        "searchTerms": [
-          "advanced.diagnostics.logging",
-          "Logging",
-          "Configure logging.",
-          "advanced",
-          "sidecar.diagnostics.logging"
-        ],
-        "editorWidth": "compact",
-        "applyTiming": "Next launch",
-        "accessibleName": "Logging",
-        "accessibleHelp": "Applies: Next launch."
-      }
-    },
-    {
       "path": "advanced.diagnostics.mod_impact_monitor",
       "title": "Mod Impact Monitor",
       "description": "Enable periodic runtime impact summaries for frame-owned mod hooks. Default: false.",
@@ -1189,6 +1095,86 @@
         "applyTiming": "Next launch",
         "accessibleName": "Refinery diagnostics",
         "accessibleHelp": "Enable focused refinery lifecycle/action diagnostics in community_patch.log. Applies: Next launch."
+      }
+    },
+    {
+      "path": "advanced.diagnostics.reserved_native_debug",
+      "title": "Reserved Native Debug",
+      "description": "Configure reserved native debug.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.reserved_native_debug",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.reserved_native_debug"
+      },
+      "presentation": {
+        "label": "Reserved native debug",
+        "group": "Advanced",
+        "searchTerms": [
+          "advanced.diagnostics.reserved_native_debug",
+          "Reserved Native Debug",
+          "Configure reserved native debug.",
+          "advanced"
+        ],
+        "editorWidth": "compact",
+        "applyTiming": "Next launch",
+        "accessibleName": "Reserved native debug",
+        "accessibleHelp": "Applies: Next launch."
+      }
+    },
+    {
+      "path": "advanced.diagnostics.reserved_native_payload_logging",
+      "title": "Reserved Native Payload Logging",
+      "description": "Configure reserved native payload logging.",
+      "category": "advanced",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "internal",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "advanced.diagnostics.reserved_native_payload_logging",
+        "defaultSource": "mods/src/defaultconfig.h:advanced.diagnostics.reserved_native_payload_logging"
+      },
+      "presentation": {
+        "label": "Reserved native payload logging",
+        "group": "Advanced",
+        "searchTerms": [
+          "advanced.diagnostics.reserved_native_payload_logging",
+          "Reserved Native Payload Logging",
+          "Configure reserved native payload logging.",
+          "advanced"
+        ],
+        "editorWidth": "compact",
+        "applyTiming": "Next launch",
+        "accessibleName": "Reserved native payload logging",
+        "accessibleHelp": "Applies: Next launch."
       }
     },
     {
@@ -8215,6 +8201,47 @@
         "applyTiming": "Next launch",
         "accessibleName": "Original frame policy",
         "accessibleHelp": "Explicit original frame policy: mod, fallthrough_unhandled, fallthrough_all. Applies: Next launch."
+      }
+    },
+    {
+      "path": "input.repair_orphaned_tutorial_shortcut_gate",
+      "title": "Repair Orphaned Tutorial Shortcut Gate",
+      "description": "Repair the M94 orphaned tutorial flag that can leave Scopely shortcuts disabled after restart. Default: false.",
+      "category": "input",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": false,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "next-session",
+      "sensitivity": "public",
+      "stability": "experimental",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "input.repair_orphaned_tutorial_shortcut_gate",
+        "defaultSource": "mods/src/defaultconfig.h:input.repair_orphaned_tutorial_shortcut_gate"
+      },
+      "presentation": {
+        "label": "Repair orphaned tutorial shortcut gate",
+        "help": "Repair the M94 orphaned tutorial flag that can leave Scopely shortcuts disabled after restart.",
+        "group": "Input",
+        "searchTerms": [
+          "input.repair_orphaned_tutorial_shortcut_gate",
+          "Repair Orphaned Tutorial Shortcut Gate",
+          "Repair the M94 orphaned tutorial flag that can leave Scopely shortcuts disabled after restart. Default: false.",
+          "input"
+        ],
+        "editorWidth": "compact",
+        "applyTiming": "Next launch",
+        "accessibleName": "Repair orphaned tutorial shortcut gate",
+        "accessibleHelp": "Repair the M94 orphaned tutorial flag that can leave Scopely shortcuts disabled after restart. Applies: Next launch."
       }
     },
     {
@@ -16134,6 +16161,47 @@
         "applyTiming": "Restart required",
         "accessibleName": "Panhooks",
         "accessibleHelp": "Pan-momentum hooks. Applies: Restart required."
+      }
+    },
+    {
+      "path": "patches.repairactioninterlock",
+      "title": "Repairactioninterlock",
+      "description": "Repair action presentation and stale-click protection.",
+      "category": "patches",
+      "control": "scalar",
+      "valueType": {
+        "kind": "boolean"
+      },
+      "default": true,
+      "platforms": [
+        "windows",
+        "macos"
+      ],
+      "apply": "restart-required",
+      "sensitivity": "public",
+      "stability": "advanced",
+      "sourceSupport": [
+        "guffawaffle"
+      ],
+      "aliases": [],
+      "provenance": {
+        "runtimePath": "patches.repairactioninterlock",
+        "defaultSource": "mods/src/defaultconfig.h:patches.repairactioninterlock"
+      },
+      "presentation": {
+        "label": "Repairactioninterlock",
+        "help": "Repair action presentation and stale-click protection.",
+        "group": "Patches",
+        "searchTerms": [
+          "patches.repairactioninterlock",
+          "Repairactioninterlock",
+          "Repair action presentation and stale-click protection.",
+          "patches"
+        ],
+        "editorWidth": "compact",
+        "applyTiming": "Restart required",
+        "accessibleName": "Repairactioninterlock",
+        "accessibleHelp": "Repair action presentation and stale-click protection. Applies: Restart required."
       }
     },
     {

--- a/example_community_patch_settings.toml
+++ b/example_community_patch_settings.toml
@@ -107,6 +107,9 @@ scopely_shortcuts = "off"
 # Original ScreenManager frame policy: mod, fallthrough_unhandled, or fallthrough_all
 original_frame_policy = "mod"
 
+# Repair the M94 orphaned tutorial state that can disable Scopely hotkeys after restart
+repair_orphaned_tutorial_shortcut_gate = false
+
 #  <[============================================================]>
 #
 #        ****                       *        *

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -48,6 +48,7 @@ namespace DCAQ  = DefaultConfig::Advanced::Queue;
 namespace DCAKQ = DefaultConfig::Advanced::KirsharaQueue;
 namespace DCN   = DefaultConfig::Notifications;
 namespace DCC   = DefaultConfig::Control;
+namespace DCI   = DefaultConfig::Input;
 namespace DCU   = DefaultConfig::UI;
 namespace DCMH  = DefaultConfig::UI::MissionHud;
 namespace DCBS  = DefaultConfig::Buffs;
@@ -71,11 +72,12 @@ using config_metadata::notificationToggleSpecs;
 static_assert(!DCS::allow_unsafe_tls_without_certificate_validation, "Unsafe TLS override default must remain false.");
 
 // Legacy settings exposed through read-only accessors.
-static bool                      g_allow_key_fallthrough    = false;
-static ScopelyShortcutPolicy     g_scopely_shortcuts_policy = ScopelyShortcutPolicy::Off;
-static OriginalFramePolicy       g_original_frame_policy    = OriginalFramePolicy::Mod;
-static bool                      g_live_debug_channel       = DCAD::live_query;
-static bool                      g_queue_repair_enabled     = DCAQ::queue_repair_enabled;
+static bool                      g_allow_key_fallthrough                  = false;
+static ScopelyShortcutPolicy     g_scopely_shortcuts_policy               = ScopelyShortcutPolicy::Off;
+static OriginalFramePolicy       g_original_frame_policy                  = OriginalFramePolicy::Mod;
+static bool                      g_repair_orphaned_tutorial_shortcut_gate = DCI::repair_orphaned_tutorial_shortcut_gate;
+static bool                      g_live_debug_channel                     = DCAD::live_query;
+static bool                      g_queue_repair_enabled                   = DCAQ::queue_repair_enabled;
 static KirsharaQueueRepairConfig g_kirshara_queue_repair_config{};
 static bool                      g_queue_add_direct_handler    = DCAQ::queue_add_direct_handler;
 static bool                      g_battle_log_decoder_enabled  = false;
@@ -105,6 +107,9 @@ ScopelyShortcutPolicy ScopelyShortcutsPolicy()
 
 OriginalFramePolicy OriginalFramePolicySetting()
 { return g_original_frame_policy; }
+
+bool RepairOrphanedTutorialShortcutGate()
+{ return g_repair_orphaned_tutorial_shortcut_gate; }
 
 bool LiveDebugChannelEnabled()
 { return g_live_debug_channel; }
@@ -1296,13 +1301,19 @@ void Config::Load()
     spdlog::warn("Ignoring [control].original_frame_policy because [input].original_frame_policy is set.");
   }
 
+  g_repair_orphaned_tutorial_shortcut_gate = read_bool_config_entry(
+      config, parsed, "input", "repair_orphaned_tutorial_shortcut_gate", "repair_orphaned_tutorial_shortcut_gate",
+      DCI::repair_orphaned_tutorial_shortcut_gate,
+      "Repair the M94 orphaned tutorial state that blocks Scopely shortcuts after restart.", write_config);
+
   write_input_policy_config(parsed, g_scopely_shortcuts_policy, g_original_frame_policy);
 
   spdlog::info(
       "[Hotkeys] config installHotkeyHooks={} hotkeys_enabled={} use_scopely_hotkeys={} allow_key_fallthrough={} "
-      "scopely_shortcuts={} original_frame_policy={}",
+      "scopely_shortcuts={} original_frame_policy={} repair_orphaned_tutorial_shortcut_gate={}",
       this->installHotkeyHooks, this->hotkeys_enabled, this->use_scopely_hotkeys, g_allow_key_fallthrough,
-      scopely_shortcut_policy_name(g_scopely_shortcuts_policy), original_frame_policy_name(g_original_frame_policy));
+      scopely_shortcut_policy_name(g_scopely_shortcuts_policy), original_frame_policy_name(g_original_frame_policy),
+      g_repair_orphaned_tutorial_shortcut_gate);
 
   if (g_allow_key_fallthrough && !this->use_scopely_hotkeys && !explicit_scopely_policy && !explicit_frame_policy
       && !legacy_scopely_hotkeys_config.policy_override && !legacy_control_frame_policy) {

--- a/mods/src/config.h
+++ b/mods/src/config.h
@@ -511,6 +511,11 @@ ScopelyShortcutPolicy ScopelyShortcutsPolicy();
 OriginalFramePolicy OriginalFramePolicySetting();
 
 /**
+ * @brief Whether the guarded M94 orphaned-tutorial shortcut repair is enabled.
+ */
+bool RepairOrphanedTutorialShortcutGate();
+
+/**
  * @brief Whether the file-backed live debug channel is enabled.
  */
 bool LiveDebugChannelEnabled();

--- a/mods/src/config_release_validation.cc
+++ b/mods/src/config_release_validation.cc
@@ -68,6 +68,7 @@ namespace
       "graphics.use_presets_as_default",
       "graphics.zoom",
       "input.original_frame_policy",
+      "input.repair_orphaned_tutorial_shortcut_gate",
       "input.scopely_shortcuts",
       "sidecar.logging.jsonl",
       "sidecar.logging.jsonl_recent_logs",

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -45,6 +45,12 @@ namespace Control
   constexpr auto select_timer = 500;
 } // namespace Control
 
+namespace Input
+{
+  /// Repair the M94 orphaned tutorial flag that can leave Scopely shortcuts disabled after restart. Default: false.
+  constexpr bool repair_orphaned_tutorial_shortcut_gate = false;
+} // namespace Input
+
 namespace Graphics
 {
   /// Start in borderless-fullscreen mode. Default: true.

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -30,13 +30,15 @@
 
 namespace
 {
-constexpr bool kEnableShortcutInitializeHook       = true;
-constexpr bool kEnableShortcutLateUpdateGuardHook  = true;
-constexpr bool kEnableRewardsButtonHook            = true;
-constexpr bool kEnablePreScanTargetHook            = true;
-constexpr bool kEnableSectionManagerBackButtonHook = true;
-constexpr bool kEnableNavigationSetCourseHook      = true;
-constexpr bool kEnableFleetBarSelectionGuardHooks  = true;
+constexpr bool     kEnableShortcutInitializeHook             = true;
+constexpr bool     kEnableShortcutLateUpdateGuardHook        = true;
+constexpr bool     kEnableRewardsButtonHook                  = true;
+constexpr bool     kEnablePreScanTargetHook                  = true;
+constexpr bool     kEnableSectionManagerBackButtonHook       = true;
+constexpr bool     kEnableNavigationSetCourseHook            = true;
+constexpr bool     kEnableFleetBarSelectionGuardHooks        = true;
+// Require two stable samples while keeping the player-visible delay near one second at 60 FPS.
+constexpr uint64_t kOrphanedTutorialShortcutGateSampleFrames = 60;
 
 const char* initialize_actions_reason()
 { return scopely_shortcut_policy_name(ScopelyShortcutsPolicy()); }
@@ -225,6 +227,283 @@ bool inspect_native_fleet_selection_component(const char* method, void* element,
   return suppress_any;
 }
 
+template <typename T> bool read_instance_field(void* instance, FieldInfo* field, T& value)
+{
+  if (!instance || !field) {
+    return false;
+  }
+
+  value = *reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(instance) + il2cpp_field_get_offset(field));
+  return true;
+}
+
+template <typename T> bool read_object_field(void* object, const char* field_name, T& value)
+{
+  if (!object) {
+    return false;
+  }
+
+  auto* klass = il2cpp_object_get_class(reinterpret_cast<Il2CppObject*>(object));
+  auto* field = klass ? il2cpp_class_get_field_from_name(klass, field_name) : nullptr;
+  return read_instance_field(object, field, value);
+}
+
+struct OrphanedTutorialShortcutRuntimeEvidence {
+  OrphanedTutorialShortcutGateState state;
+  void*                             mission         = nullptr;
+  void*                             step            = nullptr;
+  FieldInfo*                        is_active_field = nullptr;
+  bool (*get_is_active)()                           = nullptr;
+  bool (*get_can_use_shortcuts)()                   = nullptr;
+};
+
+OrphanedTutorialShortcutRuntimeEvidence collect_orphaned_tutorial_shortcut_evidence(void* shortcuts_manager)
+{
+  OrphanedTutorialShortcutRuntimeEvidence evidence;
+  auto&                                   state = evidence.state;
+  state.repair_enabled                          = RepairOrphanedTutorialShortcutGate();
+  state.native_shortcuts_enabled                = ScopelyShortcutsPolicy() != ScopelyShortcutPolicy::Off;
+
+  if (!shortcuts_manager || !state.repair_enabled || !state.native_shortcuts_enabled) {
+    return evidence;
+  }
+
+  static auto shortcuts_helper =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.GameInput", "ShortcutsManager");
+  static auto* actions_field = il2cpp_class_get_field_from_name(shortcuts_helper.get_cls(), "_actions");
+  static auto* show_keybindings_field =
+      il2cpp_class_get_field_from_name(shortcuts_helper.get_cls(), "_showKeybindings");
+  static auto get_can_use_shortcuts = shortcuts_helper.GetMethod<bool()>("get_CanUseShortcuts");
+
+  static auto hub_helper               = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.Core", "Hub");
+  static auto get_video_player_manager = hub_helper.GetMethod<void*()>("get_VideoPlayerManager");
+  static auto get_shop_scene_manager   = hub_helper.GetMethod<void*()>("get_ShopSceneManager");
+  static auto get_tutorial_manager     = hub_helper.GetMethod<void*()>("get_TutorialManager");
+
+  static auto video_player_manager_helper =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Videos", "VideoPlayerManager");
+  static auto get_is_video_playing = video_player_manager_helper.GetMethod<bool(void*)>("get_IsVideoPlaying");
+
+  static auto tutorial_manager_helper =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Tutorial", "TutorialManager");
+  static auto  get_is_tutorial_active   = tutorial_manager_helper.GetMethod<bool()>("get_IsActive");
+  static auto  get_is_tutorial_blocking = tutorial_manager_helper.GetMethod<bool()>("get_IsBlockingInput");
+  static auto* tutorial_is_active_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_isActive");
+  static auto* tutorial_ui_field = il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_loadAndShow");
+  static auto* tutorial_mission_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentMission");
+  static auto* tutorial_objective_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentTutorialObjective");
+  static auto* tutorial_data_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentTutorialData");
+  static auto* tutorial_component_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentComponent");
+  static auto* tutorial_items_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentObjectiveTutorialItems");
+  static auto* tutorial_end_step_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_endMissionTutorialStep");
+  static auto* tutorial_next_step_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_nextTutorialStep");
+  static auto* tutorial_step_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentTutorialStep");
+  static auto* tutorial_step_index_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentTutorialStepIndex");
+  static auto* tutorial_next_action_id_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_nextTutorialActionID");
+  static auto* tutorial_objective_being_cleared_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentObjectiveBeingCleared");
+  static auto* tutorial_target_section_field =
+      il2cpp_class_get_field_from_name(tutorial_manager_helper.get_cls(), "_currentTargetSection");
+
+  static auto message_box_helper         = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "MessageBox");
+  static auto get_is_message_box_visible = message_box_helper.GetMethod<bool()>("get_IsMessageBoxVisible");
+
+  static auto  touch_kit_helper  = il2cpp_get_class_helper("TouchKit", "", "TouchKit");
+  static auto* block_touch_field = il2cpp_class_get_field_from_name(touch_kit_helper.get_cls(), "BlockTouch");
+
+  static auto ui_manager_helper = il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.SharedFeatures", "UIManager");
+  static auto ui_manager_parent = ui_manager_helper.GetParent("MonoSingleton`1");
+  static auto ui_manager_instance  = ui_manager_parent.GetProperty("Instance");
+  static auto get_is_popup_visible = ui_manager_helper.GetMethod<bool(void*)>("get_IsPopupVisible");
+
+  static auto shop_scene_manager_helper =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Prime.Shop", "ShopSceneManager");
+  static auto* plc_offer_popup_field =
+      il2cpp_class_get_field_from_name(shop_scene_manager_helper.get_cls(), "_plcOfferPopupLoadAndShow");
+  static auto generic_load_and_show_helper =
+      il2cpp_get_class_helper("Assembly-CSharp", "Digit.Client.UI", "GenericLoadAndShowUI");
+  static auto is_open = generic_load_and_show_helper.GetMethod<bool(void*)>("IsOpen");
+
+  const auto bindings_complete =
+      shortcuts_helper.isValidHelper() && actions_field && show_keybindings_field && get_can_use_shortcuts
+      && hub_helper.isValidHelper() && get_video_player_manager && get_shop_scene_manager && get_tutorial_manager
+      && video_player_manager_helper.isValidHelper() && get_is_video_playing && tutorial_manager_helper.isValidHelper()
+      && get_is_tutorial_active && get_is_tutorial_blocking && tutorial_is_active_field && tutorial_ui_field
+      && tutorial_mission_field && tutorial_objective_field && tutorial_data_field && tutorial_component_field
+      && tutorial_items_field && tutorial_end_step_field && tutorial_next_step_field && tutorial_step_field
+      && tutorial_step_index_field && tutorial_next_action_id_field && tutorial_objective_being_cleared_field
+      && tutorial_target_section_field && message_box_helper.isValidHelper() && get_is_message_box_visible
+      && touch_kit_helper.isValidHelper() && block_touch_field && ui_manager_helper.isValidHelper()
+      && ui_manager_parent.isValidHelper() && ui_manager_instance.isValidHelper() && get_is_popup_visible
+      && shop_scene_manager_helper.isValidHelper() && plc_offer_popup_field
+      && generic_load_and_show_helper.isValidHelper() && is_open;
+  if (!bindings_complete) {
+    return evidence;
+  }
+
+  evidence.is_active_field       = tutorial_is_active_field;
+  evidence.get_is_active         = get_is_tutorial_active;
+  evidence.get_can_use_shortcuts = get_can_use_shortcuts;
+  state.can_use_shortcuts        = get_can_use_shortcuts();
+  state.tutorial_active          = get_is_tutorial_active();
+  state.tutorial_blocking        = get_is_tutorial_blocking();
+  state.message_box_visible      = get_is_message_box_visible();
+  state.input_focused            = Key::IsInputFocused();
+  il2cpp_field_static_get_value(block_touch_field, &state.touch_blocked);
+
+  void* actions        = nullptr;
+  auto  reads_complete = read_instance_field(shortcuts_manager, actions_field, actions)
+                         && read_instance_field(shortcuts_manager, show_keybindings_field, state.show_keybindings);
+
+  static auto input_action_asset_helper =
+      il2cpp_get_class_helper("Unity.InputSystem", "UnityEngine.InputSystem", "InputActionAsset");
+  static auto input_action_helper =
+      il2cpp_get_class_helper("Unity.InputSystem", "UnityEngine.InputSystem", "InputAction");
+  static auto asset_enabled  = input_action_asset_helper.GetMethod<bool(void*)>("get_enabled");
+  static auto find_action    = input_action_asset_helper.GetMethod<void*(void*, Il2CppString*, bool)>("FindAction");
+  static auto action_enabled = input_action_helper.GetMethod<bool(void*)>("get_enabled");
+  if (!input_action_asset_helper.isValidHelper() || !input_action_helper.isValidHelper() || !asset_enabled
+      || !find_action || !action_enabled) {
+    return evidence;
+  }
+  if (actions) {
+    state.actions_enabled         = asset_enabled(actions);
+    auto* interior_action         = find_action(actions, il2cpp_string_new("General/interior_view"), false);
+    auto* galaxy_action           = find_action(actions, il2cpp_string_new("General/galaxy_view"), false);
+    state.interior_action_enabled = interior_action && action_enabled(interior_action);
+    state.galaxy_action_enabled   = galaxy_action && action_enabled(galaxy_action);
+  }
+
+  if (auto* video_player_manager = get_video_player_manager(); video_player_manager) {
+    state.video_playing = get_is_video_playing(video_player_manager);
+  }
+  if (auto* ui_manager = ui_manager_instance.GetRaw<void>(nullptr); ui_manager) {
+    state.popup_visible = get_is_popup_visible(ui_manager);
+  }
+  if (auto* shop_scene_manager = get_shop_scene_manager(); shop_scene_manager) {
+    void* plc_offer_popup = nullptr;
+    reads_complete = read_instance_field(shop_scene_manager, plc_offer_popup_field, plc_offer_popup) && reads_complete;
+    if (plc_offer_popup) {
+      state.plc_offer_open = is_open(plc_offer_popup);
+    }
+  }
+
+  auto* tutorial_manager     = get_tutorial_manager();
+  state.has_tutorial_manager = tutorial_manager != nullptr;
+  if (!tutorial_manager) {
+    return evidence;
+  }
+
+  void* tutorial_ui     = nullptr;
+  void* objective       = nullptr;
+  void* data            = nullptr;
+  void* component       = nullptr;
+  void* objective_items = nullptr;
+  void* end_step        = nullptr;
+  void* next_step       = nullptr;
+  reads_complete        = read_instance_field(tutorial_manager, tutorial_ui_field, tutorial_ui) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_mission_field, evidence.mission) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_objective_field, objective) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_data_field, data) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_component_field, component) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_items_field, objective_items) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_end_step_field, end_step) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_next_step_field, next_step) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_step_field, evidence.step) && reads_complete;
+  reads_complete = read_instance_field(tutorial_manager, tutorial_step_index_field, state.step_index) && reads_complete;
+  reads_complete =
+      read_instance_field(tutorial_manager, tutorial_next_action_id_field, state.next_action_id) && reads_complete;
+  reads_complete =
+      read_instance_field(tutorial_manager, tutorial_objective_being_cleared_field, state.objective_being_cleared)
+      && reads_complete;
+  reads_complete =
+      read_instance_field(tutorial_manager, tutorial_target_section_field, state.target_section) && reads_complete;
+
+  state.tutorial_ui_open    = tutorial_ui && is_open(tutorial_ui);
+  state.has_mission         = evidence.mission != nullptr;
+  state.has_objective       = objective != nullptr;
+  state.has_data            = data != nullptr;
+  state.has_component       = component != nullptr;
+  state.has_objective_items = objective_items != nullptr;
+  state.has_end_step        = end_step != nullptr;
+  state.has_next_step       = next_step != nullptr;
+  state.step_identity       = reinterpret_cast<uintptr_t>(evidence.step);
+  reads_complete            = read_object_field(evidence.step, "type_", state.step_type) && reads_complete;
+  reads_complete            = read_object_field(evidence.mission, "missionId_", state.mission_id) && reads_complete;
+  reads_complete            = read_object_field(evidence.step, "actionId_", state.action_id) && reads_complete;
+
+  state.evidence_complete = reads_complete;
+  return evidence;
+}
+
+void repair_orphaned_tutorial_shortcut_gate_if_needed(void* shortcuts_manager)
+{
+  static uint64_t  frame                   = 0;
+  static uintptr_t candidate_step_identity = 0;
+  static int       consecutive_samples     = 0;
+
+  if (!RepairOrphanedTutorialShortcutGate() || ScopelyShortcutsPolicy() == ScopelyShortcutPolicy::Off) {
+    frame                   = 0;
+    candidate_step_identity = 0;
+    consecutive_samples     = 0;
+    return;
+  }
+
+  ++frame;
+  if (frame != 1 && frame % kOrphanedTutorialShortcutGateSampleFrames != 0) {
+    return;
+  }
+
+  auto  evidence = collect_orphaned_tutorial_shortcut_evidence(shortcuts_manager);
+  auto& state    = evidence.state;
+  if (!should_repair_orphaned_tutorial_shortcut_gate(state, state.step_identity, 2)) {
+    candidate_step_identity = 0;
+    consecutive_samples     = 0;
+    return;
+  }
+
+  if (candidate_step_identity != state.step_identity) {
+    candidate_step_identity = state.step_identity;
+    consecutive_samples     = 1;
+  } else {
+    ++consecutive_samples;
+  }
+
+  if (!should_repair_orphaned_tutorial_shortcut_gate(state, candidate_step_identity, consecutive_samples)) {
+    return;
+  }
+
+  bool inactive = false;
+  il2cpp_field_static_set_value(evidence.is_active_field, &inactive);
+  const auto tutorial_active_after   = evidence.get_is_active();
+  const auto can_use_shortcuts_after = evidence.get_can_use_shortcuts();
+  if (tutorial_active_after || !can_use_shortcuts_after) {
+    bool active = true;
+    il2cpp_field_static_set_value(evidence.is_active_field, &active);
+    spdlog::error("[Hotkeys] orphaned tutorial shortcut repair rolled back mission_id={} action_id={} "
+                  "tutorial_active_after={} can_use_shortcuts_after={}",
+                  state.mission_id, state.action_id, tutorial_active_after, can_use_shortcuts_after);
+  } else {
+    spdlog::warn("[Hotkeys] repaired orphaned tutorial shortcut gate mission_id={} action_id={} "
+                 "tutorial_active_after={} can_use_shortcuts_after={}",
+                 state.mission_id, state.action_id, tutorial_active_after, can_use_shortcuts_after);
+  }
+
+  candidate_step_identity = 0;
+  consecutive_samples     = 0;
+}
+
 } // namespace
 
 // ─── SPUD Hook Delegates ─────────────────────────────────────────────────────
@@ -255,6 +534,7 @@ void InitializeActions_Hook(auto original, void* _this)
 
 void ShortcutsManager_LateUpdate_Hook(auto original, void* _this)
 {
+  repair_orphaned_tutorial_shortcut_gate_if_needed(_this);
   hotkey_router_refresh_native_shortcut_suppression();
   const auto suppress = hotkey_router_should_suppress_native_shortcuts();
   if (suppress) {
@@ -387,11 +667,12 @@ void InstallHotkeyHooks()
   HookModuleHealth hooks("HotkeyHooks");
 
   spdlog::info("[Hotkeys] startup config installHotkeyHooks={} hotkeys_enabled={} use_scopely_hotkeys={} "
-               "allow_key_fallthrough={} scopely_shortcuts={} original_frame_policy={} frame_owner=FrameTickHooks "
-               "initialize_actions_hook={}",
+               "allow_key_fallthrough={} scopely_shortcuts={} original_frame_policy={} "
+               "repair_orphaned_tutorial_shortcut_gate={} frame_owner=FrameTickHooks initialize_actions_hook={}",
                Config::Get().installHotkeyHooks, Config::Get().hotkeys_enabled, Config::Get().use_scopely_hotkeys,
                AllowKeyFallthrough(), scopely_shortcut_policy_name(ScopelyShortcutsPolicy()),
-               original_frame_policy_name(OriginalFramePolicySetting()), kEnableShortcutInitializeHook);
+               original_frame_policy_name(OriginalFramePolicySetting()), RepairOrphanedTutorialShortcutGate(),
+               kEnableShortcutInitializeHook);
 
   if (kEnableShortcutInitializeHook) {
     auto shortcuts_manager_helper =

--- a/mods/src/testable_functions.cc
+++ b/mods/src/testable_functions.cc
@@ -82,6 +82,29 @@ const char* original_frame_policy_name(const OriginalFramePolicy policy)
 bool hotkey_dispatcher_owns_inputs(const bool hotkeys_enabled, const ScopelyShortcutPolicy scopely_shortcuts)
 { return hotkeys_enabled && scopely_shortcuts != ScopelyShortcutPolicy::Native; }
 
+namespace
+{
+constexpr int64_t kM94OrphanedTutorialMissionId = 1463528981;
+constexpr int64_t kM94OrphanedTutorialActionId  = -1401001831;
+} // namespace
+
+bool should_repair_orphaned_tutorial_shortcut_gate(const OrphanedTutorialShortcutGateState& state,
+                                                   const uintptr_t                          candidate_step_identity,
+                                                   const int                                consecutive_samples)
+{
+  return state.repair_enabled && state.native_shortcuts_enabled && state.evidence_complete && !state.can_use_shortcuts
+         && state.actions_enabled && state.interior_action_enabled && state.galaxy_action_enabled
+         && !state.video_playing && state.tutorial_active && !state.tutorial_blocking && !state.tutorial_ui_open
+         && !state.show_keybindings && !state.message_box_visible && !state.touch_blocked && !state.input_focused
+         && !state.popup_visible && !state.plc_offer_open && state.has_tutorial_manager && state.has_mission
+         && !state.has_objective && state.has_data && !state.has_component && !state.has_objective_items
+         && !state.has_end_step && !state.has_next_step && state.step_identity != 0
+         && state.step_identity == candidate_step_identity && state.step_index == 0 && state.target_section == -1
+         && state.mission_id == kM94OrphanedTutorialMissionId && state.action_id == kM94OrphanedTutorialActionId
+         && state.next_action_id == state.action_id
+         && state.objective_being_cleared == -1 && state.step_type == 0 && consecutive_samples >= 2;
+}
+
 bool should_suppress_escape_exit(bool disable_escape_exit, bool escape_pressed, int escape_exit_timer_ms,
                                  int64_t elapsed_ms_since_last_escape_press)
 {

--- a/mods/src/testable_functions.h
+++ b/mods/src/testable_functions.h
@@ -52,6 +52,46 @@ const char*           scopely_shortcut_policy_name(ScopelyShortcutPolicy policy)
 const char*           original_frame_policy_name(OriginalFramePolicy policy);
 bool                  hotkey_dispatcher_owns_inputs(bool hotkeys_enabled, ScopelyShortcutPolicy scopely_shortcuts);
 
+struct OrphanedTutorialShortcutGateState {
+  bool      repair_enabled           = false;
+  bool      native_shortcuts_enabled = false;
+  bool      evidence_complete        = false;
+  bool      can_use_shortcuts        = false;
+  bool      actions_enabled          = false;
+  bool      interior_action_enabled  = false;
+  bool      galaxy_action_enabled    = false;
+  bool      video_playing            = false;
+  bool      tutorial_active          = false;
+  bool      tutorial_blocking        = false;
+  bool      tutorial_ui_open         = false;
+  bool      show_keybindings         = false;
+  bool      message_box_visible      = false;
+  bool      touch_blocked            = false;
+  bool      input_focused            = false;
+  bool      popup_visible            = false;
+  bool      plc_offer_open           = false;
+  bool      has_tutorial_manager     = false;
+  bool      has_mission              = false;
+  bool      has_objective            = false;
+  bool      has_data                 = false;
+  bool      has_component            = false;
+  bool      has_objective_items      = false;
+  bool      has_end_step             = false;
+  bool      has_next_step            = false;
+  uintptr_t step_identity            = 0;
+  int       step_index               = -1;
+  int64_t   mission_id               = 0;
+  int64_t   action_id                = 0;
+  int64_t   next_action_id           = 0;
+  int64_t   objective_being_cleared  = 0;
+  int64_t   target_section           = 0;
+  int64_t   step_type                = -1;
+};
+
+// The M94 repair requires the exact observed orphan signature and two consecutive samples of the same step.
+bool should_repair_orphaned_tutorial_shortcut_gate(const OrphanedTutorialShortcutGateState& state,
+                                                   uintptr_t candidate_step_identity, int consecutive_samples);
+
 // Escape-exit policy at the real back-button seam. Returns true when the current
 // Escape-triggered back-button press should be suppressed instead of letting the
 // game open its exit prompt.

--- a/scripts/generate_config_schema.mjs
+++ b/scripts/generate_config_schema.mjs
@@ -49,6 +49,7 @@ function parseDefaultConfig() {
     ["Buffs", "buffs"],
     ["SystemConfig", "config"],
     ["Control", "control"],
+    ["Input", "input"],
     ["Graphics", "graphics"],
     ["Advanced", "advanced"],
     ["BattleLogDecoder", "battle_log_decoder"],
@@ -547,7 +548,9 @@ function stabilityFor(settingPath) {
       || settingPath.startsWith("advanced.kirshara_queue.")
       || settingPath === "control.allow_key_fallthrough") return "internal";
   if (settingPath.startsWith("patches.")) return "advanced";
-  if (settingPath === "control.enable_experimental" || settingPath.startsWith("advanced.queue.")) return "experimental";
+  if (settingPath === "control.enable_experimental"
+      || settingPath === "input.repair_orphaned_tutorial_shortcut_gate"
+      || settingPath.startsWith("advanced.queue.")) return "experimental";
   return "stable";
 }
 

--- a/tests/src/test_fleet_input_policy.cc
+++ b/tests/src/test_fleet_input_policy.cc
@@ -328,6 +328,103 @@ TEST_SUITE("hotkey_decisions")
     CHECK_FALSE(hotkey_dispatcher_owns_inputs(false, ScopelyShortcutPolicy::Native));
   }
 
+  TEST_CASE("orphaned tutorial shortcut repair requires the exact stable M94 signature")
+  {
+    OrphanedTutorialShortcutGateState state;
+    state.repair_enabled           = true;
+    state.native_shortcuts_enabled = true;
+    state.evidence_complete        = true;
+    state.actions_enabled          = true;
+    state.interior_action_enabled  = true;
+    state.galaxy_action_enabled    = true;
+    state.tutorial_active          = true;
+    state.has_tutorial_manager     = true;
+    state.has_mission              = true;
+    state.has_data                 = true;
+    state.step_identity            = 0x1234;
+    state.step_index               = 0;
+    state.mission_id               = 1463528981;
+    state.action_id                = -1401001831;
+    state.next_action_id           = state.action_id;
+    state.objective_being_cleared  = -1;
+    state.target_section           = -1;
+    state.step_type                = 0;
+
+    CHECK_FALSE(should_repair_orphaned_tutorial_shortcut_gate(state, state.step_identity, 1));
+    CHECK(should_repair_orphaned_tutorial_shortcut_gate(state, state.step_identity, 2));
+    CHECK_FALSE(should_repair_orphaned_tutorial_shortcut_gate(state, 0x5678, 2));
+
+    state.repair_enabled = false;
+    CHECK_FALSE(should_repair_orphaned_tutorial_shortcut_gate(state, state.step_identity, 2));
+  }
+
+  TEST_CASE("orphaned tutorial shortcut repair fails closed when any blocker or tutorial work remains")
+  {
+    OrphanedTutorialShortcutGateState baseline;
+    baseline.repair_enabled           = true;
+    baseline.native_shortcuts_enabled = true;
+    baseline.evidence_complete        = true;
+    baseline.actions_enabled          = true;
+    baseline.interior_action_enabled  = true;
+    baseline.galaxy_action_enabled    = true;
+    baseline.tutorial_active          = true;
+    baseline.has_tutorial_manager     = true;
+    baseline.has_mission              = true;
+    baseline.has_data                 = true;
+    baseline.step_identity            = 0x1234;
+    baseline.step_index               = 0;
+    baseline.mission_id               = 1463528981;
+    baseline.action_id                = -1401001831;
+    baseline.next_action_id           = baseline.action_id;
+    baseline.objective_being_cleared  = -1;
+    baseline.target_section           = -1;
+    baseline.step_type                = 0;
+
+    const auto blocked = [&](const OrphanedTutorialShortcutGateState& state) {
+      CHECK_FALSE(should_repair_orphaned_tutorial_shortcut_gate(state, state.step_identity, 2));
+    };
+
+    auto state              = baseline;
+    state.evidence_complete = false;
+    blocked(state);
+    state                   = baseline;
+    state.can_use_shortcuts = true;
+    blocked(state);
+    state                   = baseline;
+    state.tutorial_blocking = true;
+    blocked(state);
+    state                  = baseline;
+    state.tutorial_ui_open = true;
+    blocked(state);
+    state               = baseline;
+    state.has_component = true;
+    blocked(state);
+    state               = baseline;
+    state.has_objective = true;
+    blocked(state);
+    state                     = baseline;
+    state.has_objective_items = true;
+    blocked(state);
+    state               = baseline;
+    state.has_next_step = true;
+    blocked(state);
+    state                = baseline;
+    state.target_section = 0;
+    blocked(state);
+    state           = baseline;
+    state.step_type = 1;
+    blocked(state);
+    state            = baseline;
+    state.mission_id = 1;
+    blocked(state);
+    state                         = baseline;
+    state.objective_being_cleared = 0;
+    blocked(state);
+    state               = baseline;
+    state.input_focused = true;
+    blocked(state);
+  }
+
   TEST_CASE("Escape exit suppression only blocks Escape-triggered exit outside the double-tap window")
   {
     CHECK_FALSE(should_suppress_escape_exit(false, true, 500, -1));


### PR DESCRIPTION
## Summary
- repair the M94 orphaned `TutorialManager._isActive` state that blocks Scopely shortcuts after cold restart
- require the exact mission/action signature, every native shortcut gate to be clear, and two stable samples before repair
- add an experimental opt-in config setting plus launcher schema coverage and pure guard tests

## Runtime evidence
- reproduced the broken state across cold restarts while mod hotkeys remained functional
- verified the repair changes `TutorialManager.IsActive` from true to false and `ShortcutsManager.CanUseShortcuts` from false to true
- confirmed Q/E recover without Settings > Clear Cache and Restart
- shortened the stable-sample interval to roughly 1–2 seconds after the orphan state appears

## Validation
- `axf run global.stfc-mod-private.build --build-mode releasedbg`
- `stfc-mod-tests.exe`: 360 test cases, 4,505 assertions passed
- `node --test scripts/test_config_schema.mjs`
- `node scripts/generate_config_schema.mjs --check`
- `git diff --check`