### PR TITLE
Finish play alignment with current dev and chat-focus fix

### DIFF
--- a/KEYMAPPING.md
+++ b/KEYMAPPING.md
@@ -21,6 +21,18 @@ Value | Keys Required
 "ALT-LSHIFT-T" | (Left Or Right) Alt + Left Shift + T
 "Q" | Q (no Shift, Ctrl, etc)
 
+### Screen shortcuts
+
+These bindings can be changed in the `[shortcuts]` section of `community_patch_settings.toml`.
+
+| Setting | Default | Action |
+| --- | --- | --- |
+| `show_shipconstruction` | `SHIFT-N` | Open Ships / Ship Construction (Shipyard → Build Ship). |
+| `show_shields` | `CTRL-S` | Open the Peace Shield selection popup. |
+| `show_battlelogs` | `SHIFT-B` | Open the Battle Reports inbox. |
+
+`show_ships = "N"` continues to manage the selected ship. The shield shortcut opens the selection popup; activating a shield still requires choosing one.
+
 ### Modifiers
 
 Modifiers are not required, any specified must be used together:

--- a/example_community_patch_settings_da.toml
+++ b/example_community_patch_settings_da.toml
@@ -522,11 +522,21 @@ show_settings = "SHIFT-S"
 
 # Slå genvejstips på skærmen til/fra (viser mod-genveje, hvor de understøttes)
 # NONE deaktiverer mod-tiphooks og tekstcache; tildel en tast for at aktivere (kræver genstart).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
+
 # Symboler i mærker bruger AutoHotkey-notation: ^ Ctrl, ! Alt, + Shift, # Win/Command
 
 # Gå til administration af skibe
 show_ships = "N"
+
+# Åbn skibsværftets Byg skib-skærm
+show_shipconstruction = "SHIFT-N"
+
+# Åbn valget af fredsskjolde
+show_shields = "CTRL-S"
+
+# Åbn indbakken med kamprapporter
+show_battlelogs = "SHIFT-B"
 
 # Stationens ydre
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_de.toml
+++ b/example_community_patch_settings_de.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Bildschirmhinweise für Tastenkürzel umschalten (zeigt unterstützte Mod-Tastenkürzel)
 # NONE deaktiviert Mod-Hinweis-Hooks und den Textcache; zum Aktivieren eine Taste zuweisen (Neustart erforderlich).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Hinweissymbole verwenden die AutoHotkey-Schreibweise: ^ Strg, ! Alt, + Umschalt, # Win/Befehl
 
 # Zur Schiffsverwaltung
 show_ships = "N"
+
+# Den Bildschirm Schiff bauen der Werft öffnen
+show_shipconstruction = "SHIFT-N"
+
+# Die Auswahl für Friedensschilde öffnen
+show_shields = "CTRL-S"
+
+# Den Posteingang für Kampfberichte öffnen
+show_battlelogs = "SHIFT-B"
 
 # Stationsaußenansicht
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_en-GB-x-cockney.toml
+++ b/example_community_patch_settings_en-GB-x-cockney.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Toggle on-screen shortcut hints (shows mod bindings where supported)
 # NONE disables mod hint hooks and label caching; bind a key to enable (restart required).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Badge modifiers use AutoHotkey notation: ^ Ctrl, ! Alt, + Shift, # Win/Command
 
 # Go to Manage Ships
 show_ships = "N"
+
+# Open the Shipyard Build Ship screen
+show_shipconstruction = "SHIFT-N"
+
+# Open the Peace Shield selection popup
+show_shields = "CTRL-S"
+
+# Open the Battle Reports inbox
+show_battlelogs = "SHIFT-B"
 
 # Station Exterior
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_en-x-minionese.toml
+++ b/example_community_patch_settings_en-x-minionese.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Toggle on-screen shortcut hints (shows mod bindings where supported)
 # NONE disables mod hint hooks and label caching; bind a key to enable (restart required).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Badge modifiers use AutoHotkey notation: ^ Ctrl, ! Alt, + Shift, # Win/Command
 
 # Go to Manage Ships
 show_ships = "N"
+
+# Open the Shipyard Build Ship screen
+show_shipconstruction = "SHIFT-N"
+
+# Open the Peace Shield selection popup
+show_shields = "CTRL-S"
+
+# Open the Battle Reports inbox
+show_battlelogs = "SHIFT-B"
 
 # Station Exterior
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_en.toml
+++ b/example_community_patch_settings_en.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Toggle on-screen shortcut hints (shows mod bindings where supported)
 # NONE disables mod hint hooks and label caching; bind a key to enable (restart required).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Badge modifiers use AutoHotkey notation: ^ Ctrl, ! Alt, + Shift, # Win/Command
 
 # Go to Manage Ships
 show_ships = "N"
+
+# Open the Shipyard Build Ship screen
+show_shipconstruction = "SHIFT-N"
+
+# Open the Peace Shield selection popup
+show_shields = "CTRL-S"
+
+# Open the Battle Reports inbox
+show_battlelogs = "SHIFT-B"
 
 # Station Exterior
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_es.toml
+++ b/example_community_patch_settings_es.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Alternar las indicaciones de atajos en pantalla (muestra los atajos compatibles del mod)
 # NONE desactiva los hooks y la caché de indicaciones del mod; asigna una tecla para activar (requiere reiniciar).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Los modificadores usan la notación de AutoHotkey: ^ Ctrl, ! Alt, + Mayús, # Win/Comando
 
 # Ir a administrar barcos
 show_ships = "N"
+
+# Abrir la pantalla Construir nave del astillero
+show_shipconstruction = "SHIFT-N"
+
+# Abrir la selección de escudos de paz
+show_shields = "CTRL-S"
+
+# Abrir la bandeja de informes de batalla
+show_battlelogs = "SHIFT-B"
 
 # Exterior de la estación
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_fr.toml
+++ b/example_community_patch_settings_fr.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Afficher ou masquer les raccourcis à l’écran (affiche les raccourcis du mod pris en charge)
 # NONE désactive les hooks et le cache des indications du mod ; attribuez une touche pour activer (redémarrage requis).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Les modificateurs utilisent la notation AutoHotkey : ^ Ctrl, ! Alt, + Maj, # Win/Commande
 
 # Aller aux vaisseaux
 show_ships = "N"
+
+# Ouvrir la construction de vaisseaux du chantier spatial
+show_shipconstruction = "SHIFT-N"
+
+# Ouvrir la sélection des boucliers de paix
+show_shields = "CTRL-S"
+
+# Ouvrir la boîte de réception des rapports de combat
+show_battlelogs = "SHIFT-B"
 
 # Extérieur de la station
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_nl.toml
+++ b/example_community_patch_settings_nl.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Schermtips voor sneltoetsen in- of uitschakelen (toont ondersteunde mod-sneltoetsen)
 # NONE schakelt mod-tip-hooks en tekstcache uit; wijs een toets toe om in te schakelen (herstart vereist).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Modificatietoetsen gebruiken AutoHotkey-notatie: ^ Ctrl, ! Alt, + Shift, # Win/Command
 
 # Ga naar Scheepsmanagement
 show_ships = "N"
+
+# Open het scherm Schip bouwen van de scheepswerf
+show_shipconstruction = "SHIFT-N"
+
+# Open de selectie voor vredesschilden
+show_shields = "CTRL-S"
+
+# Open het postvak met gevechtsrapporten
+show_battlelogs = "SHIFT-B"
 
 # Station Exterieur
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_ru.toml
+++ b/example_community_patch_settings_ru.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Показать или скрыть подсказки клавиш (показывает поддерживаемые сочетания мода)
 # NONE отключает хуки и кэш подсказок мода; назначьте клавишу для включения (требуется перезапуск).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Модификаторы используют нотацию AutoHotkey: ^ Ctrl, ! Alt, + Shift, # Win/Command
 
 # Перейти к управлению кораблями
 show_ships = "N"
+
+# Открыть экран постройки корабля на верфи
+show_shipconstruction = "SHIFT-N"
+
+# Открыть окно выбора мирного щита
+show_shields = "CTRL-S"
+
+# Открыть входящие боевые отчёты
+show_battlelogs = "SHIFT-B"
 
 # Внешний вид станции
 show_stationexterior = "SHIFT-G"

--- a/example_community_patch_settings_tlh.toml
+++ b/example_community_patch_settings_tlh.toml
@@ -522,11 +522,20 @@ show_settings = "SHIFT-S"
 
 # Toggle on-screen shortcut hints (shows mod bindings where supported)
 # NONE disables mod hint hooks and label caching; bind a key to enable (restart required).
-toggle_shortcut_hints = "NONE"
+toggle_shortcut_hints = "HOME"
 # Badge modifiers use AutoHotkey notation: ^ Ctrl, ! Alt, + Shift, # Win/Command
 
 # Go Daq  Manage Ships
 show_ships = "N"
+
+# Open the Shipyard Build Ship screen
+show_shipconstruction = "SHIFT-N"
+
+# Open the Peace Shield selection popup
+show_shields = "CTRL-S"
+
+# Open the Battle Reports inbox
+show_battlelogs = "SHIFT-B"
 
 # 'ejyo'waw' Exterior
 show_stationexterior = "SHIFT-G"

--- a/mods/src/config.cc
+++ b/mods/src/config.cc
@@ -1363,6 +1363,9 @@ void Config::Load()
   parse_config_shortcut(config, parsed, "show_qtrials", GameFunction::ShowQTrials, DCSH::show_qtrials);
   parse_config_shortcut(config, parsed, "show_refinery", GameFunction::ShowRefinery, DCSH::show_refinery);
   parse_config_shortcut(config, parsed, "show_ships", GameFunction::ShowShips, DCSH::show_ships);
+  parse_config_shortcut(config, parsed, "show_shipconstruction", GameFunction::ShowShipConstruction, DCSH::show_shipconstruction);
+  parse_config_shortcut(config, parsed, "show_shields", GameFunction::ShowShields, DCSH::show_shields);
+  parse_config_shortcut(config, parsed, "show_battlelogs", GameFunction::ShowBattlelogs, DCSH::show_battlelogs);
   parse_config_shortcut(config, parsed, "show_stationexterior", GameFunction::ShoWStationExterior,
                         DCSH::show_stationexterior);
   parse_config_shortcut(config, parsed, "show_stationinterior", GameFunction::ShowStationInterior,

--- a/mods/src/defaultconfig.h
+++ b/mods/src/defaultconfig.h
@@ -163,10 +163,13 @@ namespace Shortcuts
   constexpr const char* show_scrapyard        = "Y";
   constexpr const char* show_settings         = "SHIFT-S";
   constexpr const char* show_ships            = "N";
+  constexpr const char* show_shipconstruction = "SHIFT-N";
+  constexpr const char* show_shields          = "CTRL-S";
+  constexpr const char* show_battlelogs       = "SHIFT-B";
   constexpr const char* show_stationexterior  = "SHIFT-G";
   constexpr const char* show_stationinterior  = "SHIFT-H";
   constexpr const char* show_system           = "H";
-  constexpr const char* toggle_shortcut_hints = "NONE";
+  constexpr const char* toggle_shortcut_hints = "HOME";
   constexpr const char* toggle_cargo_armada   = "ALT-5";
   constexpr const char* toggle_cargo_default  = "ALT-1";
   constexpr const char* toggle_cargo_hostile  = "ALT-4";

--- a/mods/src/patches/gamefunctions.h
+++ b/mods/src/patches/gamefunctions.h
@@ -100,6 +100,10 @@ enum GameFunction {
   Quit,
   FocusSearch,
 
+  ShowShipConstruction,
+  ShowShields,
+  ShowBattlelogs,
+
   // Automatic max value
   Max
 };

--- a/mods/src/patches/parts/hotkeys.cc
+++ b/mods/src/patches/parts/hotkeys.cc
@@ -275,6 +275,9 @@ void ShortcutKeybindHint_UpdateVisibility_Hook(auto original, void* _this, bool 
 
 static const MethodInfo* on_events_action = nullptr;
 static const MethodInfo* on_galaxy_action = nullptr;
+static const MethodInfo* show_shipconstruction_action = nullptr;
+static const MethodInfo* show_shields_action = nullptr;
+static const MethodInfo* show_battlelogs_action = nullptr;
 
 struct InputActionCallbackContext {
   void*   state;
@@ -676,6 +679,15 @@ void ScreenManager_Update_Hook(auto original, ScreenManager* _this)
         return ChangeNavigationSection(SectionID::Navigation_System);
       } else if (MapKey::IsDown(GameFunction::ShowArtifacts)) {
         return GotoSection(SectionID::ArtifactHall_Inventory);
+      } else if (MapKey::IsDown(GameFunction::ShowShipConstruction)) {
+        InvokeNativeShortcut(show_shipconstruction_action, "Ship Construction");
+        return;
+      } else if (MapKey::IsDown(GameFunction::ShowShields)) {
+        InvokeNativeShortcut(show_shields_action, "Peace Shields");
+        return;
+      } else if (MapKey::IsDown(GameFunction::ShowBattlelogs)) {
+        InvokeNativeShortcut(show_battlelogs_action, "Battle Reports");
+        return;
       } else if (MapKey::IsDown(GameFunction::ShowInventory)) {
         return GotoSection(SectionID::InventoryList);
       } else if (MapKey::IsDown(GameFunction::ShowMissions)) {
@@ -1453,6 +1465,21 @@ void InstallHotkeyHooks()
     on_galaxy_action = shortcuts_manager_helper.GetMethodInfo("OnGalaxyAction", 1);
     if (on_galaxy_action == nullptr) {
       ErrorMsg::MissingMethod("ShortcutsManager", "OnGalaxyAction");
+    }
+
+    show_shipconstruction_action = shortcuts_manager_helper.GetMethodInfo("OnShipsAction", 1);
+    if (show_shipconstruction_action == nullptr) {
+      ErrorMsg::MissingMethod("ShortcutsManager", "OnShipsAction");
+    }
+
+    show_shields_action = shortcuts_manager_helper.GetMethodInfo("OnPeaceShieldAction", 1);
+    if (show_shields_action == nullptr) {
+      ErrorMsg::MissingMethod("ShortcutsManager", "OnPeaceShieldAction");
+    }
+
+    show_battlelogs_action = shortcuts_manager_helper.GetMethodInfo("OnInboxAction", 1);
+    if (show_battlelogs_action == nullptr) {
+      ErrorMsg::MissingMethod("ShortcutsManager", "OnInboxAction");
     }
 
     auto ptr_can_user_shortcuts = shortcuts_manager_helper.GetMethod("InitializeActions");

--- a/mods/src/prime/TMP_InputField.h
+++ b/mods/src/prime/TMP_InputField.h
@@ -44,6 +44,7 @@ public:
   bool __get_isFocused()
   {
     static auto field = get_class_helper().GetProperty("isFocused");
-    return field.Get<bool>(this);
+    const auto* focused = field.Get<bool>(this);
+    return focused && *focused;
   }
 };


### PR DESCRIPTION
Bring fork main up to upstream dev 9fd595b7 and include the chat-focus fix from netniV/stfc-mod#272. This corrects the focus value that can keep ship and other shortcuts blocked after leaving a text field, and adds upstream's construction, shield, and battle-log shortcuts to the full play stack.

The full reconciliation is already merged through #262. This update preserves its stack and history. PR #253's latest head only merges the same upstream dev changes; its audio component is unchanged.

Validation: Windows releasedbg build, production-linked hint-cache regression, all 11 example TOMLs, upstream delta identity, and diff check pass. Three independent review lanes found no actionable defect at a52dd1d2. AXF built/deployed the resulting DLL and cycled the game successfully with matching hashes and no boot errors. Required Windows/macOS CI runs here. The original intermittent chat transition and new native shortcuts still need gameplay confirmation.
